### PR TITLE
Failing test

### DIFF
--- a/src/Monolog/Handler/StreamHandler.php
+++ b/src/Monolog/Handler/StreamHandler.php
@@ -44,6 +44,7 @@ class StreamHandler extends AbstractHandler
             }
             $this->stream = fopen($this->url, 'a');
             if (!is_resource($this->stream)) {
+                $this->stream = null;
                 throw new \UnexpectedValueException('The stream could not be opened, "'.$this->url.'" may be an invalid url.');
             }
         }


### PR DESCRIPTION
This fixes a failing test when the resource is invalid as `close` was called by `__destruct` with a boolean value in `$this->stream`.
