### PR TITLE
Added a BufferHandler to allow batch processing of the records

### DIFF
--- a/src/Monolog/Handler/AbstractHandler.php
+++ b/src/Monolog/Handler/AbstractHandler.php
@@ -62,6 +62,13 @@ abstract class AbstractHandler implements HandlerInterface
         return false === $this->bubble;
     }
 
+    public function handleBatch(array $records)
+    {
+        foreach ($records as $record) {
+            $this->handle($record);
+        }
+    }
+
     abstract public function write(array $record);
 
     public function close()

--- a/src/Monolog/Handler/BufferHandler.php
+++ b/src/Monolog/Handler/BufferHandler.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Logger;
+
+/**
+ * Buffers all records until closing the handler and then pass them as batch.
+ *
+ * This is useful for a MailHandler to send only one mail per request instead of
+ * sending one per log message.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class BufferHandler extends AbstractHandler
+{
+    protected $handler;
+    protected $bufferSize;
+    protected $buffer = array();
+
+    /**
+     * @param HandlerInterface $handler Handler.
+     * @param int $bufferSize How many entries should be buffered at most, beyond that the oldest items are removed from the buffer.
+     * @param Boolean $bubble
+     */
+    public function __construct(HandlerInterface $handler, $bufferSize = 0, $bubble = false)
+    {
+        $this->handler = $handler;
+        $this->bufferSize = $bufferSize;
+        $this->bubble = $bubble;
+    }
+
+    /**
+     * Handles a record
+     *
+     * Records are buffered until closing the handler.
+     *
+     * @param array $record Records
+     * @return Boolean Whether the record was handled
+     */
+    public function handle(array $record)
+    {
+        $this->buffer[] = $record;
+        if ($this->bufferSize > 0 && count($this->buffer) > $this->bufferSize) {
+            array_shift($this->buffer);
+        }
+
+        return false === $this->bubble;
+    }
+
+    public function close()
+    {
+        $this->handler->handleBatch($this->buffer);
+    }
+
+    /**
+     * Implemented to comply with the AbstractHandler requirements. Can not be called.
+     */
+    public function write(array $record)
+    {
+        throw new \BadMethodCallException('This method should not be called directly on the FingersCrossedHandler.');
+    }
+}

--- a/src/Monolog/Handler/HandlerInterface.php
+++ b/src/Monolog/Handler/HandlerInterface.php
@@ -36,6 +36,14 @@ interface HandlerInterface
     function handle(array $record);
 
     /**
+     * Handles a set of records.
+     *
+     * @param array $records The records to handle (an array of record arrays)
+     * @return Boolean Whether the handler stops the propagation in the stack or not.
+     */
+    function handleBatch(array $records);
+
+    /**
      * Adds a processor in the stack.
      *
      * @param callable $callback

--- a/tests/Monolog/Handler/BufferHandlerTest.php
+++ b/tests/Monolog/Handler/BufferHandlerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Logger;
+
+class BufferHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHandleBuffers()
+    {
+        $test = new TestHandler();
+        $handler = new BufferHandler($test);
+        $handler->handle($this->getRecord(Logger::DEBUG));
+        $handler->handle($this->getRecord(Logger::INFO));
+        $this->assertFalse($test->hasDebugRecords());
+        $this->assertFalse($test->hasInfoRecords());
+        $handler->close();
+        $this->assertTrue($test->hasInfoRecords());
+        $this->assertTrue(count($test->getRecords()) === 2);
+    }
+
+    public function testDestructPropagatesRecords()
+    {
+        $test = new TestHandler();
+        $handler = new BufferHandler($test);
+        $handler->handle($this->getRecord(Logger::WARNING));
+        $handler->handle($this->getRecord(Logger::DEBUG));
+        unset ($handler);
+        $this->assertTrue($test->hasWarningRecords());
+        $this->assertTrue($test->hasDebugRecords());
+    }
+
+    public function testHandleBufferLimit()
+    {
+        $test = new TestHandler();
+        $handler = new BufferHandler($test, 2);
+        $handler->handle($this->getRecord(Logger::DEBUG));
+        $handler->handle($this->getRecord(Logger::DEBUG));
+        $handler->handle($this->getRecord(Logger::INFO));
+        $handler->handle($this->getRecord(Logger::WARNING));
+        $handler->close();
+        $this->assertTrue($test->hasWarningRecords());
+        $this->assertTrue($test->hasInfoRecords());
+        $this->assertFalse($test->hasDebugRecords());
+    }
+
+    protected function getRecord($level = Logger::WARNING)
+    {
+        return array(
+            'level' => $level,
+            'level_name' => Logger::getLevelName($level),
+            'channel' => 'log',
+            'Record' => 'foo',
+            'datetime' => new \DateTime,
+            'extra' => array(),
+        );
+    }
+}


### PR DESCRIPTION
This is the first step before adding a MailHandler as it will allow to send only one mail when wrapping the MailHandler in a BufferHandler.
This handler is the equivalent of the GroupHandler of the LogBook library.
