### PR TITLE
fixed StreamHandler close

### DIFF
--- a/src/Monolog/Handler/StreamHandler.php
+++ b/src/Monolog/Handler/StreamHandler.php
@@ -46,10 +46,10 @@ class StreamHandler extends AbstractHandler
      */
     public function close()
     {
-        if (null !== $this->stream) {
+        if (is_resource($this->stream)) {
             fclose($this->stream);
-            $this->stream = null;
         }
+        $this->stream = null;
     }
 
     /**


### PR DESCRIPTION
I encounted the case $this->stream = 0 when close method was called,
I think the caller condition may be wrong in this case.
But stronger check for the $this->stream parameter makes sense I think.
