### PR TITLE
Refactoring of FormatterInterface

### DIFF
--- a/src/Monolog/Formatter/FormatterInterface.php
+++ b/src/Monolog/Formatter/FormatterInterface.php
@@ -22,7 +22,15 @@ interface FormatterInterface
      * Formats a log record.
      *
      * @param array $record A record to format
-     * @return array The record with a formatted message
+     * @return string The formatted message
      */
     function format(array $record);
+
+    /**
+     * Formats a set of log records.
+     *
+     * @param array $record A record to format
+     * @return string The formatted batch message
+     */
+    function formatBatch(array $records);
 }

--- a/src/Monolog/Formatter/JsonFormatter.php
+++ b/src/Monolog/Formatter/JsonFormatter.php
@@ -27,8 +27,14 @@ class JsonFormatter implements FormatterInterface
      */
     public function format(array $record)
     {
-        $record['message'] = json_encode($record);
+        return json_encode($record);
+    }
 
-        return $record;
+    /**
+     * {@inheritdoc}
+     */
+    public function formatBatch(array $records)
+    {
+        return json_encode($records);
     }
 }

--- a/src/Monolog/Formatter/LineFormatter.php
+++ b/src/Monolog/Formatter/LineFormatter.php
@@ -62,8 +62,17 @@ class LineFormatter implements FormatterInterface
         foreach ($vars['extra'] as $var => $val) {
             $output = str_replace('%extra.'.$var.'%', $val, $output);
         }
-        $record['message'] = $output;
 
-        return $record;
+        return $output;
+    }
+
+    public function formatBatch(array $records)
+    {
+        $message = '';
+        foreach ($records as $record) {
+            $message .= $this->format($record);
+        }
+
+        return $message;
     }
 }

--- a/src/Monolog/Formatter/WildfireFormatter.php
+++ b/src/Monolog/Formatter/WildfireFormatter.php
@@ -18,7 +18,7 @@ use Monolog\Logger;
  *
  * @author Eric Clemmons (@ericclemmons) <eric@uxdriven.com>
  */
-class WildfireFormatter extends LineFormatter implements FormatterInterface
+class WildfireFormatter extends LineFormatter
 {
     /**
      * Similar to LineFormatter::SIMPLE_FORMAT, except without the "[%datetime%]"
@@ -43,7 +43,7 @@ class WildfireFormatter extends LineFormatter implements FormatterInterface
     public function format(array $record)
     {
         // Format record according with LineFormatter
-        $formatted = parent::format($record);
+        $message = parent::format($record);
 
         // Create JSON object describing the appearance of the message in the console
         $json = json_encode(array(
@@ -52,17 +52,19 @@ class WildfireFormatter extends LineFormatter implements FormatterInterface
                 'File'  =>  '',
                 'Line'  =>  '',
             ),
-            $formatted['message'],
+            $message,
         ));
 
         // The message itself is a serialization of the above JSON object + it's length
-        $formatted['message'] = sprintf(
+        return sprintf(
             '%s|%s|',
             strlen($json),
             $json
         );
-
-        return $formatted;
     }
 
+    public function formatBatch(array $records)
+    {
+        throw new \BadMethodCallException('Batch formatting does not make sense for the WildfireFormatter');
+    }
 }

--- a/src/Monolog/Handler/AbstractHandler.php
+++ b/src/Monolog/Handler/AbstractHandler.php
@@ -27,6 +27,9 @@ abstract class AbstractHandler implements HandlerInterface
     protected $level = Logger::DEBUG;
     protected $bubble = false;
 
+    /**
+     * @var FormatterInterface
+     */
     protected $formatter;
     protected $processors = array();
 
@@ -57,16 +60,12 @@ abstract class AbstractHandler implements HandlerInterface
             return false;
         }
 
-        if ($this->processors) {
-            foreach ($this->processors as $processor) {
-                $record = call_user_func($processor, $record);
-            }
-        }
+        $record = $this->processRecord($record);
 
         if (!$this->formatter) {
             $this->formatter = $this->getDefaultFormatter();
         }
-        $record = $this->formatter->format($record);
+        $record['message'] = $this->formatter->format($record);
 
         $this->write($record);
 
@@ -187,5 +186,22 @@ abstract class AbstractHandler implements HandlerInterface
     protected function getDefaultFormatter()
     {
         return new LineFormatter();
+    }
+
+    /**
+     * Processes a record.
+     *
+     * @param array $record
+     * @return array
+     */
+    protected function processRecord(array $record)
+    {
+        if ($this->processors) {
+            foreach ($this->processors as $processor) {
+                $record = call_user_func($processor, $record);
+            }
+        }
+
+        return $record;
     }
 }

--- a/tests/Monolog/Formatter/JsonFormatterTest.php
+++ b/tests/Monolog/Formatter/JsonFormatterTest.php
@@ -18,13 +18,13 @@ class JsonFormatterTest extends \PHPUnit_Framework_TestCase
     public function testFormat()
     {
         $formatter = new JsonFormatter();
-        $record = $formatter->format($msg = array(
+        $message = $formatter->format($msg = array(
             'level_name' => 'WARNING',
             'channel' => 'log',
             'message' => array('foo'),
             'datetime' => new \DateTime,
             'extra' => array(),
         ));
-        $this->assertEquals(json_encode($msg), $record['message']);
+        $this->assertEquals(json_encode($msg), $message);
     }
 }

--- a/tests/Monolog/Formatter/LineFormatterTest.php
+++ b/tests/Monolog/Formatter/LineFormatterTest.php
@@ -18,20 +18,20 @@ class LineFormatterTest extends \PHPUnit_Framework_TestCase
     public function testDefFormatWithString()
     {
         $formatter = new LineFormatter(null, 'Y-m-d');
-        $record = $formatter->format(array(
+        $message = $formatter->format(array(
             'level_name' => 'WARNING',
             'channel' => 'log',
             'message' => 'foo',
             'datetime' => new \DateTime,
             'extra' => array(),
         ));
-        $this->assertEquals('['.date('Y-m-d').'] log.WARNING: foo '."\n", $record['message']);
+        $this->assertEquals('['.date('Y-m-d').'] log.WARNING: foo '."\n", $message);
     }
 
     public function testDefFormatWithArray()
     {
         $formatter = new LineFormatter(null, 'Y-m-d');
-        $record = $formatter->format(array(
+        $message = $formatter->format(array(
             'level_name' => 'ERROR',
             'channel' => 'meh',
             'datetime' => new \DateTime,
@@ -41,19 +41,19 @@ class LineFormatterTest extends \PHPUnit_Framework_TestCase
                 'baz' => 'qux',
             )
         ));
-        $this->assertEquals('['.date('Y-m-d').'] meh.ERROR: message(foo: bar, baz: qux) '."\n", $record['message']);
+        $this->assertEquals('['.date('Y-m-d').'] meh.ERROR: message(foo: bar, baz: qux) '."\n", $message);
     }
 
     public function testDefFormatExtras()
     {
         $formatter = new LineFormatter(null, 'Y-m-d');
-        $record = $formatter->format(array(
+        $message = $formatter->format(array(
             'level_name' => 'ERROR',
             'channel' => 'meh',
             'datetime' => new \DateTime,
             'extra' => array('ip' => '127.0.0.1'),
             'message' => 'log',
         ));
-        $this->assertEquals('['.date('Y-m-d').'] meh.ERROR: log extra(ip: 127.0.0.1)'."\n", $record['message']);
+        $this->assertEquals('['.date('Y-m-d').'] meh.ERROR: log extra(ip: 127.0.0.1)'."\n", $message);
     }
 }

--- a/tests/Monolog/Formatter/WildfireFormatterTest.php
+++ b/tests/Monolog/Formatter/WildfireFormatterTest.php
@@ -22,11 +22,11 @@ class WildfireFormatterTest extends \PHPUnit_Framework_TestCase
     {
         $wildfire = new WildfireFormatter();
 
-        $record = $wildfire->format($record);
+        $message = $wildfire->format($record);
 
         $this->assertEquals(
             '70|[{"Type":"ERROR","File":"","Line":""},"meh: log extra(ip: 127.0.0.1)"]|',
-            $record['message']
+            $message
         );
     }
 

--- a/tests/Monolog/TestCase.php
+++ b/tests/Monolog/TestCase.php
@@ -36,7 +36,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
         $formatter = $this->getMock('Monolog\\Formatter\\FormatterInterface');
         $formatter->expects($this->any())
             ->method('format')
-            ->will($this->returnArgument(0));
+            ->will($this->returnCallback(function($record) { return $record['message']; }));
 
         return $formatter;
     }


### PR DESCRIPTION
I started to review the PR16 about the MailHandler. This made me wonder about a batch formatting method to remove the formatting from the handler itself.
I also changed the return value of the `format` method as a Formatter should not be allowed to changed the other part of the record and it makes it consistent with `formatBatch` (which cannot return a record but only a formatted string)

Once this PR is merged, I will continue reviewing the PR16 to use these changes.
