### PR TITLE
FingersCrossedHandler improvements

### DIFF
--- a/src/Monolog/Handler/FingersCrossedHandler.php
+++ b/src/Monolog/Handler/FingersCrossedHandler.php
@@ -29,19 +29,22 @@ class FingersCrossedHandler extends AbstractHandler
     protected $buffering = true;
     protected $bufferSize;
     protected $buffer = array();
+    protected $stopBuffering;
 
     /**
      * @param callback|HandlerInterface $handler Handler or factory callback($record, $fingersCrossedHandler).
      * @param int $actionLevel The minimum logging level at which this handler will be triggered
      * @param int $bufferSize How many entries should be buffered at most, beyond that the oldest items are removed from the buffer.
      * @param Boolean $bubble Whether the messages that are handled can bubble up the stack or not
+     * @param Boolean $stopBuffering Whether the handler should stop buffering after being triggered (default true)
      */
-    public function __construct($handler, $actionLevel = Logger::WARNING, $bufferSize = 0, $bubble = false)
+    public function __construct($handler, $actionLevel = Logger::WARNING, $bufferSize = 0, $bubble = false, $stopBuffering = true)
     {
         $this->handler = $handler;
         $this->actionLevel = $actionLevel;
         $this->bufferSize = $bufferSize;
         $this->bubble = $bubble;
+        $this->stopBuffering = $stopBuffering;
     }
 
     /**
@@ -55,7 +58,9 @@ class FingersCrossedHandler extends AbstractHandler
                 array_shift($this->buffer);
             }
             if ($record['level'] >= $this->actionLevel) {
-                $this->buffering = false;
+                if ($this->stopBuffering) {
+                    $this->buffering = false;
+                }
                 if (!$this->handler instanceof HandlerInterface) {
                     $this->handler = call_user_func($this->handler, $record, $this);
                 }

--- a/tests/Monolog/Handler/FingersCrossedHandlerTest.php
+++ b/tests/Monolog/Handler/FingersCrossedHandlerTest.php
@@ -52,6 +52,18 @@ class FingersCrossedHandlerTest extends TestCase
         $this->assertFalse($test->hasInfoRecords());
     }
 
+    public function testHandleRestartBufferingAfterBeingTriggered()
+    {
+        $test = new TestHandler();
+        $handler = new FingersCrossedHandler($test, Logger::WARNING, 0, false, false);
+        $handler->handle($this->getRecord(Logger::DEBUG));
+        $handler->handle($this->getRecord(Logger::WARNING));
+        $handler->handle($this->getRecord(Logger::INFO));
+        $this->assertTrue($test->hasWarningRecords());
+        $this->assertTrue($test->hasDebugRecords());
+        $this->assertFalse($test->hasInfoRecords());
+    }
+
     public function testHandleBufferLimit()
     {
         $test = new TestHandler();


### PR DESCRIPTION
This adds the availability to configure the behavior of the FingersCrossedHandler after being triggered and changed to `formatBatch` to behave better when the nested handler does not just do a `foreach` loop to handle batch.
