### PR TITLE
Trying to carefully improve the language on a common exception message

### DIFF
--- a/src/Monolog/Handler/StreamHandler.php
+++ b/src/Monolog/Handler/StreamHandler.php
@@ -64,7 +64,7 @@ class StreamHandler extends AbstractProcessingHandler
             $this->stream = @fopen($this->url, 'a');
             if (!is_resource($this->stream)) {
                 $this->stream = null;
-                throw new \UnexpectedValueException('The stream could not be opened, "'.$this->url.'" may be an invalid url.');
+                throw new \UnexpectedValueException(sprintf('The stream or file "%s" could not be opened; it may be invalid or not writable.', $this->url));
             }
         }
         fwrite($this->stream, (string) $record['message']);


### PR DESCRIPTION
Hey Jordi-

There may be a better way to handle this - I'm not sure if you can determine factually if a stream URL is in fact a file or not. But basically, if we use the word "stream", it's not going to be clear to everyone. And since this is probably the first thing a user will see when they load up their newly downloaded Symfony2 distribution, I want it to be as clear as possible.

Thanks!
