### PR TITLE
Monolog\Processor\MemoryProcessor is now an abstract class

### DIFF
--- a/src/Monolog/Processor/MemoryProcessor.php
+++ b/src/Monolog/Processor/MemoryProcessor.php
@@ -16,7 +16,7 @@ namespace Monolog\Processor;
  *
  * @author Rob Jensen
  */
-class MemoryProcessor
+abstract class MemoryProcessor
 {
     protected $realUsage;
 


### PR DESCRIPTION
Monolog\Processor\MemoryProcessor is now an abstract class since it can be used explicitly
