### PR TITLE
Added note to README regarding phpunit 3.5+ being necessary

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -71,7 +71,8 @@ About
 Requirements
 ------------
 
-Any flavor of PHP 5.3 should do
+- Any flavor of PHP 5.3 should do
+- [optional] PHPUnit 3.5+ to execute the test suite (phpunit --version)
 
 Submitting bugs and feature requests
 ------------------------------------


### PR DESCRIPTION
In order to run the test suite you need at least phpunit 3.5. It is less confusing to those that aren't already using 3.5 to simply note this in the README.
