### PR TITLE
Added Monolog\Logger::getLevelCode()

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -64,13 +64,22 @@ class Logger
      */
     const ALERT = 550;
 
-    protected static $levels = array(
-        100 => 'DEBUG',
-        200 => 'INFO',
-        300 => 'WARNING',
-        400 => 'ERROR',
-        500 => 'CRITICAL',
-        550 => 'ALERT',
+    protected static $levelCodes = array(
+        self::DEBUG => 'DEBUG',
+        self::INFO => 'INFO',
+        self::WARNING => 'WARNING',
+        self::ERROR => 'ERROR',
+        self::CRITICAL => 'CRITICAL',
+        self::ALERT => 'ALERT',
+    );
+
+    protected static $levelNames = array(
+        'DEBUG' => self::DEBUG,
+        'INFO' => self::INFO,
+        'WARNING' => self::WARNING,
+        'ERROR' => self::ERROR,
+        'CRITICAL' => self::CRITICAL,
+        'ALERT' => self::ALERT
     );
 
     protected $name;
@@ -274,7 +283,18 @@ class Logger
      */
     public static function getLevelName($level)
     {
-        return self::$levels[$level];
+        return self::$levelCodes[$level];
+    }
+
+    /**
+     * Returns the level code of the given level name.
+     *
+     * @param string $name
+     * @return int Level code
+     */
+    public static function getLevelCode($name)
+    {
+        return self::$levelNames[$name];
     }
 
     // ZF Logger Compat

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -27,6 +27,32 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Monolog\Logger::getLevelName()
+     */
+    public function testFindingLevelNames()
+    {
+        $this->assertEquals('DEBUG', Logger::getLevelName(100));
+        $this->assertEquals('INFO', Logger::getLevelName(200));
+        $this->assertEquals('WARNING', Logger::getLevelName(300));
+        $this->assertEquals('ERROR', Logger::getLevelName(400));
+        $this->assertEquals('CRITICAL', Logger::getLevelName(500));
+        $this->assertEquals('ALERT', Logger::getLevelName(550));
+    }
+
+    /**
+     * @covers Monolog\Logger::getLevelCode()
+     */
+    public function testFindingLevelCodes()
+    {
+        $this->assertEquals(100, Logger::getLevelCode('DEBUG'));
+        $this->assertEquals(200, Logger::getLevelCode('INFO'));
+        $this->assertEquals(300, Logger::getLevelCode('WARNING'));
+        $this->assertEquals(400, Logger::getLevelCode('ERROR'));
+        $this->assertEquals(500, Logger::getLevelCode('CRITICAL'));
+        $this->assertEquals(550, Logger::getLevelCode('ALERT'));
+    }
+
+    /**
      * @covers Monolog\Logger::__construct
      */
     public function testChannel()


### PR DESCRIPTION
Added Monolog\Logger::getLevelCode() - ability to retrieve the error level code using a string identifier. Renamed Monolog\Logger::$levels to Monolog\Logger::$levelCodes in order to fit this new functionality. Tests have also been added to ensure the error codes will fail tests if they ever change. Error codes should not change so this acts as an enforcement to that rule.
