### PR TITLE
switch initialized state in example handler

### DIFF
--- a/doc/extending.md
+++ b/doc/extending.md
@@ -54,6 +54,8 @@ class PDOHandler extends AbstractProcessingHandler
         $this->statement = $this->pdo->prepare(
             'INSERT INTO monolog (channel, level, message, time) VALUES (:channel, :level, :message, :time)'
         );
+
+        $this->initialized = true;
     }
 }
 ```


### PR DESCRIPTION
The example PDOHandler does not switch its "initialized" flag after initializing itself.
