### PR TITLE
Functions to disable temporarily the logging.

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -184,7 +184,7 @@ class Logger
      */
     public function addRecord($level, $message, array $context = array())
     {
-        if (!self::$enabled) {
+        if (!$this->enabled) {
             return false;
         }
         


### PR DESCRIPTION
``` php
    /**
     * @return boolean Returns true when logging is currently enabled.
     */
    public function isEnabled()

    /**
     * @param boolean $enable Enable (true) or disable (false) the logging.
     */
    public function setEnabled($enable)
```

It might be useful within controled loops when a suboperation makes logging and you could not deactivate it. For example:

``` php
// logger as a symfony container
$this->Logger = $this->getContainer()->get('logger');

// ...

// a very intensive controlled loop
while ($quantity-- > 0) {
    $this->Logger->setEnabled(false);
    $this->LabelRepository->createLabel($serial);
    $this->Logger->setEnabled(true);
}
```
