### PR TITLE
SyslogHandler upgraded to support external hosts without breaking backward compatability.

### DIFF
--- a/src/Monolog/Handler/SyslogHandler.php
+++ b/src/Monolog/Handler/SyslogHandler.php
@@ -104,7 +104,7 @@ class SyslogHandler extends AbstractProcessingHandler
 	{
 		$this->ident = $ident;
 		$this->facility = $facility;
-		$this->socket = fsockopen("tcp://".$host, $port, $errno, $errstr);
+		$this->socket = fsockopen("udp://".$host, $port, $errno, $errstr);
 		stream_set_blocking($this->socket, 0); // Non-blocking socket
 	}
     }


### PR DESCRIPTION
Works perfectly with Loggly. Tested. Did not create an actual test or run the tests, since i don't have phpUnit installed on this machine right now.
