### PR TITLE
Prevent exceptions from being thrown in file handler destructors

### DIFF
--- a/src/Monolog/Handler/AbstractHandler.php
+++ b/src/Monolog/Handler/AbstractHandler.php
@@ -156,7 +156,7 @@ abstract class AbstractHandler implements HandlerInterface
     {
         try {
             $this->close();    
-        } catch( \Exception $e ) {
+        } catch(\Exception $e) {
             // do nothing
         }
     }


### PR DESCRIPTION
In certain setups I was getting a 'Exception thrown without a stack frame' error on first run of the day when the rotating file handler was used (and so the log file had not been yet created). Appears that the handler was trying to close a non-existent stream which was then throwing an exception in the destructor, causing the issue.

Wrapping this call to the close method in a try/catch block will prevent this 'no stack frame' exception error from occurring.
