### PR TITLE
Add microseconds to the DateTime object

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -168,7 +168,7 @@ class Logger
             'level' => $level,
             'level_name' => self::getLevelName($level),
             'channel' => $this->name,
-            'datetime' => new \DateTime(),
+            'datetime' => \DateTime::createFromFormat('U.u', microtime(true)),
             'extra' => array(),
         );
         // check if any message will handle this message


### PR DESCRIPTION
Patch that goes along with issue #57. I opted for the object syntax vs the procedural method suggested in the issue.
