### PR TITLE
Third attempt at fixing microseconds

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -168,7 +168,7 @@ class Logger
             'level' => $level,
             'level_name' => self::getLevelName($level),
             'channel' => $this->name,
-            'datetime' => \DateTime::createFromFormat('0.u00 U', microtime()),
+            'datetime' => \DateTime::createFromFormat('U.u', sprintf('%.6f', microtime(true))),
             'extra' => array(),
         );
         // check if any message will handle this message


### PR DESCRIPTION
The last update by Seldaek causes the original behavior of always having 0 microseconds. My best guess is that PHP resets the microseconds to 0 after the seconds is parsed. I tested the latest change with the following code at 1 million iterations.

``` php
for($i=0;$i<$argv[1];$i++){
    $dt = \DateTime::createFromFormat('U.u', sprintf('%.6f', microtime(true)));
    var_dump($dt->format('U.u'));
}
```
