### PR TITLE
WebProcessor: Add server name

### DIFF
--- a/src/Monolog/Processor/WebProcessor.php
+++ b/src/Monolog/Processor/WebProcessor.php
@@ -52,6 +52,7 @@ class WebProcessor
                 'url'         => $this->serverData['REQUEST_URI'],
                 'ip'          => $this->serverData['REMOTE_ADDR'],
                 'http_method' => $this->serverData['REQUEST_METHOD'],
+                'server_name' => $this->serverData['SERVER_NAME'],
             )
         );
 


### PR DESCRIPTION
Useful for figuring out the source of log messages when you have a lot of vhosts.
