### PR TITLE
Fix issue 78 (fatal error in tests when mlehner/gelf-php is not installed)

### DIFF
--- a/tests/Monolog/Formatter/GelfMessageFormatterTest.php
+++ b/tests/Monolog/Formatter/GelfMessageFormatterTest.php
@@ -12,9 +12,17 @@
 namespace Monolog\Formatter;
 
 use Monolog\Logger;
+use Monolog\Formatter\GelfMessageFormatter;
 
 class GelfMessageFormatterTest extends \PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        if (!class_exists("Gelf\Message")) {
+            $this->markTestSkipped("mlehner/gelf-php not installed");
+        }
+    }
+
     /**
      * @covers Monolog\Formatter\GelfMessageFormatter::format
      */

--- a/tests/Monolog/Handler/GelfHandlerTest.php
+++ b/tests/Monolog/Handler/GelfHandlerTest.php
@@ -14,25 +14,16 @@ namespace Monolog\Handler;
 use Monolog\TestCase;
 use Monolog\Logger;
 use Monolog\Formatter\GelfMessageFormatter;
-use Gelf\MessagePublisher;
-use Gelf\Message;
-
-class MockMessagePublisher extends MessagePublisher
-{
-    public function publish(Message $message) {
-        $this->lastMessage = $message;
-    }
-
-    public $lastMessage = null;
-}
 
 class GelfHandlerTest extends TestCase
 {
     public function setUp()
     {
-        if (!class_exists("Gelf\MessagePublisher")) {
+        if (!class_exists("Gelf\MessagePublisher") || !class_exists("Gelf\Message")) {
             $this->markTestSkipped("mlehner/gelf-php not installed");
         }
+
+        require_once __DIR__ . '/GelfMocks.php';
     }
 
     /**

--- a/tests/Monolog/Handler/GelfMocks.php
+++ b/tests/Monolog/Handler/GelfMocks.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Gelf\MessagePublisher;
+use Gelf\Message;
+
+class MockMessagePublisher extends MessagePublisher
+{
+    public function publish(Message $message) {
+        $this->lastMessage = $message;
+    }
+
+    public $lastMessage = null;
+}
+
+


### PR DESCRIPTION
Refactor `GelfMessageFormatterTest` and `GelfHandlerTest` so that they don't
fatal error when `mlehner/gelf-php` is not installed.

Fixes GH-78.
