### PR TITLE
Fix GelfMessageFormatter doc block

### DIFF
--- a/src/Monolog/Formatter/GelfMessageFormatter.php
+++ b/src/Monolog/Formatter/GelfMessageFormatter.php
@@ -15,7 +15,8 @@ use Monolog\Logger;
 use Gelf\Message;
 
 /**
- * Serializes a log message according to Wildfire's header requirements
+ * Serializes a log message to GELF
+ * @see http://www.graylog2.org/about/gelf
  *
  * @author Matt Lehner <mlehner@gmail.com>
  */


### PR DESCRIPTION
It doesn't serialize to [Wildfire](http://www.wildfirehq.org/) (that's FirePHP); it serializes to [GELF](http://www.graylog2.org/about/gelf).
