### PR TITLE
Add posibility to specify more address and custom headers in NativeMailerHandler

### DIFF
--- a/src/Monolog/Handler/NativeMailerHandler.php
+++ b/src/Monolog/Handler/NativeMailerHandler.php
@@ -23,7 +23,7 @@ class NativeMailerHandler extends MailHandler
     protected $to;
     protected $subject;
     protected $headers = array(
-        'Content-type: text-plain; charset=utf-8'
+        'Content-type: text/plain; charset=utf-8'
     );
 
     /**


### PR DESCRIPTION
I recently need to specify custom headers and more emails in handler (i know, that i can do same thing by adding more handlers with different adresses, but this is more elegant). And I think, it can be useful for somebody else too. 

So there it is.
