### PR TITLE
Timezone for log record datetime attribute.

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -176,13 +176,24 @@ class Logger
         if (!$this->handlers) {
             $this->pushHandler(new StreamHandler('php://stderr', self::DEBUG));
         }
+
+        $dateTime = \DateTime::createFromFormat(
+            'U.u', sprintf('%.6F', microtime(true))
+        );
+
+        $tzString = date_default_timezone_get();
+        if ($tzString) {
+            $dateTimeZone = new \DateTimeZone($tzString);
+            $dateTime->setTimezone($dateTimeZone);
+        }
+
         $record = array(
             'message' => (string) $message,
             'context' => $context,
             'level' => $level,
             'level_name' => self::getLevelName($level),
             'channel' => $this->name,
-            'datetime' => \DateTime::createFromFormat('U.u', sprintf('%.6F', microtime(true))),
+            'datetime' => $dateTime,
             'extra' => array(),
         );
         // check if any message will handle this message


### PR DESCRIPTION
Log record datetime attribute always in UTC+0 timezone but should be in server timezone.
It's an attempt to fix it.
