### PR TITLE
Improved default line formatter for syslog handler

### DIFF
--- a/src/Monolog/Handler/SyslogHandler.php
+++ b/src/Monolog/Handler/SyslogHandler.php
@@ -107,4 +107,12 @@ class SyslogHandler extends AbstractProcessingHandler
     {
         syslog($this->logLevels[$record['level']], (string) $record['formatted']);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getDefaultFormatter()
+    {
+        return new LineFormatter('%channel%.%level_name%: %message% %context% %extra%\n');
+    }
 }


### PR DESCRIPTION
By default syslog prefixes the date in each log message. The default line formatter used for the syslog handler contains a date at the beginning of it's default format.

I think that the most desired behavior is to have by default the message that contains one date in syslog files.
