### PR TITLE
Added an handler for NewRelic

### DIFF
--- a/nbproject/private/private.properties
+++ b/nbproject/private/private.properties
@@ -1,2 +1,0 @@
-index.file=index.php
-url=http://localhost/monolog/

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,7 +1,0 @@
-include.path=${php.global.include.path}
-php.version=PHP_53
-source.encoding=UTF-8
-src.dir=.
-tags.asp=false
-tags.short=true
-web.root=.

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://www.netbeans.org/ns/project/1">
-    <type>org.netbeans.modules.php.project</type>
-    <configuration>
-        <data xmlns="http://www.netbeans.org/ns/php-project/1">
-            <name>monolog</name>
-        </data>
-    </configuration>
-</project>


### PR DESCRIPTION
- implemented a test which verifies that the fallback handler handles records when the NewRelic PHP extension is not installes
- implemented the actual handler

There are a few problems that Id like to discuss:
- how to properly test it? The `NewRelic` extension is proprietary, so you cannot obtain it for free
- do we need the fallback handler? It would be super useful for local development, since developers dont usually get the NR extension on their local machines - at the same time I recognize that there is no fallback handler for other handlers (ie `Graylog2`)
- currently, that test seems a little bit too weak to be called a "test"
- if we use `function_exists` we could add some more meaningful tests, but at the same time `extension_loaded` is more _right_
