### PR TITLE
Added SimpleDBHandler

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -114,6 +114,7 @@ Handlers
 - _AmqpHandler_: Logs records to an [amqp](http://www.amqp.org/) compatible
   server. Requires the [php-amqp](http://pecl.php.net/package/amqp) extension (1.0+).
 - _CubeHandler_: Logs records to a [Cube](http://square.github.com/cube/) server.
+- _SimpleDBHandler_: Logs records to a [SimpleDB](http://aws.amazon.com/simpledb) domain.
 
 Wrappers / Special Handlers
 ---------------------------

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,12 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "mlehner/gelf-php": "1.0.*"
+        "mlehner/gelf-php": "1.0.*",
+        "amazonwebservices/aws-sdk-for-php": "1.5.*"
     },
     "suggest": {
         "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
+        "amazonwebservices/aws-sdk-for-php": "Allow sending log messages to Amazon SimpleDB",
         "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
         "ext-mongo": "Allow sending log messages to a MongoDB server"
     },

--- a/src/Monolog/Handler/SimpleDBHandler.php
+++ b/src/Monolog/Handler/SimpleDBHandler.php
@@ -2,9 +2,9 @@
 
 /*
  * This file is part of the Monolog package.
- * 
+ *
  * (c) Jordi Boggiano <j.boggiano@seld.be>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -17,16 +17,16 @@ use Monolog\Handler\AbstractProcessingHandler;
 
 /**
  * Logs to a SimpleDB Domain, using Amazon's AWS SDK for PHP.
- * 
- * You'll probably want to create the domain in advance, since 
- * creating new domains can take up to 10 seconds. 
- * 
- * However, creating SimpleDB domains is an idempotent operation; running it 
- * multiple times using the same domain name will not result in an error 
+ *
+ * You'll probably want to create the domain in advance, since
+ * creating new domains can take up to 10 seconds.
+ *
+ * However, creating SimpleDB domains is an idempotent operation; running it
+ * multiple times using the same domain name will not result in an error
  * response.
- * 
+ *
  * Usage example:
- * 
+ *
  * $log = new Logger('my-logging-channel');
  * $sdb = new AmazonSDB(array(
  *      // bundled, but not used by default? Weird, but true.
@@ -35,45 +35,44 @@ use Monolog\Handler\AbstractProcessingHandler;
  *      'secret' => 'AWS Secret Key'
  * ));
  * $sdb->set_region(AmazonSDB::REGION_CALIFORNIA);
- * 
+ *
  * // recommended: create a SimpleDB Domain for each logging channel
  * // $sdb->create_domain('my-logging-channel');
- * 
+ *
  * $log->pushHandler(new SimpleDBHandler($sdb, Logger::WARNING));
- * 
+ *
  * @author Clay Loveless <clay@php.net>
  */
 class SimpleDBHandler extends AbstractProcessingHandler
 {
     protected $sdb;
     protected $skipCreate;
-    protected $knownChannels = array();    
-    
+    protected $knownChannels = array();
+
     /**
      * Pass in the SimpleDB object, the level of logging to record, the bubble-factor
      * and an optional $skip_create parameter to bypass attempts to create
      * the SimpleDB domain.
-     * 
-     * @param object  $sdb          AmazonSDB object
-     * @param integer $level        Logging level
-     * @param boolean $bubble       Whether the messages that are handled can bubble up the stack or not
-     * @param boolean $skip_create  Whether or not to send the create_domain command for the log channel
+     *
+     * @param object  $sdb         AmazonSDB object
+     * @param integer $level       Logging level
+     * @param boolean $bubble      Whether the messages that are handled can bubble up the stack or not
+     * @param boolean $skip_create Whether or not to send the create_domain command for the log channel
      */
     public function __construct(\AmazonSDB $sdb, $level = Logger::DEBUG, $bubble = true, $skip_create = false)
     {
         $this->sdb = $sdb;
-        
+
         $this->skipCreate = (bool) $skip_create;
-        
-        parent::__construct($level, $bubble);        
+
+        parent::__construct($level, $bubble);
     }
-    
 
     /**
      * {@inheritDoc}
      */
     protected function write(array $record)
-    {        
+    {
         // send the domain create command for the channel, if necessary
         if (!$this->skipCreate) {
             if (!in_array($record['channel'], $this->knownChannels)) {
@@ -81,19 +80,19 @@ class SimpleDBHandler extends AbstractProcessingHandler
                 $this->knownChannels[] = $record['channel'];
             }
         }
-        
+
         $item_name = $this->getLogItemName();
-        
+
         $item = array(
             'datetime' => $record['datetime']->format(DATE_ISO8601),
             'level' => $record['level'],
             'message' => $record['formatted']['message']
         );
-        
+
         // add 'context' and 'extra' as first-class values
         $item = array_merge(
-            $item, 
-            $record['formatted']['context'], 
+            $item,
+            $record['formatted']['context'],
             $record['formatted']['extra']
         );
 
@@ -101,10 +100,10 @@ class SimpleDBHandler extends AbstractProcessingHandler
 
         return false === $this->bubble;
     }
-    
+
     /**
      * Create a UUID without relying on ext/uuid
-     * 
+     *
      * @return string
      */
     protected function getLogItemName()
@@ -113,28 +112,29 @@ class SimpleDBHandler extends AbstractProcessingHandler
          * Thanks to Andrew Moore.
          * @see http://www.php.net/manual/en/function.uniqid.php#94959
          */
+
         return sprintf('%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
-            
+
             // 32 bits for "time_low"
             mt_rand(0, 0xffff), mt_rand(0, 0xffff),
-            
+
             // 16 bits for "time_mid"
             mt_rand(0, 0xffff),
-            
+
             // 16 bits for "time_hi_and_version"
             // four most significant bits holds version number 4
             mt_rand(0, 0x0fff) | 0x4000,
-            
+
             // 16 bits, 8 bits for "clk_seq_hi_res",
             // 8 bits for "clk_seq_low",
             // two most significant bits holds zero and one for variant DCE1.1
             mt_rand(0, 0x3fff) | 0x8000,
-            
+
             // 48 bits for "node"
             mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0xffff)
         );
     }
-    
+
     /**
      * {@inheritDoc}
      */

--- a/src/Monolog/Handler/SimpleDBHandler.php
+++ b/src/Monolog/Handler/SimpleDBHandler.php
@@ -47,9 +47,9 @@ use Monolog\Handler\AbstractProcessingHandler;
 class SimpleDBHandler extends AbstractProcessingHandler
 {
     protected $sdb;
-    protected $origin_info;
+    protected $originInfo;
     protected $onEC2;
-    protected $ec2_metadata_keys = array(
+    protected $ec2MetadataKeys = array(
         'ami-id',
         'hostname',
         'instance-id',
@@ -58,8 +58,8 @@ class SimpleDBHandler extends AbstractProcessingHandler
         'public-ipv4',
         'placement/availability-zone'
     );
-    protected $skip_create;
-    protected $known_channels = array();    
+    protected $skipCreate;
+    protected $knownChannels = array();    
     
     /**
      * Pass in the SimpleDB object, the level of logging to record, the bubble-factor
@@ -80,7 +80,7 @@ class SimpleDBHandler extends AbstractProcessingHandler
         $this->sdb = $sdb;
         
         $this->onEC2 = (bool) $onEC2;
-        $this->skip_create = (bool) $skip_create;
+        $this->skipCreate = (bool) $skip_create;
         $this->setOriginInfo();
         
         parent::__construct($level, $bubble);        
@@ -130,7 +130,7 @@ class SimpleDBHandler extends AbstractProcessingHandler
                 if (is_array($this->onEC2)) {
                     $metadata_keys = $this->onEC2;
                 } else {
-                    $metadata_keys = $this->ec2_metadata_keys;
+                    $metadata_keys = $this->ec2MetadataKeys;
                 }
                 
                 // since socket is already open, use it                
@@ -154,7 +154,7 @@ class SimpleDBHandler extends AbstractProcessingHandler
             );
         }
         
-        $this->origin_info = $origin_info;
+        $this->originInfo = $origin_info;
     }
     
     /**
@@ -168,10 +168,10 @@ class SimpleDBHandler extends AbstractProcessingHandler
         }
         
         // send the domain create command for the channel, if necessary
-        if (! $this->skip_create) {
-            if (! in_array($record['channel'], $this->known_channels)) {
+        if (! $this->skipCreate) {
+            if (! in_array($record['channel'], $this->knownChannels)) {
                 $this->sdb->create_domain($record['channel']);
-                $this->known_channels[] = $record['channel'];
+                $this->knownChannels[] = $record['channel'];
             }
         }
         
@@ -197,7 +197,7 @@ class SimpleDBHandler extends AbstractProcessingHandler
             }
         }
         
-        $item = array_merge($item, $this->origin_info);
+        $item = array_merge($item, $this->originInfo);
 
         $this->sdb->put_attributes($record['channel'], $item_name, $item);
 

--- a/src/Monolog/Handler/SimpleDBHandler.php
+++ b/src/Monolog/Handler/SimpleDBHandler.php
@@ -179,17 +179,13 @@ class SimpleDBHandler extends AbstractProcessingHandler
             'message' => $record['formatted']['message']
         );
         
-        // add context as first-class values
-        foreach ($record['formatted']['context'] as $context_key => $context_val) {
-            $item[$context_key] = $context_val;
-        }
-        
-        // processor-added values are also first-class
-        foreach ($record['formatted']['extra'] as $extra_key => $extra_val) {
-            $item[$extra_key] = $extra_val;
-        }
-        
-        $item = array_merge($item, $this->originInfo);
+        // add 'context' and 'extra' as first-class values
+        $item = array_merge(
+            $item, 
+            $record['formatted']['context'], 
+            $record['formatted']['extra'],
+            $this->originInfo
+        );
 
         $this->sdb->put_attributes($record['channel'], $item_name, $item);
 

--- a/src/Monolog/Handler/SimpleDBHandler.php
+++ b/src/Monolog/Handler/SimpleDBHandler.php
@@ -1,0 +1,215 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ * 
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ * 
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Logger;
+use Monolog\Formatter\NormalizerFormatter;
+use Monolog\Handler\AbstractProcessingHandler;
+
+/**
+ * Logs to a SimpleDB Domain, using Amazon's AWS SDK for PHP.
+ * 
+ * You'll want to create the domain in advance, more than likely, since 
+ * creating new domains can take up to 10 seconds.
+ * 
+ * Usage example:
+ * 
+ * $log = new Logger('my-logging-channel');
+ * $sdb = new AmazonSDB(array(
+ *      // bundled, but not used by default? Weird, but true.
+ *      'certificate_authority' => __DIR__.'/../vendor/amazonwebservices/aws-sdk-for-php/lib/requestcore/cacert.pem'
+ *      'key' => 'AWS Access Key',
+ *      'secret' => 'AWS Secret Key'
+ * ));
+ * $sdb->set_region(AmazonSDB::REGION_CALIFORNIA);
+ * 
+ * // recommended: create a SimpleDB Domain for each logging channel
+ * // $sdb->create_domain('my-logging-channel');
+ * 
+ * $log->pushHandler(new SimpleDBHandler($sdb, Logger::WARNING));
+ * 
+ * @author Clay Loveless <clay@php.net>
+ */
+class SimpleDBHandler extends AbstractProcessingHandler
+{
+    
+    protected $sdb;
+    protected $origin_info;
+    protected $onEC2;
+    protected $ec2_metadata_keys = array(
+        'ami-id',
+        'hostname',
+        'instance-id',
+        'instance-type',
+        'local-ipv4',
+        'public-ipv4',
+        'placement/availability-zone'
+    );
+    protected $buffer = array();
+    
+    
+    /**
+     * Pass in the SimpleDB object, the level of logging to record, the bubble-factor
+     * and an optional parameter for $onEC2. If $onEC2 is true, 
+     * the we'll add some extra fields about the EC2 instance you're running on.
+     * This is the default behavior.
+     * 
+     * If you're NOT running on EC2, php_uname() hostname value will be logged.
+     * 
+     */
+    public function __construct(\AmazonSDB $sdb, $level = Logger::DEBUG, $bubble = true, $onEC2 = true)
+    {
+        // batch process from here
+        $sdb->batch();
+        $this->sdb = $sdb;
+        
+        $this->onEC2 = $onEC2;
+        $this->setOriginInfo();
+        
+        parent::__construct($level, $bubble);        
+    }
+    
+    /**
+     * If you're running this handler on EC2, the following EC2 metadata
+     * key values will be stored with each log entry.
+     * 
+     *   hostname
+     *   ami-id
+     *   instance-id
+     *   instance-type
+     *   local-ipv4
+     *   public-ipv4
+     *   placement/availability-zone
+     * 
+     * If you want more metadata, or less, just set the keys you want instead
+     * of simply passing TRUE to isEC2 in the constructor
+     * 
+     * Usage example:
+     * 
+     *$log = new Logger('my-logging-channel');
+     * $sdb = new AmazonSDB(array(
+     *      'certificate_authority' => __DIR__.'/../vendor/amazonwebservices/aws-sdk-for-php/lib/requestcore/cacert.pem'
+     *      'key' => 'AWS Access Key',
+     *      'secret' => 'AWS Secret Key'
+     * ));
+     * // $sdb->set_region(AmazonSDB::REGION_CALIFORNIA);
+     * 
+     * $sdb_handler = new SimpleDBHandler($sdb, Logger::WARNING, true, array('hostname', 'ami-id', 'kernel-id'));
+     * 
+     * $log->pushHandler($sdb_handler);
+     * 
+     */    
+    protected function setOriginInfo()
+    {
+        $origin_info = array();
+        if ($this->onEC2 !== false) {
+            // should be an instant connection if on EC2
+            $fp = fsockopen('169.254.169.254', 80, $errno, $errstr, 1);
+            if ($fp) {
+                
+                if (is_array($this->onEC2)) {
+                    $metadata_keys = $this->onEC2;
+                } else {
+                    $metadata_keys = $this->ec2_metadata_keys;
+                }
+                
+                // since socket is already open, use it                
+                foreach ($metadata_keys as $metakey) {
+                    $req = "GET /latest/meta-data/{$metakey} HTTP/1.0";
+                    fwrite($fp, $req);
+                    $origin_info[$metakey] = stream_get_contents($fp);
+                }
+                fclose($fp);
+                
+            }
+        }
+        if (empty($origin_info)) {
+            $origin_info = array(
+                'hostname' => php_uname('n'),
+                'uname-a' => php_uname('a')
+            );
+        }
+        
+        $this->origin_info = $origin_info;
+    }
+    
+    /**
+     * Buffer writes so SimpleDB BatchPutAttributes can be used
+     * 
+     */
+    protected function write(array $record)
+    {
+        if ($record['level'] < $this->level) {
+            return false;
+        }
+        
+        $this->buffer[] = $record;
+
+        return false === $this->bubble;
+    }
+    
+    /**
+     * Close handler writes to SimpleDB
+     */
+    public function close()
+    {
+        parent::close();
+        
+        $item_keypairs = array();
+        $i = 0;
+        foreach ($this->buffer as $record) {
+            // generate unique ItemName
+            $item_name = hash('sha256', var_export($record, true) . uniqid());
+            
+            $item = array(
+                'datetime' => $record['datetime']->format(DATE_ISO8601),
+                'level' => $record['level'],
+                'message' => $record['formatted']['message']
+            );
+            
+            // add context as first-class values
+            if (! empty($record['formatted']['context'])) {
+                foreach ($record['formatted']['context'] as $context_key => $context_val) {
+                    $item[$context_key] = $context_val;
+                }
+            }
+            
+            // processor-added values are also first-class
+            if (! empty($record['formatted']['extra'])) {
+                foreach ($record['formatted']['extra'] as $extra_key => $extra_val) {
+                    $item[$extra_key] = $extra_val;
+                }
+            }
+            
+            $item = array_merge($item, $this->origin_info);
+            $item_keypairs[$item_name] = $item;
+            $i++;
+            if ($i == 25) {
+                // need to start a new one
+                $this->sdb->batch_put_attributes($record['channel'], $item_keypairs);
+                $i = 0;
+                $item_keypairs = array();
+            }
+        }
+        $result = $this->sdb->batch_put_attributes($record['channel'], $item_keypairs);
+        $result = $this->sdb->batch()->send();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDefaultFormatter()
+    {
+        return new NormalizerFormatter();
+    }
+
+}

--- a/src/Monolog/Handler/SimpleDBHandler.php
+++ b/src/Monolog/Handler/SimpleDBHandler.php
@@ -57,13 +57,13 @@ class SimpleDBHandler extends AbstractProcessingHandler
      * @param object  $sdb         AmazonSDB object
      * @param integer $level       Logging level
      * @param boolean $bubble      Whether the messages that are handled can bubble up the stack or not
-     * @param boolean $skip_create Whether or not to send the create_domain command for the log channel
+     * @param boolean $skipCreate  Whether or not to send the create_domain command for the log channel
      */
-    public function __construct(\AmazonSDB $sdb, $level = Logger::DEBUG, $bubble = true, $skip_create = false)
+    public function __construct(\AmazonSDB $sdb, $level = Logger::DEBUG, $bubble = true, $skipCreate = false)
     {
         $this->sdb = $sdb;
 
-        $this->skipCreate = (bool) $skip_create;
+        $this->skipCreate = (bool) $skipCreate;
 
         parent::__construct($level, $bubble);
     }
@@ -81,7 +81,7 @@ class SimpleDBHandler extends AbstractProcessingHandler
             }
         }
 
-        $item_name = $this->getLogItemName();
+        $itemName = $this->getLogItemName();
 
         $item = array(
             'datetime' => $record['datetime']->format(DATE_ISO8601),
@@ -96,9 +96,7 @@ class SimpleDBHandler extends AbstractProcessingHandler
             $record['formatted']['extra']
         );
 
-        $this->sdb->put_attributes($record['channel'], $item_name, $item);
-
-        return false === $this->bubble;
+        $this->sdb->put_attributes($record['channel'], $itemName, $item);
     }
 
     /**

--- a/src/Monolog/Handler/SimpleDBHandler.php
+++ b/src/Monolog/Handler/SimpleDBHandler.php
@@ -180,17 +180,13 @@ class SimpleDBHandler extends AbstractProcessingHandler
         );
         
         // add context as first-class values
-        if (!empty($record['formatted']['context'])) {
-            foreach ($record['formatted']['context'] as $context_key => $context_val) {
-                $item[$context_key] = $context_val;
-            }
+        foreach ($record['formatted']['context'] as $context_key => $context_val) {
+            $item[$context_key] = $context_val;
         }
         
         // processor-added values are also first-class
-        if (!empty($record['formatted']['extra'])) {
-            foreach ($record['formatted']['extra'] as $extra_key => $extra_val) {
-                $item[$extra_key] = $extra_val;
-            }
+        foreach ($record['formatted']['extra'] as $extra_key => $extra_val) {
+            $item[$extra_key] = $extra_val;
         }
         
         $item = array_merge($item, $this->originInfo);

--- a/src/Monolog/Handler/SimpleDBHandler.php
+++ b/src/Monolog/Handler/SimpleDBHandler.php
@@ -162,11 +162,7 @@ class SimpleDBHandler extends AbstractProcessingHandler
      * 
      */
     protected function write(array $record)
-    {
-        if ($record['level'] < $this->level) {
-            return false;
-        }
-        
+    {        
         // send the domain create command for the channel, if necessary
         if (! $this->skipCreate) {
             if (! in_array($record['channel'], $this->knownChannels)) {

--- a/src/Monolog/Handler/SimpleDBHandler.php
+++ b/src/Monolog/Handler/SimpleDBHandler.php
@@ -164,8 +164,8 @@ class SimpleDBHandler extends AbstractProcessingHandler
     protected function write(array $record)
     {        
         // send the domain create command for the channel, if necessary
-        if (! $this->skipCreate) {
-            if (! in_array($record['channel'], $this->knownChannels)) {
+        if (!$this->skipCreate) {
+            if (!in_array($record['channel'], $this->knownChannels)) {
                 $this->sdb->create_domain($record['channel']);
                 $this->knownChannels[] = $record['channel'];
             }
@@ -180,14 +180,14 @@ class SimpleDBHandler extends AbstractProcessingHandler
         );
         
         // add context as first-class values
-        if (! empty($record['formatted']['context'])) {
+        if (!empty($record['formatted']['context'])) {
             foreach ($record['formatted']['context'] as $context_key => $context_val) {
                 $item[$context_key] = $context_val;
             }
         }
         
         // processor-added values are also first-class
-        if (! empty($record['formatted']['extra'])) {
+        if (!empty($record['formatted']['extra'])) {
             foreach ($record['formatted']['extra'] as $extra_key => $extra_val) {
                 $item[$extra_key] = $extra_val;
             }

--- a/src/Monolog/Processor/AmazonEC2Processor.php
+++ b/src/Monolog/Processor/AmazonEC2Processor.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+/**
+ * Injects several EC2 instance properties in all records
+ *
+ * @author Clay Loveless <clay@php.net>
+ */
+class AmazonEC2Processor
+{
+    /**
+     * @see http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/AESDG-chapter-instancedata.html
+     */
+    protected $metadataKeys = array(
+        'ami-id',
+        'hostname',
+        'instance-id',
+        'instance-type',
+        'local-ipv4',
+        'public-ipv4',
+        'placement/availability-zone'        
+    );
+    
+    protected $baseUrl;
+    
+    /**
+     * @param array   $metadataKeys Array of metadata keys to record
+     * @param boolean $overwrite If TRUE, passed metadataKeys will not be merged
+     * @param string  $base_url Used to set where the metadata should be queried
+     */
+    public function __construct(array $metadata_keys, $overwrite = false, $base_url = 'http://169.254.169.254')
+    {
+        if ($overwrite) {
+            $this->metadataKeys = $metadata_keys;
+        } else {
+            $this->metadataKeys = array_merge($this->metadataKeys, $metadata_keys);
+        }
+        $this->baseUrl = $base_url;
+    }
+    
+    /**
+     * @param  array $record
+     * @return array
+     */
+    public function __invoke(array $record)
+    {
+        $metadata = array();
+        
+        // should be an instant connection if on EC2, so timeout after
+        // one second to minimize delay for anyone using this processor
+        // mistakenly in a local dev environment.
+        $socket_timeout = ini_get('default_socket_timeout');
+        ini_set('default_socket_timeout', 1);
+        
+        // if we can't get hostname, we can't get any others either
+        $hostname = file_get_contents($this->baseUrl . '/latest/meta-data/hostname');
+        if ($hostname !== false) {
+            // don't get hostname twice
+            if (in_array('hostname', $this->metadataKeys)) {
+                $metadata['hostname'] = $hostname;
+            }
+            foreach ($this->metadataKeys as $metakey) {
+                if ($metakey == 'hostname') {
+                    continue;
+                }
+                $url = $this->baseUrl . '/latest/meta-data/' . $metakey;
+                $metadata[$metakey] = file_get_contents($url);
+            }
+        }
+        
+        // restore socket settings
+        ini_set('default_socket_timeout', $socket_timeout);
+        
+        $record['extra'] = array_merge(
+            $record['extra'],
+            $metadata
+        );
+
+        return $record;
+    }
+}

--- a/src/Monolog/Processor/AmazonEC2Processor.php
+++ b/src/Monolog/Processor/AmazonEC2Processor.php
@@ -28,15 +28,15 @@ class AmazonEC2Processor
         'instance-type',
         'local-ipv4',
         'public-ipv4',
-        'placement/availability-zone'        
+        'placement/availability-zone'
     );
-    
+
     protected $baseUrl;
-    
+
     /**
      * @param array   $metadataKeys Array of metadata keys to record
-     * @param boolean $overwrite If TRUE, passed metadataKeys will not be merged
-     * @param string  $base_url Used to set where the metadata should be queried
+     * @param boolean $overwrite    If TRUE, passed metadataKeys will not be merged
+     * @param string  $base_url     Used to set where the metadata should be queried
      */
     public function __construct(array $metadata_keys, $overwrite = false, $base_url = 'http://169.254.169.254')
     {
@@ -47,7 +47,7 @@ class AmazonEC2Processor
         }
         $this->baseUrl = $base_url;
     }
-    
+
     /**
      * @param  array $record
      * @return array
@@ -55,13 +55,13 @@ class AmazonEC2Processor
     public function __invoke(array $record)
     {
         $metadata = array();
-        
+
         // should be an instant connection if on EC2, so timeout after
         // one second to minimize delay for anyone using this processor
         // mistakenly in a local dev environment.
         $socket_timeout = ini_get('default_socket_timeout');
         ini_set('default_socket_timeout', 1);
-        
+
         // if we can't get hostname, we can't get any others either
         $hostname = file_get_contents($this->baseUrl . '/latest/meta-data/hostname');
         if ($hostname !== false) {
@@ -77,10 +77,10 @@ class AmazonEC2Processor
                 $metadata[$metakey] = file_get_contents($url);
             }
         }
-        
+
         // restore socket settings
         ini_set('default_socket_timeout', $socket_timeout);
-        
+
         $record['extra'] = array_merge(
             $record['extra'],
             $metadata

--- a/src/Monolog/Processor/AmazonEC2Processor.php
+++ b/src/Monolog/Processor/AmazonEC2Processor.php
@@ -36,16 +36,16 @@ class AmazonEC2Processor
     /**
      * @param array   $metadataKeys Array of metadata keys to record
      * @param boolean $overwrite    If TRUE, passed metadataKeys will not be merged
-     * @param string  $base_url     Used to set where the metadata should be queried
+     * @param string  $baseUrl      Used to set where the metadata should be queried
      */
-    public function __construct(array $metadata_keys, $overwrite = false, $base_url = 'http://169.254.169.254')
+    public function __construct(array $metadataKeys, $overwrite = false, $baseUrl = 'http://169.254.169.254')
     {
         if ($overwrite) {
-            $this->metadataKeys = $metadata_keys;
+            $this->metadataKeys = $metadataKeys;
         } else {
-            $this->metadataKeys = array_merge($this->metadataKeys, $metadata_keys);
+            $this->metadataKeys = array_merge($this->metadataKeys, $metadataKeys);
         }
-        $this->baseUrl = $base_url;
+        $this->baseUrl = $baseUrl;
     }
 
     /**
@@ -59,7 +59,7 @@ class AmazonEC2Processor
         // should be an instant connection if on EC2, so timeout after
         // one second to minimize delay for anyone using this processor
         // mistakenly in a local dev environment.
-        $socket_timeout = ini_get('default_socket_timeout');
+        $socketTimeout = ini_get('default_socket_timeout');
         ini_set('default_socket_timeout', 1);
 
         // if we can't get hostname, we can't get any others either
@@ -79,7 +79,7 @@ class AmazonEC2Processor
         }
 
         // restore socket settings
-        ini_set('default_socket_timeout', $socket_timeout);
+        ini_set('default_socket_timeout', $socketTimeout);
 
         $record['extra'] = array_merge(
             $record['extra'],

--- a/src/Monolog/Processor/HostnameProcessor.php
+++ b/src/Monolog/Processor/HostnameProcessor.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+/**
+ * Injects environment's hostname in all records
+ *
+ * @author Clay Loveless <clay@php.net>
+ */
+class HostnameProcessor
+{
+    /**
+     * @param  array $record
+     * @return array
+     */
+    public function __invoke(array $record)
+    {
+        $record['extra'] = array_merge(
+            $record['extra'],
+            array(
+                'hostname' => php_uname('n'),
+            )
+        );
+
+        return $record;
+    }
+}

--- a/tests/Monolog/Handler/SimpleDBHandlerTest.php
+++ b/tests/Monolog/Handler/SimpleDBHandlerTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\TestCase;
+use Monolog\Logger;
+use Monolog\Handler\SimpleDBHandler;
+
+class SimpleDBHandlerTest extends TestCase
+{
+    protected static $sdb;
+    protected static $channel;
+    
+    public static function setUpBeforeClass()
+    {
+        if (! defined('MONOLOG_AWS_SDB_KEY')) {
+            return;
+        }
+        
+        static::$sdb = new \AmazonSDB(array(
+            'key' => MONOLOG_AWS_SDB_KEY,
+            'secret' => MONOLOG_AWS_SDB_SECRET,
+            'certificate_authority' => __DIR__.'/../../../vendor/amazonwebservices/aws-sdk-for-php/lib/requestcore/cacert.pem'
+        ));
+        static::$sdb->set_region(MONOLOG_SDB_REGION);
+        
+        static::$channel = uniqid('monolog_phpunit_events_');        
+    }
+    
+    public function setUp()
+    {
+        if (! class_exists('\AmazonSDB')) {
+            $this->markTestSkipped('amazonwebservices/aws-sdk-for-php not installed');
+        }
+        if (! defined('MONOLOG_AWS_SDB_KEY')) {
+            $this->markTestSkipped('SimpleDB constants are not set in phpunit.xml');
+        }
+        
+        if (empty(static::$channel)) {
+            $this->markTestSkipped('Gave up waiting on test domain creation');            
+        }
+        
+        // do we need to create the test domain?
+        $domains = static::$sdb->get_domain_list();
+
+        if (! in_array(static::$channel, $domains)) {
+            $result = static::$sdb->create_domain(static::$channel);
+
+            $channel_found = false;
+            $wait_max = 20;
+            $wait = 0;
+            while (! $channel_found) {
+                // wait awhile
+                sleep(1);
+                $wait++;
+                $domains = static::$sdb->get_domain_list();
+                if (in_array(static::$channel, $domains)) {
+                    $channel_found = true;
+                }
+                if ($wait == $wait_max) {
+                    static::$channel = null;
+                    $this->markTestSkipped("Waited {$wait_max} seconds for test domain creation");
+                    break;
+                }
+            }
+        }
+
+    }
+    
+    public function testConstruct()
+    {
+        $handler = $this->getHandler();
+        $this->assertInstanceOf('Monolog\Handler\SimpleDBHandler', $handler);
+    }
+    
+    public function testDebug()
+    {
+        $handler = $this->getHandler();
+        
+        $record = $this->getRecord(Logger::DEBUG, "A testDebug message");
+        $record['channel'] = static::$channel;
+        $handler->handle($record);
+        
+        // account for eventual consistency
+        sleep(3);
+        
+        $result = static::$sdb->select("SELECT * FROM ".static::$channel." WHERE level='".Logger::DEBUG."'");
+        $msg = null;
+        foreach ($result->body->SelectResult->Item->Attribute as $att) {
+            if ($att->Name == 'message') {
+                $msg = (string) $att->Value;
+            }
+        }
+        
+        $this->assertSame('A testDebug message', $msg);
+    }
+    
+    protected function getHandler()
+    {
+        return new SimpleDBHandler(static::$sdb, Logger::DEBUG, true, false);
+    }
+    
+    public static function tearDownAfterClass()
+    {
+        if (! empty(static::$sdb)) {
+            static::$sdb->delete_domain(static::$channel);
+        }
+    }
+}

--- a/tests/Monolog/Handler/SimpleDBHandlerTest.php
+++ b/tests/Monolog/Handler/SimpleDBHandlerTest.php
@@ -55,18 +55,18 @@ class SimpleDBHandlerTest extends TestCase
         if (! in_array(static::$channel, $domains)) {
             $result = static::$sdb->create_domain(static::$channel);
 
-            $channel_found = false;
-            $wait_max = 20;
+            $channelFound = false;
+            $waitMax = 20;
             $wait = 0;
-            while (! $channel_found) {
+            while (! $channelFound) {
                 // wait awhile
                 sleep(1);
                 $wait++;
                 $domains = static::$sdb->get_domain_list();
                 if (in_array(static::$channel, $domains)) {
-                    $channel_found = true;
+                    $channelFound = true;
                 }
-                if ($wait == $wait_max) {
+                if ($wait == $waitMax) {
                     static::$channel = null;
                     $this->markTestSkipped("Waited {$wait_max} seconds for test domain creation");
                     break;

--- a/tests/Monolog/Processor/AmazonEC2ProcessorTest.php
+++ b/tests/Monolog/Processor/AmazonEC2ProcessorTest.php
@@ -40,8 +40,8 @@ class AmazonEC2ProcessorTest extends TestCase
      */
     public function testProcessor()
     {
-        $base_url = "file://".self::$tmpdir;
-        $processor = new AmazonEC2Processor(array(), false, $base_url);
+        $baseUrl = "file://".self::$tmpdir;
+        $processor = new AmazonEC2Processor(array(), false, $baseUrl);
         $record = $processor($this->getRecord());
         $this->assertArrayHasKey('hostname', $record['extra']);
         $this->assertSame('t1.micro', $record['extra']['instance-type']);
@@ -49,8 +49,8 @@ class AmazonEC2ProcessorTest extends TestCase
 
     public function testProcessorCanOverrideDefaultMetadataKeys()
     {
-        $base_url = "file://".self::$tmpdir;
-        $processor = new AmazonEC2Processor(array('public-ipv4'), true, $base_url);
+        $baseUrl = "file://".self::$tmpdir;
+        $processor = new AmazonEC2Processor(array('public-ipv4'), true, $baseUrl);
         $record = $processor($this->getRecord());
         $this->assertArrayNotHasKey('hostname', $record['extra']);
         $this->assertArrayHasKey('public-ipv4', $record['extra']);
@@ -63,8 +63,8 @@ class AmazonEC2ProcessorTest extends TestCase
         self::$metadataFixture['mac'] = $mac;
         file_put_contents(self::$tmpdir . '/latest/meta-data/mac', $mac);
 
-        $base_url = "file://".self::$tmpdir;
-        $processor = new AmazonEC2Processor(array('mac'), false, $base_url);
+        $baseUrl = "file://".self::$tmpdir;
+        $processor = new AmazonEC2Processor(array('mac'), false, $baseUrl);
         $record = $processor($this->getRecord());
         $this->assertArrayHasKey('hostname', $record['extra']);
         $this->assertArrayHasKey('public-ipv4', $record['extra']);

--- a/tests/Monolog/Processor/AmazonEC2ProcessorTest.php
+++ b/tests/Monolog/Processor/AmazonEC2ProcessorTest.php
@@ -25,7 +25,7 @@ class AmazonEC2ProcessorTest extends TestCase
         'placement/availability-zone'   => 'us-west-1c'
     );
     protected static $tmpdir;
-    
+
     public static function setUpBeforeClass()
     {
         self::$tmpdir = __DIR__ . '/Fixtures/' . uniqid('AmazonEC2ProcessorTest_');
@@ -34,7 +34,7 @@ class AmazonEC2ProcessorTest extends TestCase
             file_put_contents(self::$tmpdir . '/latest/meta-data/' . $key, $val);
         }
     }
-    
+
     /**
      * @covers Monolog\Processor\AmazonEC2Processor
      */
@@ -43,10 +43,10 @@ class AmazonEC2ProcessorTest extends TestCase
         $base_url = "file://".self::$tmpdir;
         $processor = new AmazonEC2Processor(array(), false, $base_url);
         $record = $processor($this->getRecord());
-        $this->assertArrayHasKey('hostname', $record['extra']);        
-        $this->assertSame('t1.micro', $record['extra']['instance-type']);        
+        $this->assertArrayHasKey('hostname', $record['extra']);
+        $this->assertSame('t1.micro', $record['extra']['instance-type']);
     }
-    
+
     public function testProcessorCanOverrideDefaultMetadataKeys()
     {
         $base_url = "file://".self::$tmpdir;
@@ -54,24 +54,24 @@ class AmazonEC2ProcessorTest extends TestCase
         $record = $processor($this->getRecord());
         $this->assertArrayNotHasKey('hostname', $record['extra']);
         $this->assertArrayHasKey('public-ipv4', $record['extra']);
-        $this->assertSame('204.236.140.81', $record['extra']['public-ipv4']);   
+        $this->assertSame('204.236.140.81', $record['extra']['public-ipv4']);
     }
-    
+
     public function testProcessorCanMergeWithDefaultMetadataKeys()
     {
         $mac = '12:31:40:00:85:CA';
         self::$metadataFixture['mac'] = $mac;
         file_put_contents(self::$tmpdir . '/latest/meta-data/mac', $mac);
-        
+
         $base_url = "file://".self::$tmpdir;
         $processor = new AmazonEC2Processor(array('mac'), false, $base_url);
         $record = $processor($this->getRecord());
         $this->assertArrayHasKey('hostname', $record['extra']);
         $this->assertArrayHasKey('public-ipv4', $record['extra']);
         $this->assertArrayHasKey('mac', $record['extra']);
-        $this->assertSame($mac, $record['extra']['mac']);           
+        $this->assertSame($mac, $record['extra']['mac']);
     }
-    
+
     public static function tearDownAfterClass()
     {
         foreach (self::$metadataFixture as $key => $val) {

--- a/tests/Monolog/Processor/AmazonEC2ProcessorTest.php
+++ b/tests/Monolog/Processor/AmazonEC2ProcessorTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+use Monolog\TestCase;
+
+class AmazonEC2ProcessorTest extends TestCase
+{
+    protected static $metadataFixture = array(
+        'hostname'                      => 'ip-10-170-138-51.us-west-1.compute.internal',
+        'ami-id'                        => 'ami-e78cd3a1',
+        'instance-id'                   => 'i-1abfb30a',
+        'instance-type'                 => 't1.micro',
+        'local-ipv4'                    => '10.170.138.51',
+        'public-ipv4'                   => '204.236.140.81',
+        'placement/availability-zone'   => 'us-west-1c'
+    );
+    protected static $tmpdir;
+    
+    public static function setUpBeforeClass()
+    {
+        self::$tmpdir = __DIR__ . '/Fixtures/' . uniqid('AmazonEC2ProcessorTest_');
+        mkdir(self::$tmpdir . '/latest/meta-data/placement', 0777, true);
+        foreach (self::$metadataFixture as $key => $val) {
+            file_put_contents(self::$tmpdir . '/latest/meta-data/' . $key, $val);
+        }
+    }
+    
+    /**
+     * @covers Monolog\Processor\AmazonEC2Processor
+     */
+    public function testProcessor()
+    {
+        $base_url = "file://".self::$tmpdir;
+        $processor = new AmazonEC2Processor(array(), false, $base_url);
+        $record = $processor($this->getRecord());
+        $this->assertArrayHasKey('hostname', $record['extra']);        
+        $this->assertSame('t1.micro', $record['extra']['instance-type']);        
+    }
+    
+    public function testProcessorCanOverrideDefaultMetadataKeys()
+    {
+        $base_url = "file://".self::$tmpdir;
+        $processor = new AmazonEC2Processor(array('public-ipv4'), true, $base_url);
+        $record = $processor($this->getRecord());
+        $this->assertArrayNotHasKey('hostname', $record['extra']);
+        $this->assertArrayHasKey('public-ipv4', $record['extra']);
+        $this->assertSame('204.236.140.81', $record['extra']['public-ipv4']);   
+    }
+    
+    public function testProcessorCanMergeWithDefaultMetadataKeys()
+    {
+        $mac = '12:31:40:00:85:CA';
+        self::$metadataFixture['mac'] = $mac;
+        file_put_contents(self::$tmpdir . '/latest/meta-data/mac', $mac);
+        
+        $base_url = "file://".self::$tmpdir;
+        $processor = new AmazonEC2Processor(array('mac'), false, $base_url);
+        $record = $processor($this->getRecord());
+        $this->assertArrayHasKey('hostname', $record['extra']);
+        $this->assertArrayHasKey('public-ipv4', $record['extra']);
+        $this->assertArrayHasKey('mac', $record['extra']);
+        $this->assertSame($mac, $record['extra']['mac']);           
+    }
+    
+    public static function tearDownAfterClass()
+    {
+        foreach (self::$metadataFixture as $key => $val) {
+            unlink(self::$tmpdir . '/latest/meta-data/' . $key);
+        }
+        rmdir(self::$tmpdir . '/latest/meta-data/placement');
+        rmdir(self::$tmpdir . '/latest/meta-data');
+        rmdir(self::$tmpdir . '/latest');
+        rmdir(self::$tmpdir);
+    }
+}

--- a/tests/Monolog/Processor/Fixtures/.gitignore
+++ b/tests/Monolog/Processor/Fixtures/.gitignore
@@ -1,0 +1,1 @@
+AmazonEC2ProcessorTest_*/

--- a/tests/Monolog/Processor/HostnameProcessorTest.php
+++ b/tests/Monolog/Processor/HostnameProcessorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+use Monolog\TestCase;
+
+class HostnameProcessorTest extends TestCase
+{
+    /**
+     * @covers Monolog\Processor\HostnameProcessor
+     */
+    public function testProcessor()
+    {
+        $processor = new HostnameProcessor();
+        $record = $processor($this->getRecord());
+        $this->assertArrayHasKey('hostname', $record['extra']);
+        
+        $hostname = php_uname('n');
+        $this->assertSame($hostname, $record['extra']['hostname']);
+    }
+}

--- a/tests/Monolog/Processor/HostnameProcessorTest.php
+++ b/tests/Monolog/Processor/HostnameProcessorTest.php
@@ -23,7 +23,7 @@ class HostnameProcessorTest extends TestCase
         $processor = new HostnameProcessor();
         $record = $processor($this->getRecord());
         $this->assertArrayHasKey('hostname', $record['extra']);
-        
+
         $hostname = php_uname('n');
         $this->assertSame($hostname, $record['extra']['hostname']);
     }


### PR DESCRIPTION
I've added a SimpleDBHandler to log messages using a passed-in AmazonSDB object from the official Amazon SDK for PHP.

Given the size limitations (which are gracious, but still exist) of SimpleDB domains, I've taken the approach of mapping log channels-to-SimpleDB domains.

While SimpleDB has support for batch put operations, and the AmazonSDB class has support for sending items in parallel -- which, when combined, could conceivably allow for parallel batch puts -- I have kept this first commit simple, so that this handler's behavior mirrors that of most of the others.

If it winds up being popular and users request it, I'd be happy to contribute a further SimpleDBBatchHandler that dives into supporting those scenarios.

Meanwhile, I look forward to your feedback on this less complicated submission.