### PR TITLE
new section: customizing logger output format

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -121,3 +121,38 @@ $securityLogger = new Logger('security');
 $securityLogger->pushHandler($stream);
 $securityLogger->pushHandler($firephp);
 ```
+
+Customizing log format
+----------------------
+
+In Monolog it's easy to customize the format of the logs written into files,
+sockets, mails, databases and other handlers. Most of the handlers use the
+
+```php
+$record['formatted']
+```
+
+value to be automatically put into the log device. This value depends on the
+formatter settings. You can choose between predefined formatter classes or
+write your own (e.g. a multiline text file for human-readable output).
+
+To configure a predefined formatter class, just set it as the handler's field:
+
+```php
+// the default date format is "Y-m-d H:i:s"
+$dateFormat = "Y n j, g:i a";
+// the default output format is "[%datetime%] %channel%.%level_name%: %message% %context% %extra%\n"
+$output = "%datetime% > %level_name% > %message% %context% %extra%\n"
+// finally, create a formatter
+$formatter = new LineFormatter($output, $dateFormat);
+
+// Create a handler
+$stream = new StreamHandler(__DIR__.'/my_app.log', Logger::DEBUG);
+$stream->setFormatter($formatter);
+// bind it to a logger object
+$securityLogger = new Logger('security');
+$securityLogger->pushHandler($stream);
+```
+
+You may also reuse the same formatter between multiple handlers and share those
+handlers between multiple loggers.


### PR DESCRIPTION
Hi Jordi!

I suggest adding a new section in the usage docs file . It covers the topic of formatting log output. It's quite an easy mechanism, but it takes a while to scan src classes, since it's not mentioned in the actual docs.

I hope you'll find my work useful. Cheers!
