### PR TITLE
Suppress warnings on date_default_timezone_get()

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -109,7 +109,7 @@ class Logger
         $this->name = $name;
 
         if (!self::$timezone) {
-            self::$timezone = new \DateTimeZone(date_default_timezone_get() ?: 'UTC');
+            self::$timezone = new \DateTimeZone(@date_default_timezone_get() ?: 'UTC');
         }
     }
 


### PR DESCRIPTION
Unfortunately `date_default_timezone_get()` still triggers the classic timezone warning, and there is no other way to determine if a timezone has been set.

While one can ensure their projects always perform a `date_default_timezone_set()` there are still common places where monolog can be imported without direct user control over setting default timezones. 

In my particular case, including monolog in a Symfony2 composer project with the stock Symfony2 `post-install-cmd` and `post-update-cmd` chain causes failures at the end of an install/update cycle. I believe it's composer in this case that translates all triggered warnings/errors into exceptions which causes whatever process that is running to fail.

Therefore I propose we just suppress the warnings from `date_default_timezone_set()` for now.

In the future timezone management should maybe be mildly refactored to be injectable and default to UTC, but this will eliminate 
