### PR TITLE
Save some I/O

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -191,7 +191,7 @@ class Logger
             'level' => $level,
             'level_name' => static::getLevelName($level),
             'channel' => $this->name,
-            'datetime' => \DateTime::createFromFormat('U.u', sprintf('%.6F', microtime(true)))->setTimeZone(static::$timezone),
+            'datetime' => \DateTime::createFromFormat('U.u', sprintf('%.6F', microtime(true)), static::$timezone)->setTimezone(static::$timezone),
             'extra' => array(),
         );
         // check if any handler will handle this message
@@ -339,7 +339,7 @@ class Logger
             'level' => $level,
             'level_name' => static::getLevelName($level),
             'channel' => $this->name,
-            'datetime' => new \DateTime(),
+            'datetime' => new \DateTime('now', static::$timezone),
             'extra' => array(),
         );
 


### PR DESCRIPTION
Add the timezone in the the \DateTime constructor. While the DateTime object

is initialized without the DateTimeZone instance, the underline library
execute a stat('.../Europe/Paris') to check if the OS knows the timezone.

This will improve performance on long run process by avoiding unless i/o calls.
