### PR TITLE
Make Monolog a Composer "light-weight-distribution-package"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,4 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 .travis.yml export-ignore
-CHANGELOG.mdown export-ignore
 phpunit.xml.dist export-ignore
-README.mdown export-ignore


### PR DESCRIPTION
In order to save space and bandwidth when installing this package using Composer, I have added .gitattributes in order not to include unnecessary files and folders (doc, tests, etc.) when packaging (git archive).

(extracted from http://getcomposer.org/doc/02-libraries.md#light-weight-distribution-packages)

Including the tests and other useless information like .travis.yml in distributed packages is not a good idea.

The .gitattributes file is a git specific file like .gitignore also living at the root directory of your library. It overrides local and global configuration (.git/config and ~/.gitconfig respectively) when present and tracked by git.

Use .gitattributes to prevent unwanted files from bloating the zip distribution packages.

// .gitattributes
/Tests export-ignore
phpunit.xml.dist export-ignore
Resources/doc/ export-ignore
.travis.yml export-ignore
Test it by inspecting the zip file generated manually:

git archive branchName --format zip -o file.zip

Note: Files would be still tracked by git just not included in the distribution. This will only work for GitHub packages installed from dist (i.e. tagged releases) for now.
