### PR TITLE
Fixed bug when several handlers are registered

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -210,8 +210,14 @@ class Logger
         foreach ($this->processors as $processor) {
             $record = call_user_func($processor, $record);
         }
-        while (isset($this->handlers[$handlerKey]) &&
-            false === $this->handlers[$handlerKey]->handle($record)) {
+        while (isset($this->handlers[$handlerKey])) {
+            if ($this->handlers[$handlerKey]->isHandling($record)) {
+                $ret = $this->handlers[$handlerKey]->handle($record);
+                if (false !== $ret) {
+                    break;
+                }
+
+            }
             $handlerKey++;
         }
 

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -210,18 +210,17 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         $logger = new Logger(__METHOD__);
 
         $handler1 = $this->getMock('Monolog\Handler\HandlerInterface');
-        $handler1->expects($this->never())
+        $handler1->expects($this->once())
             ->method('isHandling')
             ->will($this->returnValue(false))
         ;
-        $handler1->expects($this->once())
+        $handler1->expects($this->never())
             ->method('handle')
-            ->will($this->returnValue(false))
         ;
         $logger->pushHandler($handler1);
 
         $handler2 = $this->getMock('Monolog\Handler\HandlerInterface');
-        $handler2->expects($this->once())
+        $handler2->expects($this->exactly(2))
             ->method('isHandling')
             ->will($this->returnValue(true))
         ;


### PR DESCRIPTION
```
$log = new Logger('name');

$log->pushHandler(new StreamHandler('path/to/your1.log', Logger::WARNING));
$log->pushHandler(new StreamHandler('path/to/your2.log', Logger::DEBUG));

$log->debug('foo');
```

Here, the first handler should not be called.
