### PR TITLE
Add line break to logstash formatter

### DIFF
--- a/src/Monolog/Formatter/LogstashFormatter.php
+++ b/src/Monolog/Formatter/LogstashFormatter.php
@@ -93,6 +93,6 @@ class LogstashFormatter extends NormalizerFormatter
             $message['@fields'][$this->contextPrefix . $key] = $val;
         }
 
-        return json_encode($message);
+        return json_encode($message) . PHP_EOL;
     }
 }


### PR DESCRIPTION
`LogstashFormatter->format` does not add a line break to the returned message. This causes every message to be put on the same line when logging to a `StreamHandler`.

This PR simply adds a line break after `json_encode`.

I'm not sure if this added line break affects other handlers, unit tests still pass.
