### PR TITLE
Syslog Constants vary depending on the OS (windows/linux) so GelfMessageFormatter may submit incorrect error levels to graylog

### DIFF
--- a/src/Monolog/Formatter/GelfMessageFormatter.php
+++ b/src/Monolog/Formatter/GelfMessageFormatter.php
@@ -41,14 +41,14 @@ class GelfMessageFormatter extends NormalizerFormatter
      * Translates Monolog log levels to Graylog2 log priorities.
      */
     private $logLevels = array(
-        Logger::DEBUG     => LOG_DEBUG,
-        Logger::INFO      => LOG_INFO,
-        Logger::NOTICE    => LOG_NOTICE,
-        Logger::WARNING   => LOG_WARNING,
-        Logger::ERROR     => LOG_ERR,
-        Logger::CRITICAL  => LOG_CRIT,
-        Logger::ALERT     => LOG_ALERT,
-        Logger::EMERGENCY => LOG_EMERG,
+        Logger::DEBUG     => 7,
+        Logger::INFO      => 6,
+        Logger::NOTICE    => 5,
+        Logger::WARNING   => 4,
+        Logger::ERROR     => 3,
+        Logger::CRITICAL  => 2,
+        Logger::ALERT     => 1,
+        Logger::EMERGENCY => 0,
     );
 
     public function __construct($systemName = null, $extraPrefix = null, $contextPrefix = 'ctxt_')


### PR DESCRIPTION
The issue here is because Windows and linux syslog constants vary (See examples below)
This means that GelfMessageFormatter will submit incorrect log levels when the web server is running on windows.

To solve this, I've replaced the LOG_\* PHP constants in GelfMessageFormatter with the correct constant values.

For example these are the syslog constants on Linux.

``` php
array(8) {
  ["LOG_DEBUG"]=>
  int(7)
  ["LOG_INFO"]=>
  int(6)
  ["LOG_NOTICE"]=>
  int(5)
  ["LOG_WARNING"]=>
  int(4)
  ["LOG_ERROR"]=>
  int(3)
  ["LOG_CRITICAL"]=>
  int(2)
  ["LOG_ALERT"]=>
  int(1)
  ["LOG_EMERGENCY"]=>
  int(0)
}
```

And now these are the constants on Windows.

``` php
array(8) {
  'LOG_DEBUG' =>
  int(6)
  'LOG_INFO' =>
  int(6)
  'LOG_NOTICE' =>
  int(6)
  'LOG_WARNING' =>
  int(5)
  'LOG_ERROR' =>
  int(4)
  'LOG_CRITICAL' =>
  int(1)
  'LOG_ALERT' =>
  int(1)
  'LOG_EMERGENCY' =>
  int(1)
}
```

Thanks
