### PR TITLE
Resolution of bug #146: PushoverHandler cannot send multiple/ concurrent messages in quick succession

### DIFF
--- a/src/Monolog/Handler/PushoverHandler.php
+++ b/src/Monolog/Handler/PushoverHandler.php
@@ -31,10 +31,13 @@ class PushoverHandler extends SocketHandler
      * @param string  $title  Title sent to Pushover API
      * @param integer $level  The minimum logging level at which this handler will be triggered
      * @param Boolean $bubble Whether the messages that are handled can bubble up the stack or not
+     * @param Boolean $useSSL Whether to connect via SSL. Required when pushing messages to users that are not
+     *                        the pushover.net app owner. OpenSSL is required for this option.
      */
-    public function __construct($token, $user, $title = null, $level = Logger::CRITICAL, $bubble = true)
+    public function __construct($token, $user, $title = null, $level = Logger::CRITICAL, $bubble = true, $useSSL = true)
     {
-        parent::__construct('api.pushover.net:80', $level, $bubble);
+        $connectionString = $useSSL ? 'ssl://api.pushover.net:443' : 'api.pushover.net:80';
+        parent::__construct($connectionString, $level, $bubble);
 
         $this->token = $token;
         $this->user = $user;
@@ -75,5 +78,11 @@ class PushoverHandler extends SocketHandler
         $header .= "\r\n";
 
         return $header;
+    }
+
+    public function write(array $record)
+    {
+        parent::write($record);
+        $this->closeSocket();
     }
 }


### PR DESCRIPTION
Solves #146: When sending messages in rapid succession to pushover.net only the first one is sent.
The SSL option is needed when sending messages to users that are not the pushover.net app owner; pushover.net doesn't accept those messages over plain HTTP.
