### PR TITLE
Fix issue where ChromePHP and FirePHP handlers sent logs to ineligible browsers when >1 handler is instantiated

### DIFF
--- a/src/Monolog/Handler/ChromePHPHandler.php
+++ b/src/Monolog/Handler/ChromePHPHandler.php
@@ -38,7 +38,7 @@ class ChromePHPHandler extends AbstractProcessingHandler
         'rows' => array(),
     );
 
-    protected $sendHeaders = true;
+    protected static $sendHeaders = true;
 
     /**
      * {@inheritdoc}
@@ -91,7 +91,7 @@ class ChromePHPHandler extends AbstractProcessingHandler
     protected function send()
     {
         if (!self::$initialized) {
-            $this->sendHeaders = $this->headersAccepted();
+            self::$sendHeaders = $this->headersAccepted();
             self::$json['request_uri'] = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '';
 
             self::$initialized = true;
@@ -108,7 +108,7 @@ class ChromePHPHandler extends AbstractProcessingHandler
      */
     protected function sendHeader($header, $content)
     {
-        if (!headers_sent() && $this->sendHeaders) {
+        if (!headers_sent() && self::$sendHeaders) {
             header(sprintf('%s: %s', $header, $content));
         }
     }

--- a/src/Monolog/Handler/FirePHPHandler.php
+++ b/src/Monolog/Handler/FirePHPHandler.php
@@ -51,7 +51,7 @@ class FirePHPHandler extends AbstractProcessingHandler
      */
     protected static $messageIndex = 1;
 
-    protected $sendHeaders = true;
+    protected static $sendHeaders = true;
 
     /**
      * Base header creation function used by init headers & record headers
@@ -117,7 +117,7 @@ class FirePHPHandler extends AbstractProcessingHandler
      */
     protected function sendHeader($header, $content)
     {
-        if (!headers_sent() && $this->sendHeaders) {
+        if (!headers_sent() && self::$sendHeaders) {
             header(sprintf('%s: %s', $header, $content));
         }
     }
@@ -133,7 +133,7 @@ class FirePHPHandler extends AbstractProcessingHandler
     {
         // WildFire-specific headers must be sent prior to any messages
         if (!self::$initialized) {
-            $this->sendHeaders = $this->headersAccepted();
+            self::$sendHeaders = $this->headersAccepted();
 
             foreach ($this->getInitHeaders() as $header => $content) {
                 $this->sendHeader($header, $content);


### PR DESCRIPTION
I noticed that when I have multiple instances of either ChromePHPHandler or FirePHPHandler, that some messages are being delivered when the requesting browser's user agent should have prevented this.  It seems that the static $Initialized variable determines whether or not to check the requesting user agent, so only one handler does the check while any other instances of that handler default to sending the headers without doing a check.
