### PR TITLE
Deferred timezone creation

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -109,10 +109,6 @@ class Logger implements LoggerInterface
     public function __construct($name)
     {
         $this->name = $name;
-
-        if (!static::$timezone) {
-            static::$timezone = new \DateTimeZone(date_default_timezone_get() ?: 'UTC');
-        }
     }
 
     /**
@@ -187,6 +183,11 @@ class Logger implements LoggerInterface
         if (!$this->handlers) {
             $this->pushHandler(new StreamHandler('php://stderr', static::DEBUG));
         }
+
+        if (!static::$timezone) {
+            static::$timezone = new \DateTimeZone(date_default_timezone_get() ?: 'UTC');
+        }
+
         $record = array(
             'message' => (string) $message,
             'context' => $context,


### PR DESCRIPTION
This defers the function call to the moment when something is logged rather that on instantiation in order to help out in Symfony2. For me, some times this function is about as slow as 2.5ms out of a 19ms total run time. I'll also add some changes so that the add function is called only when **really** needed in prod.
