### PR TITLE
A fair log rotate

### DIFF
--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -43,7 +43,13 @@ class RotatingFileHandler extends StreamHandler
             $this->mustRotate = false;
         }
 
-        parent::__construct($this->getTimedFilename(), $level, $bubble);
+        $timedName = $this->getTimedFilename();
+
+        parent::__construct($timedName, $level, $bubble);
+
+        if (null === $this->mustRotate && !file_exists($timedName)) {
+            $this->mustRotate = true;
+        }
     }
 
     /**


### PR DESCRIPTION
The problem occurs when running long-living scripts (daemons for example).
All messages will be written to the file with date when script was started.
