### PR TITLE
Raven handler: Send plain message instead of formatted one

### DIFF
--- a/src/Monolog/Handler/RavenHandler.php
+++ b/src/Monolog/Handler/RavenHandler.php
@@ -60,7 +60,7 @@ class RavenHandler extends AbstractProcessingHandler
     protected function write(array $record)
     {
         $this->ravenClient->captureMessage(
-            $record['formatted'],
+            $record['message'],
             array(),                              // $params - not used
             $this->logLevels[$record['level']],   // $level
             false                                 // $stack


### PR DESCRIPTION
When using Sentry, all details are displayed nice in the UI. Errors are grouped based on the error message. If a string which contains the timestamp is sent to Sentry it cannot group errors of the same kind. Therefore just the plain error message should be set as title.
