### PR TITLE
Add validation to add level to check if is integer

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -337,8 +337,10 @@ class Logger implements LoggerInterface
      */
     public static function getLevelName($level)
     {
-        if (!isset(static::$levels[$level])) {
-            throw new InvalidArgumentException('Level "'.$level.'" is not defined, use one of: '.implode(', ', array_keys(static::$levels)));
+        if (!is_int($level) || !isset(static::$levels[$level])) {
+            throw new InvalidArgumentException(
+                'Level "' . ((is_scalar($level)) ? $level : 'not representable') . '" is not defined, use one of: '.implode(', ', array_keys(static::$levels))
+            );
         }
 
         return static::$levels[$level];

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -43,6 +43,15 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Monolog\Logger::getLevelName
+     * @expectedException InvalidArgumentException
+     */
+    public function testGetLevelNameLevelAsArray()
+    {
+        Logger::getLevelName(array('invalid-level'));
+    }
+
+    /**
      * @covers Monolog\Logger::__construct
      */
     public function testChannel()


### PR DESCRIPTION
Using Monolog addRecord I was passing a level wrongly defined as array, to avoid an  

```
Illegal offset type in isset or empty

/home/www/monolog/src/Monolog/Logger.php:340
```

I think is good idea the getLevelName check if the level passed is integer.

I added one test to ensure the code is working as expected.
