### PR TITLE
Updated the ChromePHPHandler for the new version of the extension

### DIFF
--- a/src/Monolog/Handler/ChromePHPHandler.php
+++ b/src/Monolog/Handler/ChromePHPHandler.php
@@ -24,12 +24,12 @@ class ChromePHPHandler extends AbstractProcessingHandler
     /**
      * Version of the extension
      */
-    const VERSION = '3.0';
+    const VERSION = '4.0';
 
     /**
      * Header name
      */
-    const HEADER_NAME = 'X-ChromePhp-Data';
+    const HEADER_NAME = 'X-ChromeLogger-Data';
 
     protected static $initialized = false;
 

--- a/tests/Monolog/Handler/ChromePHPHandlerTest.php
+++ b/tests/Monolog/Handler/ChromePHPHandlerTest.php
@@ -32,7 +32,7 @@ class ChromePHPHandlerTest extends TestCase
         $handler->handle($this->getRecord(Logger::WARNING));
 
         $expected = array(
-            'X-ChromePhp-Data'   => base64_encode(utf8_encode(json_encode(array(
+            'X-ChromeLogger-Data'   => base64_encode(utf8_encode(json_encode(array(
                 'version' => ChromePHPHandler::VERSION,
                 'columns' => array('label', 'log', 'backtrace', 'type'),
                 'rows' => array(
@@ -56,7 +56,7 @@ class ChromePHPHandlerTest extends TestCase
         $handler->handle($this->getRecord(Logger::WARNING, str_repeat('a', 100*1024)));
 
         $expected = array(
-            'X-ChromePhp-Data'   => base64_encode(utf8_encode(json_encode(array(
+            'X-ChromeLogger-Data'   => base64_encode(utf8_encode(json_encode(array(
                 'version' => ChromePHPHandler::VERSION,
                 'columns' => array('label', 'log', 'backtrace', 'type'),
                 'rows' => array(
@@ -99,7 +99,7 @@ class ChromePHPHandlerTest extends TestCase
         $handler2->handle($this->getRecord(Logger::WARNING));
 
         $expected = array(
-            'X-ChromePhp-Data'   => base64_encode(utf8_encode(json_encode(array(
+            'X-ChromeLogger-Data'   => base64_encode(utf8_encode(json_encode(array(
                 'version' => ChromePHPHandler::VERSION,
                 'columns' => array('label', 'log', 'backtrace', 'type'),
                 'rows' => array(


### PR DESCRIPTION
The header used in version 4.0 of the extension is not the same anymore (naming it `ChromePHP-Data` has probably been considered as an issue once introducing the official library in Python).
As Chrome auto-updates the extensions too, I don't think we need to keep a support for the version 3.
