### PR TITLE
Return the generated record to the user

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -230,7 +230,7 @@ class Logger implements LoggerInterface
             $handlerKey++;
         }
 
-        return true;
+        return $record;
     }
 
     /**


### PR DESCRIPTION
It's very useful to get the record back after writing to the log.
For example, post processors can add a unique id to the log entry, which is useful to display to the user in case of a system crash.

This should not affect the backward compatibility, as a record array will always evaluate to true.