### PR TITLE
Let record message be of any type

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -200,7 +200,7 @@ class Logger implements LoggerInterface
         }
 
         $record = array(
-            'message' => (string) $message,
+            'message' => $message,
             'context' => $context,
             'level' => $level,
             'level_name' => static::getLevelName($level),


### PR DESCRIPTION
Allowing any value for a message gives Handlers more flexibility to do what they want with the record.

For example an array message that is encoded using the JsonFormatter.

This doesn't actually break any tests so I assume the cast is not needed.
