### PR TITLE
Remove message casting on Logger::addRecord()

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -210,7 +210,7 @@ class Logger implements LoggerInterface
         }
 
         $record = array(
-            'message' => (string) $message,
+            'message' => $message,
             'context' => $context,
             'level' => $level,
             'level_name' => static::getLevelName($level),

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -354,6 +354,29 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Monolog\Logger::addRecord
+     */
+    public function testShouldObjectsAsMessage()
+    {
+        $logger = new Logger(__METHOD__);
+
+        $object = new \Exception('Testing loggins exceptions');
+
+        $handler = $this->getMock('Monolog\Handler\HandlerInterface');
+        $handler->expects($this->any())
+            ->method('isHandling')
+            ->will($this->returnValue(true))
+        ;
+        $handler->expects($this->once())
+            ->method('handle')
+            ->with($this->contains($object, true))
+        ;
+        $logger->pushHandler($handler);
+
+        $this->assertTrue($logger->addRecord(Logger::DEBUG, $object));
+    }
+
+    /**
      * @dataProvider logMethodProvider
      * @covers Monolog\Logger::addDebug
      * @covers Monolog\Logger::addInfo


### PR DESCRIPTION
Thinking about someone creating a handler or formatter to work with objects in it's own way I think better to not cast messages as string.
