### PR TITLE
Refactored ErrorLogHandler to use constantes for types

### DIFF
--- a/src/Monolog/Handler/ErrorLogHandler.php
+++ b/src/Monolog/Handler/ErrorLogHandler.php
@@ -20,6 +20,9 @@ use Monolog\Logger;
  */
 class ErrorLogHandler extends AbstractProcessingHandler
 {
+    const OPERATING_SYSTEM = 0;
+    const SAPI = 4;
+
     protected $messageType;
 
     /**
@@ -27,13 +30,27 @@ class ErrorLogHandler extends AbstractProcessingHandler
      * @param integer $level       The minimum logging level at which this handler will be triggered
      * @param Boolean $bubble      Whether the messages that are handled can bubble up the stack or not
      */
-    public function __construct($messageType = 0, $level = Logger::DEBUG, $bubble = true)
+    public function __construct($messageType = self::OPERATING_SYSTEM, $level = Logger::DEBUG, $bubble = true)
     {
         parent::__construct($level, $bubble);
-        if (!in_array($messageType, array(0, 4))) {
-            throw new \InvalidArgumentException('Only message types 0 and 4 are supported');
+
+        if (false === in_array($messageType, self::getAvailableTypes())) {
+            $message = sprintf('The given message type "%s" is not supported', print_r($messageType, true));
+            throw new \InvalidArgumentException($message);
         }
+
         $this->messageType = $messageType;
+    }
+
+    /**
+     * @return array With all available types
+     */
+    public static function getAvailableTypes()
+    {
+        return array(
+            self::OPERATING_SYSTEM,
+            self::SAPI,
+        );
     }
 
     /**

--- a/tests/Monolog/Handler/ErrorLogHandlerTest.php
+++ b/tests/Monolog/Handler/ErrorLogHandlerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Monolog\Handler;
+
+use Monolog\TestCase;
+use Monolog\Logger;
+
+function error_log()
+{
+    $GLOBALS['error_log'] = func_get_args();
+}
+
+class ErrorLogHandlerTest extends TestCase
+{
+
+    protected function setUp()
+    {
+        $GLOBALS['error_log'] = array();
+    }
+
+    /**
+     * @covers Monolog\Handler\ErrorLogHandler::__construct
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage The given message type "42" is not supported
+     */
+    public function testShouldNotAcceptAnInvalidTypeOnContructor()
+    {
+        new ErrorLogHandler(42);
+    }
+
+    /**
+     * @covers Monolog\Handler\ErrorLogHandler::write
+     */
+    public function testShouldLogMessagesUsingErrorLogFuncion()
+    {
+        $type = ErrorLogHandler::OPERATING_SYSTEM;
+        $handler = new ErrorLogHandler($type);
+        $handler->handle($this->getRecord(Logger::ERROR));
+
+        $this->assertStringMatchesFormat('[%s] test.ERROR: test [] []', $GLOBALS['error_log'][0]);
+        $this->assertSame($GLOBALS['error_log'][1], $type);
+    }
+}


### PR DESCRIPTION
- Create tests for ErrorLogHandler;
- Remove types 1, 2 and 3 in favor of specific handlers.
