### PR TITLE
Default name for Logger.

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -121,15 +121,16 @@ class Logger implements LoggerInterface
     protected $processors;
 
     /**
-     * @param string $name       The logging channel
-     * @param array  $handlers   Optional stack of handlers, the first one in the array is called first, etc.
-     * @param array  $processors Optional array of processors
+     * @param string $name       The logging channel, default channel is Global.
+     * @param array|string  $handlers   Optional stack of handlers, or a handler name, 
+     *     the first one in the array is called first, etc.
+     * @param array|string  $processors Optional array of processors or a processors name.
      */
-    public function __construct($name, array $handlers = array(), array $processors = array())
+    public function __construct($name = 'Global', $handlers = array(), $processors = array())
     {
         $this->name = $name;
-        $this->handlers = $handlers;
-        $this->processors = $processors;
+        $this->handlers = (array) $handlers;
+        $this->processors = (array) $processors;
     }
 
     /**


### PR DESCRIPTION
I use very very high from log class in my program.
I dont use from this class direct, i have a 'Error' class that management errors, and use from this library.
that have 8 public method of standard log(debug, info, notice and .....)
example: Error::alert(*)
that do log, disable application, aware me and ...
for evry call this methods, that create a log object
so, I have very log object in my program.
i want use a singleton log object for evry method of Error Class.

sorry, I can not speak english good.
