### PR TITLE
Small fix to test bootstrap

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,5 +9,5 @@
  * file that was distributed with this source code.
  */
 
-$loader = require_once __DIR__ . "/../vendor/autoload.php";
+$loader = require __DIR__ . "/../vendor/autoload.php";
 $loader->add('Monolog\\', __DIR__);


### PR DESCRIPTION
The previous `require_once` statement returns `true` when it loads the autoload file rather than an instance of `ClassLoader`. Changing the statement to `require` returns the instance needed to add the Monolog test directory.

``` bash
PHP Fatal error:  Call to a member function add() on a non-object in /srv/tests/bootstrap.php on line 13
PHP Stack trace:
PHP   1. {main}() /srv/vendor/phpunit/phpunit/composer/bin/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main() /srv/vendor/phpunit/phpunit/composer/bin/phpunit:63
PHP   3. PHPUnit_TextUI_Command->run() /srv/vendor/phpunit/phpunit/PHPUnit/TextUI/Command.php:129
PHP   4. PHPUnit_TextUI_Command->handleArguments() /srv/vendor/phpunit/phpunit/PHPUnit/TextUI/Command.php:138
PHP   5. PHPUnit_TextUI_Command->handleBootstrap() /srv/vendor/phpunit/phpunit/PHPUnit/TextUI/Command.php:606
PHP   6. PHPUnit_Util_Fileloader::checkAndLoad() /srv/vendor/phpunit/phpunit/PHPUnit/TextUI/Command.php:778
PHP   7. PHPUnit_Util_Fileloader::load() /srv/vendor/phpunit/phpunit/PHPUnit/Util/Fileloader.php:76
PHP   8. include_once() /srv/vendor/phpunit/phpunit/PHPUnit/Util/Fileloader.php:92
```

The issue was witnessed on PHP 5.5.3:

``` bash
PHP 5.5.3-1+debphp.org~precise+2 (cli) (built: Aug 27 2013 09:15:48)
Copyright (c) 1997-2013 The PHP Group
Zend Engine v2.5.0, Copyright (c) 1998-2013 Zend Technologies
    with Zend OPcache v7.0.3-dev, Copyright (c) 1999-2013, by Zend Technologies
    with Xdebug v2.2.3, Copyright (c) 2002-2013, by Derick Rethans
```
