### PR TITLE
Add PHPUnit to dev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ php:
 before_script:
   - composer install --dev --prefer-source
 
-script: phpunit
+script: ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
+        "phpunit/phpunit": "~3.7.0",
         "mlehner/gelf-php": "1.0.*",
         "raven/raven": "0.5.*",
         "doctrine/couchdb": "dev-master"


### PR DESCRIPTION
The easier it is for people to contribute, the better.
Relying on a global install of PHPUnit via PEAR doesn't sit well with some developers as they may need specific versions across projects. As other dev dependencies are installed via composer, why not add PHPUnit itself to the list?
