### PR TITLE
$mongoCollection attribute visibility changed to protected

### DIFF
--- a/src/Monolog/Handler/MongoDBHandler.php
+++ b/src/Monolog/Handler/MongoDBHandler.php
@@ -27,7 +27,7 @@ use Monolog\Formatter\NormalizerFormatter;
  */
 class MongoDBHandler extends AbstractProcessingHandler
 {
-    private $mongoCollection;
+    protected $mongoCollection;
 
     public function __construct($mongo, $database, $collection, $level = Logger::DEBUG, $bubble = true)
     {


### PR DESCRIPTION
$mongoCollection attribute visibility changed to protected so subclasses can access this attribute to query the database
