### PR TITLE
Fixes isHandling() result not being acknowledged in handle() in AbstractProcessingHandler

### DIFF
--- a/src/Monolog/Handler/AbstractProcessingHandler.php
+++ b/src/Monolog/Handler/AbstractProcessingHandler.php
@@ -26,7 +26,7 @@ abstract class AbstractProcessingHandler extends AbstractHandler
      */
     public function handle(array $record)
     {
-        if ($record['level'] < $this->level) {
+        if (!$this->isHandling($record)) {
             return false;
         }
 


### PR DESCRIPTION
When a handler that extends `AbstractProcessingHandler` overrides `isHandling`, the returned value isn't acknowledged within the `handle` method. This causes records to not be written when `isHandling` doesn't necessarily match up with the activation level of the handler.

``` php
class MyHandler extends \Monolog\Handler\AbstractProcessingHandler {
    public function isHandling(array $record) {
        return $record['level'] < $this->level || $some_other_condition;
    }
}
```
