### PR TITLE
get record with highest log level in raven batch

### DIFF
--- a/src/Monolog/Handler/RavenHandler.php
+++ b/src/Monolog/Handler/RavenHandler.php
@@ -80,10 +80,10 @@ class RavenHandler extends AbstractProcessingHandler
         // the record with the highest severity is the "main" one
         $record = array_reduce($records, function($highest, $record) {
             if ($record['level'] >= $highest['level']) {
-                $highest = $record;
-
-                return $highest;
+                return $record;
             }
+
+            return $highest;
         });
 
         // the other ones are added as a context item

--- a/tests/Monolog/Handler/RavenHandlerTest.php
+++ b/tests/Monolog/Handler/RavenHandlerTest.php
@@ -92,12 +92,16 @@ class RavenHandlerTest extends TestCase
     public function testHandleBatch()
     {
         $records = $this->getMultipleRecords();
+        $records[] = $this->getRecord(Logger::WARNING, 'warning');
+        $records[] = $this->getRecord(Logger::WARNING, 'warning');
 
         $logFormatter = $this->getMock('Monolog\\Formatter\\FormatterInterface');
         $logFormatter->expects($this->once())->method('formatBatch');
 
         $formatter = $this->getMock('Monolog\\Formatter\\FormatterInterface');
-        $formatter->expects($this->once())->method('format');
+        $formatter->expects($this->once())->method('format')->with($this->callback(function($record) {
+            return $record['level'] == 400;
+        }));
 
         $handler = $this->getHandler($this->getRavenClient());
         $handler->setBatchFormatter($logFormatter);


### PR DESCRIPTION
When using the raven handler in combination with the buffer handler, the raven handler doesn't choose the record with the highest log level as main record, if it isn't the last one.
