### PR TITLE
eAccelerator doesn't like anonymous functions.

### DIFF
--- a/src/Monolog/Handler/StreamHandler.php
+++ b/src/Monolog/Handler/StreamHandler.php
@@ -61,7 +61,7 @@ class StreamHandler extends AbstractProcessingHandler
             if (!$this->url) {
                 throw new \LogicException('Missing stream url, the stream can not be opened. This may be caused by a premature call to close().');
             }
-            $errorMessage = null;
+            $this->errorMessage = null;
             set_error_handler(array($this, 'customErrorHandler'));
             $this->stream = fopen($this->url, 'a');
             restore_error_handler();
@@ -73,7 +73,7 @@ class StreamHandler extends AbstractProcessingHandler
         fwrite($this->stream, (string) $record['formatted']);
     }
 
-    protected function customErrorHandler($code, $msg) {
+    private function customErrorHandler($code, $msg) {
         $this->errorMessage = preg_replace('{^fopen\(.*?\): }', '', $msg);
     }
 }


### PR DESCRIPTION
- Change to private instance method for error handler.

Got this error when using Monolog with eAccelerator:
`Fatal error: Invalid opcode 153/1/8. in /vendor/composer/monolog/monolog/src/Monolog/Handler/StreamHandler.php on line 64`

This fixes it.
