### PR TITLE
add right pid for childs

### DIFF
--- a/src/Monolog/Processor/ProcessIdProcessor.php
+++ b/src/Monolog/Processor/ProcessIdProcessor.php
@@ -18,22 +18,13 @@ namespace Monolog\Processor;
  */
 class ProcessIdProcessor
 {
-    private static $pid;
-
-    public function __construct()
-    {
-        if (null === self::$pid) {
-            self::$pid = getmypid();
-        }
-    }
-
     /**
      * @param  array $record
      * @return array
      */
     public function __invoke(array $record)
     {
-        $record['extra']['process_id'] = self::$pid;
+        $record['extra']['process_id'] = getmypid();
 
         return $record;
     }


### PR DESCRIPTION
Sample code to reproduce an issue:

```
<?php

use Monolog\Logger;
use Monolog\Handler\StreamHandler;
use Monolog\Processor\ProcessIdProcessor;

class Job
{
    protected $logger;

    public function __construct()
    {
        $this->logger = new Logger(
            'test',
            [
                new StreamHandler(STDOUT)
            ],
            [
                new ProcessIdProcessor()
            ]
        );
    }

    public function run()
    {
        $pid = pcntl_fork();

        if ($pid == -1) {
            throw new \RuntimeException('Can\'t fork new process!');
        } elseif ($pid) {
            $this->logger->info('parent', ['real_pid' => getmypid()]);
        } else {
            $this->logger->info('child', ['real_pid' => getmypid()]);
        }
    }
}

require __DIR__ . "/vendor/autoload.php";
$t = new Job();
$t->run();
```

Expected result:

[2013-11-04 12:02:48] test.INFO: parent {"real_pid":12978} {"process_id":12978}
[2013-11-04 12:02:48] test.INFO: child {"real_pid":12979} {"process_id":12979}

Actual result:

[2013-11-04 12:02:48] test.INFO: parent {"real_pid":12978} {"process_id":12978}
[2013-11-04 12:02:48] test.INFO: child {"real_pid":12979} {"process_id":12978}
