### PR TITLE
Ability to access logger instances in the global scope via static calls

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -159,7 +159,7 @@ class Logger implements LoggerInterface
      * @return Monolog\Logger
      * @throws InvalidArgumentException If logging channel has not been created
      */
-    public static function __callStatic($name)
+    public static function __callStatic($name, $arguments)
     {
         if(!isset(self::$loggerInstances[$name])) {
             throw new \InvalidArgumentException('The requested logging channel has not been created yet');


### PR DESCRIPTION
The goal of this pull request is have ability to access created Logger instances in all methods, functions, ... Everything you need to know is the logging channel's name.

```
$logger1 = new Monolog\Logger('application');
$logger2 = new Monolog\Logger('api');

function test()
{
    Monolog\Logger::api()->addDebug('Sent to $logger2');
}
```
