### PR TITLE
Ability to access logger instances in the global scope via static calls

### DIFF
--- a/src/Monolog/Registry.php
+++ b/src/Monolog/Registry.php
@@ -23,7 +23,7 @@ use InvalidArgumentException;
  * $application = new Monolog\Logger('application');
  * $api = new Monolog\Logger('api');
  *
- * $application->addToRegistry();
+ * Monolog\Registry::addLogger($application);
  * Monolog\Registry::addLogger($api);
  *
  * function testLogger()


### PR DESCRIPTION
OK, I moved all the logic to the separated `Registry` class and only one method is new in the `Logger`. That method simply add current instance to the Registry. Is this better approach?
