### PR TITLE
Add HTML email formatter

### DIFF
--- a/src/Monolog/Formatter/HtmlEmailFormatter.php
+++ b/src/Monolog/Formatter/HtmlEmailFormatter.php
@@ -50,6 +50,7 @@ class HtmlEmailFormatter extends NormalizerFormatter
      */
     private function addRow($th, $td = ' ')
     {
+        $th = htmlspecialchars($th);
         $td = '<pre>'.htmlspecialchars($td).'</pre>';
 
         return "<tr style=\"padding: 4px;spacing: 0;text-align: left;\">\n<th style=\"background: #cccccc\" width=\"100px\">$th:</th>\n<td style=\"padding: 4px;spacing: 0;text-align: left;background: #eeeeee\">".$td."</td>\n</tr>";
@@ -64,6 +65,8 @@ class HtmlEmailFormatter extends NormalizerFormatter
      */
     private function addTitle($title, $level)
     {
+        $title = htmlspecialchars($title);
+     
         return '<h1 style="background: '.$this->logLevels[$level].';color: #ffffff;padding: 5px;">'.$title.'</h1>';
     }
     /**


### PR DESCRIPTION
This Formatter formats incoming records into a HTML table to create a readable email logging notification.

The email result is something like this:

![Example](https://f.cloud.github.com/assets/1071148/1577936/504cf4ca-5172-11e3-8044-3db06596abbe.png)

This have one requirement, your email must be sent with **content_type: text/html**

Example in Symfony 2:

``` yaml
monolog:
    handlers:
        #other handlers...
        swift:
            type:       swift_mailer
            content_type: text/html
            #your configuration...
```
