### PR TITLE
Init IntrospectionProcessor with skip classes parameter

### DIFF
--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -28,9 +28,12 @@ class IntrospectionProcessor
 {
     private $level;
 
-    public function __construct($level = Logger::DEBUG)
+    private $skipClassesPartials = [];
+
+    public function __construct($level = Logger::DEBUG, $skipClassesPartials = ['Monolog\\']) 
     {
         $this->level = $level;
+        $this->skipClassesPartials = $skipClassesPartials;
     }
 
     /**
@@ -52,8 +55,17 @@ class IntrospectionProcessor
         array_shift($trace);
 
         $i = 0;
-        while (isset($trace[$i]['class']) && false !== strpos($trace[$i]['class'], 'Monolog\\')) {
-            $i++;
+        while (isset($trace[$i]['class']))
+        {
+            foreach ($this->skipClassesPartials as $part)
+            {
+                if (strpos($trace[$i]['class'], $part) !== false)
+                {
+                    $i++;
+                    continue 2;
+                }
+            }
+            break;
         }
 
         // we should have the call source now


### PR DESCRIPTION
Logger maybe use in other debug classes and I must be able to skip my debug classes.

For example: new IntrospectionProcessor(Logger::DEBUG, ['Monolog\', 'Debug'])
