### PR TITLE
Fixes MongoDBHandler unit-test

### DIFF
--- a/tests/Monolog/Handler/MongoDBHandlerTest.php
+++ b/tests/Monolog/Handler/MongoDBHandlerTest.php
@@ -26,7 +26,7 @@ class MongoDBHandlerTest extends TestCase
 
     public function testHandle()
     {
-        $mongo = $this->getMock('Mongo', array('selectCollection'));
+        $mongo = $this->getMock('Mongo', array('selectCollection'), array(), '', false);
         $collection = $this->getMock('stdClass', array('save'));
 
         $mongo->expects($this->once())


### PR DESCRIPTION
On systems with mongo-ext but no MongoDB on localhost the unit-
tests are failing. This commit disables the constructor execution
for the Mongo-mock, so no connection-error is generated.
