### PR TITLE
Remove unnecessary `use` statement

### DIFF
--- a/src/Monolog/Formatter/ScalarFormatter.php
+++ b/src/Monolog/Formatter/ScalarFormatter.php
@@ -11,8 +11,6 @@
 
 namespace Monolog\Formatter;
 
-use Monolog\Formatter\NormalizerFormatter;
-
 /**
  * Formats data into an associative array of scalar values.
  * Objects and arrays will be JSON encoded.


### PR DESCRIPTION
Only a small patch; nothing critical.

`Monolog\Formatter\NormalizerFormatter` was originally imported because the formatter used to live in a different namespace before it was ported over from [graze/MonologExtensions](/graze/MonologExtensions).

It's no longer necessary to import it.
