### PR TITLE
do not bind the raven version to 0.5*, use possible newer versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "phpunit/phpunit": "~3.7.0",
         "mlehner/gelf-php": "1.0.*",
-        "raven/raven": "0.5.*",
+        "raven/raven": "~0.5",
         "ruflin/elastica": "0.90.*",
         "doctrine/couchdb": "dev-master",
         "aws/aws-sdk-php": "~2.4.8"


### PR DESCRIPTION
With this change the raven version is no longer bound to 0.5.x as requested in #302. Newer versions of raven seem to be backward compatible.
