### PR TITLE
Added Logger::exception() to simplify logging exceptions

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -579,4 +579,21 @@ class Logger implements LoggerInterface
     {
         return $this->addRecord(static::EMERGENCY, $message, $context);
     }
+
+    /**
+     * Log information about an exception. The exception object
+     * will automatically be added to the context.
+     *
+     * @param  \Exception $e
+     * @param  array      $context
+     * @param  integer    $level
+     * @return boolean
+     */
+    public function exception(\Exception $e, array $context = array(), $level = self::ERROR)
+    {
+        $context["exception"] = $e;
+        $type = get_class($e);
+
+        return $this->addRecord($level, "{$type}: {$e->getMessage()}", $context);
+    }
 }

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -382,6 +382,25 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedLevel, $record['level']);
     }
 
+    /**
+     * @covers Monolog\Logger::exception
+     */
+    public function testLogException()
+    {
+        $logger = new Logger('foo');
+        $handler = new TestHandler;
+        $logger->pushHandler($handler);
+        $message = "foobar";
+        $e = new \Exception($message);
+        $logger->exception($e);
+        list($record) = $handler->getRecords();
+        $this->assertEquals($logger::ERROR, $record['level']);
+        $this->assertContains(get_class($e), $record['message']);
+        $this->assertContains($message, $record['message']);
+        $this->assertArrayHasKey('exception', $record['context']);
+        $this->assertSame($e, $record['context']['exception']);
+    }
+
     public function logMethodProvider()
     {
         return array(


### PR DESCRIPTION
Perhaps there's a fundamental reason why, and I'm open to the reasons, but I'm confused by the lack of a simple way to log exceptions in a centralised way.

Currently, I'm forced to extend the Logger just to add this functionality so I'd be keen to understand why it is missing from the core and, if possible, have it merged in.
