### PR TITLE
Fix non-scalar messages casted to string before formatter can normalize it

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -218,7 +218,7 @@ class Logger implements LoggerInterface
         }
 
         $record = array(
-            'message' => (string) $message,
+            'message' => $message,
             'context' => $context,
             'level' => $level,
             'level_name' => static::getLevelName($level),

--- a/tests/Monolog/Formatter/LineFormatterTest.php
+++ b/tests/Monolog/Formatter/LineFormatterTest.php
@@ -30,6 +30,20 @@ class LineFormatterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('['.date('Y-m-d').'] log.WARNING: foo [] []'."\n", $message);
     }
 
+    public function testDefFormatWithArrayMessage()
+    {
+        $formatter = new LineFormatter(null, 'Y-m-d');
+        $message = $formatter->format(array(
+            'level_name' => 'WARNING',
+            'channel' => 'log',
+            'context' => array(),
+            'message' => array('foo'),
+            'datetime' => new \DateTime,
+            'extra' => array(),
+        ));
+        $this->assertEquals('['.date('Y-m-d').'] log.WARNING: ["foo"] [] []'."\n", $message);
+    }
+
     public function testDefFormatWithArrayContext()
     {
         $formatter = new LineFormatter(null, 'Y-m-d');

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -70,6 +70,16 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($logger->addWarning('test'));
     }
 
+    public function testLogNonScalarMessage()
+    {
+        $logger = new Logger(__METHOD__);
+        $handler = new TestHandler;
+        $logger->pushHandler($handler);
+        $logger->addWarning(array('test'));
+        list($record) = $handler->getRecords();
+        $this->assertEquals(array('test'), $record['message']);
+    }
+
     /**
      * @covers Monolog\Logger::addRecord
      */


### PR DESCRIPTION
With `LineFormatter` `$logger->debug(array('test'));` should be rendered as `["test"]` but is rendered as `Array` instead.
