### PR TITLE
Added PHP 5.6 to travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 before_script:


### PR DESCRIPTION
Travis is supporting the newest PHP 5.6 alpha releases.
