### PR TITLE
Removed header sanitiy checks

### DIFF
--- a/src/Monolog/Handler/NativeMailerHandler.php
+++ b/src/Monolog/Handler/NativeMailerHandler.php
@@ -83,9 +83,6 @@ class NativeMailerHandler extends MailHandler
     public function addHeader($headers)
     {
         foreach ((array) $headers as $header) {
-            if (strpos($header, "\n") !== false || strpos($header, "\r") !== false) {
-                throw new \InvalidArgumentException('Headers can not contain newline characters for security reasons');
-            }
             $this->headers[] = $header;
         }
     }


### PR DESCRIPTION
Since php 5.1.2 the `header()` methods takes care that no headers can be injected
