### PR TITLE
Added MinMaxHandler.

### DIFF
--- a/tests/Monolog/Handler/MinMaxHandlerTest.php
+++ b/tests/Monolog/Handler/MinMaxHandlerTest.php
@@ -93,4 +93,35 @@ class MinMaxHandlerTest extends TestCase
         $this->assertFalse($handler->handle($this->getRecord(Logger::INFO)));
         $this->assertFalse($handler->handle($this->getRecord(Logger::WARNING)));
     }
+
+    /**
+     * @covers Monolog\Handler\MinMaxHandler::handle
+     */
+    public function testHandleWithCallback()
+    {
+        $test    = new TestHandler();
+        $handler = new MinMaxHandler(
+            function ($record, $handler) use ($test) {
+                return $test;
+            }, Logger::INFO, Logger::NOTICE, false
+        );
+        $handler->handle($this->getRecord(Logger::DEBUG));
+        $handler->handle($this->getRecord(Logger::INFO));
+        $this->assertFalse($test->hasDebugRecords());
+        $this->assertTrue($test->hasInfoRecords());
+    }
+
+    /**
+     * @covers Monolog\Handler\MinMaxHandler::handle
+     * @expectedException \RuntimeException
+     */
+    public function testHandleWithBadCallbackThrowsException()
+    {
+        $handler = new MinMaxHandler(
+            function ($record, $handler) {
+                return 'foo';
+            }
+        );
+        $handler->handle($this->getRecord(Logger::WARNING));
+    }
 }


### PR DESCRIPTION
I have created a small wrapper handler, which allow to define which log level messages should be passed to wrapped handler. 

In particular, we are logging levels `INFO` and above to _someNormalHandler_ and have **fingerCrossedHandler**(with _someDebugHandler_) which activates on `ERROR` and should additionally log `DEBUG` level. In the case, that there comes an error, all the messages from `INFO` to `EMERGENCY` got duplicated, because they got processed by both handlers. Now, **fingerCrossedHandler** uses **MinMaxHandler**(with _debugHandler_) and everything is  logged as expected (`DEBUG`->_someDebugHandler_, `INFO`-`EMERGENCY`->_someNormalHandler_).

Even simpler use case: you want to log messages only with log level `DEBUG`, not higher -> use minMaxHandler($someHandler,Logger::DEBUG,Logger::DEBUG) 

Example from unit tests:
(Only records with log level between INFO and NOTICE are logged, other are ignored.)

``` php
        $test    = new TestHandler();
        $handler = new MinMaxHandler($test, Logger::INFO, Logger::NOTICE);

        $handler->handle($this->getRecord(Logger::DEBUG));
        $this->assertFalse($test->hasDebugRecords());

        $handler->handle($this->getRecord(Logger::INFO));
        $this->assertTrue($test->hasInfoRecords());

        $handler->handle($this->getRecord(Logger::WARNING));
        $this->assertFalse($test->hasWarningRecords());
```
