### PR TITLE
fixed resource check for multithreaded usage

### DIFF
--- a/src/Monolog/Handler/StreamHandler.php
+++ b/src/Monolog/Handler/StreamHandler.php
@@ -61,7 +61,7 @@ class StreamHandler extends AbstractProcessingHandler
      */
     protected function write(array $record)
     {
-        if (null === $this->stream) {
+        if (!is_resource($this->stream)) {
             if (!$this->url) {
                 throw new \LogicException('Missing stream url, the stream can not be opened. This may be caused by a premature call to close().');
             }


### PR DESCRIPTION
If you use the logger in a multithreaded php application based on pthreads it will show up `fwrite() expects parameter 1 to be resource, integer given` when doing logs. This comes because a stream resource taken to a thread context won't be null. The fix is to do a explicit check if it isn't a resource. I'am on the integration of monolog to our [`PHP WebServer`](https://github.com/techdivision/TechDivision_WebServer) at the moment so it would be nice if you can accept that pull request shortly :)

Cheers!
Johann
