### PR TITLE
Set @timestamp default value and ignore other empty values.

### DIFF
--- a/src/Monolog/Formatter/LogstashFormatter.php
+++ b/src/Monolog/Formatter/LogstashFormatter.php
@@ -90,19 +90,22 @@ class LogstashFormatter extends NormalizerFormatter
         }
         $message = array(
             '@timestamp' => $record['datetime'],
-            '@message' => @$record['message'],
-            '@tags' => array(@$record['channel']),
             '@source' => $this->systemName,
-            '@fields' => array(
-                'channel' => @$record['channel'],
-                'level' => @$record['level']
-            )
+            '@fields' => array()
         );
-
+        if (isset($record['message'])) {
+            $message['@message'] = $record['message'];
+        }
+        if (isset($record['channel'])) {
+            $message['@tags'] = array($record['channel']);
+            $message['@fields']['channel'] = $record['channel'];
+        }
+        if (isset($record['level'])) {
+            $message['@fields']['level'] = $record['level'];
+        }
         if ($this->applicationName) {
             $message['@type'] = $this->applicationName;
         }
-
         if (isset($record['extra']['server'])) {
             $message['@source_host'] = $record['extra']['server'];
         }
@@ -131,13 +134,18 @@ class LogstashFormatter extends NormalizerFormatter
         $message = array(
             '@timestamp' => $record['datetime'],
             '@version' => 1,
-            'message' => @$record['message'],
             'host' => $this->systemName,
-            'type' => @$record['channel'],
-            'channel' => @$record['channel'],
-            'level' => @$record['level_name']
         );
-
+        if (isset($record['message'])) {
+            $message['message'] = $record['message'];
+        }
+        if (isset($record['channel'])) {
+            $message['type'] = $record['channel'];
+            $message['channel'] = $record['channel'];
+        }
+        if (isset($record['level_name'])) {
+            $message['level'] = $record['level_name'];
+        }
         if ($this->applicationName) {
             $message['type'] = $this->applicationName;
         }


### PR DESCRIPTION
Prevent PHP from throwing unwanted NOTICEs whenever any of the following `$record` fields don't exist:
- `channel`
- `context`
- `datetime`
- `extra`
- `level`
- `level_name`
- `message`

Also, if `$record['datetime']` is empty, set `@timestamp` to the current ISO8601 timestamp by calling `gmdate('c')`. (according to the [logstash source](https://github.com/elasticsearch/logstash/blob/master/lib/logstash/event.rb), from the settable fields, only `@timestamp` is required)

Works with both V0 and V1 formats and all tests pass after these changes.
