### PR TITLE
When handling exception log exception message rather generic message

### DIFF
--- a/src/Monolog/ErrorHandler.php
+++ b/src/Monolog/ErrorHandler.php
@@ -123,7 +123,7 @@ class ErrorHandler
     {
         $this->logger->log(
             $this->uncaughtExceptionLevel === null ? LogLevel::ERROR : $this->uncaughtExceptionLevel,
-            $e->getMessage(),
+            sprintf('Uncaught Exception %s: "%s" at %s line %s', get_class($e), $e->getMessage(), $e->getFile(), $e->getLine()),
             array('exception' => $e)
         );
 


### PR DESCRIPTION
When logging using ChromePHPFormatter and LineFormatter, the message is lost in the context.  

In my opinion this provides better feedback of what the problem is.
