### PR TITLE
ErrorHandler: pass exception by ref, fix for WARNING

### DIFF
--- a/src/Monolog/ErrorHandler.php
+++ b/src/Monolog/ErrorHandler.php
@@ -119,7 +119,7 @@ class ErrorHandler
     /**
      * @private
      */
-    public function handleException(\Exception $e)
+    public function handleException(\Exception &$e)
     {
         $this->logger->log(
             $this->uncaughtExceptionLevel === null ? LogLevel::ERROR : $this->uncaughtExceptionLevel,


### PR DESCRIPTION
Using default `ErrorHandler` raises WARNING:

```
WARNING: Parameter 1 to exceptionHandler() expected to be a reference, value given line: 131 file: vendor/monolog/monolog/src/Monolog/ErrorHandler.php
```

Passing Exception by reference fixes this issue.
