### PR TITLE
Create PEAR System_Daemon handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
         "ext-mongo": "Allow sending log messages to a MongoDB server",
         "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+        "pear/system_daemon": "Allow sending log messages to PEAR System_Daemon class",
         "rollbar/rollbar": "Allow sending log messages to Rollbar"
     },
     "autoload": {

--- a/src/Monolog/Handler/SystemDaemonHandler.php
+++ b/src/Monolog/Handler/SystemDaemonHandler.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Formatter\LineFormatter;
+use Monolog\Logger;
+use OutOfBoundsException;
+use System_Daemon;
+
+/**
+ * System_Daemon (http://pear.php.net/System_Daemon) log handler
+ *
+ * @author Henrique Moody <henriquemoody@gmail.com>
+ */
+class SystemDaemonHandler extends AbstractProcessingHandler
+{
+    protected $levels = array(
+        Logger::EMERGENCY => 'emerg',
+        Logger::ALERT => 'alert',
+        Logger::CRITICAL => 'crit',
+        Logger::ERROR => 'err',
+        Logger::WARNING => 'warning',
+        Logger::NOTICE => 'notice',
+        Logger::INFO => 'info',
+        Logger::DEBUG => 'debug',
+    );
+
+    protected $systemDaemonClassName = 'System_Daemon';
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDefaultFormatter()
+    {
+        return new LineFormatter('(%channel%) %message% %context% %extra%');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function write(array $record)
+    {
+        $level = $record['level'];
+        if (! isset($this->levels[$level])) {
+            throw new OutOfBoundsException(sprintf('Unrecognized level "%s"', $level));
+        }
+
+        call_user_func(array($this->systemDaemonClassName, $this->levels[$level]), $record['formatted']);
+    }
+}

--- a/tests/Monolog/Handler/SystemDaemonHandlerTest.php
+++ b/tests/Monolog/Handler/SystemDaemonHandlerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Logger;
+use Monolog\TestCase;
+use ReflectionProperty;
+
+class SystemDaemonHandlerTest extends TestCase
+{
+    protected function setup()
+    {
+        if (! class_exists('System_Daemon')) {
+            $this->markTestSkipped('The "pear/system_daemon" package is not installed');
+        }
+    }
+
+    public function logLevelsProvider()
+    {
+        return array(
+            array(Logger::EMERGENCY, 'emerg'),
+            array(Logger::ALERT, 'alert'),
+            array(Logger::CRITICAL, 'crit'),
+            array(Logger::ERROR, 'err'),
+            array(Logger::WARNING, 'warning'),
+            array(Logger::NOTICE, 'notice'),
+            array(Logger::INFO, 'info'),
+            array(Logger::DEBUG, 'debug'),
+        );
+    }
+
+    /**
+     * @dataProvider logLevelsProvider
+     */
+    public function testShouldLogUsingSystemDaemon($level, $methodName)
+    {
+        $record = $this->getRecord($level, 'test', array('data' => new \stdClass, 'foo' => 34));
+
+        $systemDaemonMock = $this->getMockClass('System_Daemon', array($methodName));
+        $systemDaemonMock::staticExpects($this->once())
+            ->method($methodName)
+            ->with('(test) test {"data":"[object] (stdClass: {})","foo":34} []');
+
+        $handler = new SystemDaemonHandler();
+        $reflection = new ReflectionProperty($handler, 'systemDaemonClassName');
+        $reflection->setAccessible(true);
+        $reflection->setValue($handler, $systemDaemonMock);
+
+        $handler->handle($record);
+    }
+}


### PR DESCRIPTION
[System_Daemon](http://pear.php.net/package/System_Daemon) is an very stable package to work with daemons in PHP. It already handles logs by itself this pull request aims to integrate System_Daemon and Monolog.
A default formatter was created, since System_Daemon already prefix the date and level to the log message there is no need to duplicate this information, SystemDaemonFormatter is based on LineFormatter but has only channel, message, context and extras.
