### PR TITLE
Remove new live from default error_log formatter

### DIFF
--- a/src/Monolog/Formatter/ErrorLogFormatter.php
+++ b/src/Monolog/Formatter/ErrorLogFormatter.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+/**
+ * @author Henrique Moody <henriquemoody@gmail.com>
+ */
+class ErrorLogFormatter extends LineFormatter
+{
+    const SIMPLE_FORMAT = "[%datetime%] %channel%.%level_name%: %message% %context% %extra%";
+}

--- a/src/Monolog/Handler/ErrorLogHandler.php
+++ b/src/Monolog/Handler/ErrorLogHandler.php
@@ -11,6 +11,7 @@
 
 namespace Monolog\Handler;
 
+use Monolog\Formatter\ErrorLogFormatter;
 use Monolog\Logger;
 
 /**
@@ -51,6 +52,14 @@ class ErrorLogHandler extends AbstractProcessingHandler
             self::OPERATING_SYSTEM,
             self::SAPI,
         );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDefaultFormatter()
+    {
+        return new ErrorLogFormatter();
     }
 
     /**


### PR DESCRIPTION
`error_log()` function already insert a new line at end of the given message, this pull request just remove the new line at end to remove the new live duplication.
