### PR TITLE
Log extra data as custom parameters in new relic.

### DIFF
--- a/src/Monolog/Handler/NewRelicHandler.php
+++ b/src/Monolog/Handler/NewRelicHandler.php
@@ -62,6 +62,10 @@ class NewRelicHandler extends AbstractProcessingHandler
         foreach ($record['context'] as $key => $parameter) {
             newrelic_add_custom_parameter($key, $parameter);
         }
+
+        foreach ($record['extra'] as $key => $parameter) {
+            newrelic_add_custom_parameter($key, $parameter);
+        }
     }
 
     /**


### PR DESCRIPTION
The 'extra' data which usually contains identity type information isn't being logged, this adds support for that.
