### PR TITLE
Allowing some messages to always be flushed from FingersCrossedHandler

### DIFF
--- a/tests/Monolog/Handler/FingersCrossedHandlerTest.php
+++ b/tests/Monolog/Handler/FingersCrossedHandlerTest.php
@@ -31,6 +31,7 @@ class FingersCrossedHandlerTest extends TestCase
         $this->assertFalse($test->hasDebugRecords());
         $this->assertFalse($test->hasInfoRecords());
         $handler->handle($this->getRecord(Logger::WARNING));
+        $handler->close();
         $this->assertTrue($test->hasInfoRecords());
         $this->assertTrue(count($test->getRecords()) === 3);
     }
@@ -44,6 +45,7 @@ class FingersCrossedHandlerTest extends TestCase
         $handler = new FingersCrossedHandler($test);
         $handler->handle($this->getRecord(Logger::WARNING));
         $handler->handle($this->getRecord(Logger::DEBUG));
+        $handler->close();
         $this->assertTrue($test->hasWarningRecords());
         $this->assertTrue($test->hasDebugRecords());
     }
@@ -60,6 +62,7 @@ class FingersCrossedHandlerTest extends TestCase
         $handler->handle($this->getRecord(Logger::DEBUG));
         $handler->reset();
         $handler->handle($this->getRecord(Logger::INFO));
+        $handler->close();
         $this->assertTrue($test->hasWarningRecords());
         $this->assertTrue($test->hasDebugRecords());
         $this->assertFalse($test->hasInfoRecords());
@@ -75,6 +78,7 @@ class FingersCrossedHandlerTest extends TestCase
         $handler->handle($this->getRecord(Logger::DEBUG));
         $handler->handle($this->getRecord(Logger::WARNING));
         $handler->handle($this->getRecord(Logger::INFO));
+        $handler->close();
         $this->assertTrue($test->hasWarningRecords());
         $this->assertTrue($test->hasDebugRecords());
         $this->assertFalse($test->hasInfoRecords());
@@ -185,5 +189,19 @@ class FingersCrossedHandlerTest extends TestCase
         $this->assertTrue($test->hasWarningRecords());
         $records = $test->getRecords();
         $this->assertTrue($records[0]['extra']['foo']);
+    }
+
+    /**
+     * @covers Monolog\Handler\FingersCrossedHandler::close
+     */
+    public function testPassthruOnClose()
+    {
+        $test = new TestHandler();
+        $handler = new FingersCrossedHandler($test, new ErrorLevelActivationStrategy(Logger::WARNING), 0, true, true, Logger::INFO);
+        $handler->handle($this->getRecord(Logger::DEBUG));
+        $handler->handle($this->getRecord(Logger::INFO));
+        $handler->close();
+        $this->assertFalse($test->hasDebugRecords());
+        $this->assertTrue($test->hasInfoRecords());
     }
 }


### PR DESCRIPTION
This PR adds an optional argument to specify a minimum level of message to always flush through when FingersCrossedHandler is closed.

The purpose of FingersCrossedHandler is to prevent your logs from filling up with debug-level junk by only logging it in situations where something has gone wrong. However, I sometimes still want to get a basic level of logging in normal situations, and this is not possible with FCH at the moment; it's either everything or nothing.

It's possible to work around this in the current monolog by using FilterHandlers, but currently that will always cause either duplicate or out-of-order messages (depending on how you arrange the filters).
