### PR TITLE
Add years to the copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) Jordi Boggiano
+Copyright (c) 2011-2014 Jordi Boggiano
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
A copyright notice should include the year of first publication. Since
changes have been made to the initial work since then, it’s common
usage to also document the years in between.

The dates have been figured out from the Git repository.
