### PR TITLE
Added microsecond support for JSON serialized DateTime objects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.0",
         "psr/log": "~1.0"
     },
     "require-dev": {

--- a/src/Monolog/DateTime.php
+++ b/src/Monolog/DateTime.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog;
+
+/**
+ * Add microsecond detail to JSON encoded DateTime objects
+ *
+ * @author Menno Holtkamp
+ */
+class DateTime extends \DateTime implements \JsonSerializable
+{
+
+    /**
+     * Override function to ensure an object of this class is returned
+     *
+     * @link http://stackoverflow.com/questions/17909871/getting-date-format-m-d-y-his-u-from-milliseconds
+     * @param string $format
+     * @param string $time
+     * @param DateTimeZone $timezone
+     * @return static
+     */
+    public static function createFromFormat($format, $time, $timezone = null)
+    {
+        $timestamp = microtime(true);
+        $microseconds = sprintf('%06d', ($timestamp - floor($timestamp)) * 1000000);
+
+        return new static(date('Y-m-d H:i:s.' . $microseconds, $timestamp));
+    }
+
+    /**
+     * Append the microseconds to the date property
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $result = (array)$this;
+        $result['date'] .= $this->format('.u');
+
+        return $result;
+
+    }
+
+}

--- a/src/Monolog/DateTime.php
+++ b/src/Monolog/DateTime.php
@@ -20,23 +20,6 @@ class DateTime extends \DateTime implements \JsonSerializable
 {
 
     /**
-     * Override function to ensure an object of this class is returned
-     *
-     * @link http://stackoverflow.com/questions/17909871/getting-date-format-m-d-y-his-u-from-milliseconds
-     * @param string $format
-     * @param string $time
-     * @param DateTimeZone $timezone
-     * @return static
-     */
-    public static function createFromFormat($format, $time, $timezone = null)
-    {
-        $timestamp = microtime(true);
-        $microseconds = sprintf('%06d', ($timestamp - floor($timestamp)) * 1000000);
-
-        return new static(date('Y-m-d H:i:s.' . $microseconds, $timestamp));
-    }
-
-    /**
      * Append the microseconds to the date property
      *
      * @return array
@@ -47,7 +30,6 @@ class DateTime extends \DateTime implements \JsonSerializable
         $result['date'] .= $this->format('.u');
 
         return $result;
-
     }
 
 }

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -239,7 +239,7 @@ class Logger implements LoggerInterface
             'level' => $level,
             'level_name' => static::getLevelName($level),
             'channel' => $this->name,
-            'datetime' => DateTime::createFromFormat('U.u', sprintf('%.6F', microtime(true)), static::$timezone)->setTimezone(static::$timezone),
+            'datetime' => $this->getDateTimeWithMicroSeconds(),
             'extra' => array(),
         );
         // check if any handler will handle this message
@@ -265,6 +265,23 @@ class Logger implements LoggerInterface
         }
 
         return true;
+    }
+
+    /**
+     * Prevent DateTime::createFromFormat() which always returns the native DateTime instead of the specialized one
+     *
+     * @link https://bugs.php.net/bug.php?id=60302
+     * @link http://stackoverflow.com/questions/17909871/getting-date-format-m-d-y-his-u-from-milliseconds
+     * @return DateTime
+     */
+    private function getDateTimeWithMicroSeconds()
+    {
+        $timestamp = microtime(true);
+        $microseconds = sprintf("%06d",($timestamp - floor($timestamp)) * 1000000);
+        $dateTime = new DateTime(date('Y-m-d H:i:s.' . $microseconds, $timestamp), static::$timezone);
+        $dateTime->setTimezone(static::$timezone);
+
+        return $dateTime;
     }
 
     /**

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -239,7 +239,7 @@ class Logger implements LoggerInterface
             'level' => $level,
             'level_name' => static::getLevelName($level),
             'channel' => $this->name,
-            'datetime' => \DateTime::createFromFormat('U.u', sprintf('%.6F', microtime(true)), static::$timezone)->setTimezone(static::$timezone),
+            'datetime' => DateTime::createFromFormat('U.u', sprintf('%.6F', microtime(true)), static::$timezone)->setTimezone(static::$timezone),
             'extra' => array(),
         );
         // check if any handler will handle this message


### PR DESCRIPTION
When using the JsonFormatter, all records are encoded using json_encode(). For the timestamp this would mean that a DateTime object results in something like:

```
    "datetime": {
        "date": "2014-07-31 11:15:22",
        "timezone_type": 3,
        "timezone": "Europe/Amsterdam"
    }
```

This way we 'loose' the ability to format the timestamp with microsecond precision. A way to avoid this loss of detail is to extend the native DateTime class with one that implements [JsonSerializable](http://php.net/manual/en/class.jsonserializable.php) which appends the microseconds.

Note that due to https://bugs.php.net/bug.php?id=60302, this means we can no longer use DateTime::createFromFormat(), so I isolated it in a private function.