### PR TITLE
Allow to add extra fields

### DIFF
--- a/src/Monolog/Processor/WebProcessor.php
+++ b/src/Monolog/Processor/WebProcessor.php
@@ -75,6 +75,18 @@ class WebProcessor
     }
 
     /**
+     * @param string $extraName
+     * @param string $serverName
+     * @return $this
+     */
+    public function addExtraField($extraName, $serverName)
+    {
+        $this->extraFields[$extraName] = $serverName;
+
+        return $this;
+    }
+    
+    /**
      * @param  array $extra
      * @return array
      */


### PR DESCRIPTION
As suggested in https://github.com/Seldaek/monolog/pull/400#issuecomment-50885207, which would allow something like:

```
$webProcessor = new WebProcessor();
$webProcessor->addExtraField('xip', 'HTTP_X_FORWARDED_FOR')
    ->addExtraField('http_auth_user', 'PHP_AUTH_USER');
```
