### PR TITLE
update link to latest version of documentation

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -194,7 +194,7 @@ Formatters
 - _WildfireFormatter_: Used to format log records into the Wildfire/FirePHP protocol, only useful for the FirePHPHandler.
 - _ChromePHPFormatter_: Used to format log records into the ChromePHP format, only useful for the ChromePHPHandler.
 - _GelfMessageFormatter_: Used to format log records into Gelf message instances, only useful for the GelfHandler.
-- _LogstashFormatter_: Used to format log records into [logstash](http://logstash.net/) event json, useful for any handler listed under inputs [here](http://logstash.net/docs/1.4.2/).
+- _LogstashFormatter_: Used to format log records into [logstash](http://logstash.net/) event json, useful for any handler listed under inputs [here](http://logstash.net/docs/latest).
 - _ElasticaFormatter_: Used to format log records into an Elastica\Document object, only useful for the ElasticSearchHandler.
 - _LogglyFormatter_: Used to format log records into Loggly messages, only useful for the LogglyHandler.
 - _FlowdockFormatter_: Used to format log records into Flowdock messages, only useful for the FlowdockHandler.


### PR DESCRIPTION
URL change to most recent version of Logstash documentation. Wish they would just make the URL http://logstash.net/docs/ point to the latest but oh well.
