### PR TITLE
HtmlFormatter - Embed context and extra datas in tables

### DIFF
--- a/src/Monolog/Formatter/HtmlFormatter.php
+++ b/src/Monolog/Formatter/HtmlFormatter.php
@@ -46,14 +46,17 @@ class HtmlFormatter extends NormalizerFormatter
     /**
      * Creates an HTML table row
      *
-     * @param  string $th Row header content
-     * @param  string $td Row standard cell content
+     * @param  string $th        Row header content
+     * @param  string $td        Row standard cell content
+     * @param  bool   $escapeTd  false if td content must not be html escaped
      * @return string
      */
-    private function addRow($th, $td = ' ')
+    private function addRow($th, $td = ' ', $escapeTd = true)
     {
         $th = htmlspecialchars($th, ENT_NOQUOTES, 'UTF-8');
-        $td = '<pre>'.htmlspecialchars($td, ENT_NOQUOTES, 'UTF-8').'</pre>';
+        if ($escapeTd) {
+            $td = '<pre>'.htmlspecialchars($td, ENT_NOQUOTES, 'UTF-8').'</pre>';
+        }
 
         return "<tr style=\"padding: 4px;spacing: 0;text-align: left;\">\n<th style=\"background: #cccccc\" width=\"100px\">$th:</th>\n<td style=\"padding: 4px;spacing: 0;text-align: left;background: #eeeeee\">".$td."</td>\n</tr>";
     }
@@ -86,10 +89,20 @@ class HtmlFormatter extends NormalizerFormatter
         $output .= $this->addRow('Time', $record['datetime']->format('Y-m-d\TH:i:s.uO'));
         $output .= $this->addRow('Channel', $record['channel']);
         if ($record['context']) {
-            $output .= $this->addRow('Context', $this->convertToString($record['context']));
+            $embeddedTable = '<table cellspacing="1" width="100%">';
+            foreach ($record['context'] as $key => $value) {
+                $embeddedTable .= $this->addRow($key, $this->convertToString($value));
+            }
+            $embeddedTable .= '</table>';
+            $output .= $this->addRow('Context', $embeddedTable, false);
         }
         if ($record['extra']) {
-            $output .= $this->addRow('Extra', $this->convertToString($record['extra']));
+            $embeddedTable = '<table cellspacing="1" width="100%">';
+            foreach ($record['extra'] as $key => $value) {
+                $embeddedTable .= $this->addRow($key, $this->convertToString($value));
+            }
+            $embeddedTable .= '</table>';
+            $output .= $this->addRow('Extra', $embeddedTable, false);
         }
 
         return $output.'</table>';


### PR DESCRIPTION
Hello,

In fact, I first wanted to extend HtmlFormatter to override public function format (cause json is not easy-to-read, especially with Exception traces).
But addRow and addTitle are private.

If my PR is rejected, is it possible to move them to protected ?

Thanks
