### PR TITLE
FIX trouble when register multiple handlers

### DIFF
--- a/src/Monolog/Handler/AbstractHandler.php
+++ b/src/Monolog/Handler/AbstractHandler.php
@@ -46,7 +46,7 @@ abstract class AbstractHandler implements HandlerInterface
      */
     public function isHandling(array $record)
     {
-        return $record['level'] >= $this->level;
+        return $record['level'] == $this->level;
     }
 
     /**


### PR DESCRIPTION
FIX trouble when you try register multiple handlers for each logging levels (one handler for one logging level).
