### PR TITLE
Invalid StreamHandler Arguments

### DIFF
--- a/src/Monolog/Handler/StreamHandler.php
+++ b/src/Monolog/Handler/StreamHandler.php
@@ -29,12 +29,13 @@ class StreamHandler extends AbstractProcessingHandler
     protected $useLocking;
 
     /**
-     * @param  Resource|string $stream
-     * @param  integer         $level          The minimum logging level at which this handler will be triggered
-     * @param  Boolean         $bubble         Whether the messages that are handled can bubble up the stack or not
-     * @param  int|null        $filePermission Optional file permissions (default (0644) are only for owner read/write)
-     * @param  Boolean         $useLocking     Try to lock log file before doing any writes
-     * @throws InvalidArgumentException        If stream is not a resource or string
+     * @param resource|string $stream
+     * @param integer         $level          The minimum logging level at which this handler will be triggered
+     * @param Boolean         $bubble         Whether the messages that are handled can bubble up the stack or not
+     * @param int|null        $filePermission Optional file permissions (default (0644) are only for owner read/write)
+     * @param Boolean         $useLocking     Try to lock log file before doing any writes
+     *
+     * @throws InvalidArgumentException If stream is not a resource or string
      */
     public function __construct($stream, $level = Logger::DEBUG, $bubble = true, $filePermission = null, $useLocking = false)
     {

--- a/tests/Monolog/Handler/StreamHandlerTest.php
+++ b/tests/Monolog/Handler/StreamHandlerTest.php
@@ -88,12 +88,10 @@ class StreamHandlerTest extends TestCase
      * @dataProvider invalidArgumentProvider
      * @expectedException InvalidArgumentException
      * @covers Monolog\Handler\StreamHandler::__construct
-     * @covers Monolog\Handler\StreamHandler::write
      */
     public function testWriteInvalidArgument($invalidArgument)
     {
         $handler = new StreamHandler($invalidArgument);
-        $handler->handle($this->getRecord());
     }
     
     /**


### PR DESCRIPTION
My application was incorrectly passing the StreamHandler a argument of

```
$stream = array('file://url');
$handler = new StreamHandler($stream);
```

And when the stream handler tried to handle a record it would cause the following error

```
Array to string conversion at /var/www/service-manager/vendor/monolog/monolog/src/Monolog/Handler/StreamHandler.php:82
```

I thought by adding an InvalidArgumentException it might show people where they are going wrong quicker
