### PR TITLE
NewRelicHandler: Prevent newrelic_add_custom_parameter() overwriting

### DIFF
--- a/src/Monolog/Handler/NewRelicHandler.php
+++ b/src/Monolog/Handler/NewRelicHandler.php
@@ -60,11 +60,11 @@ class NewRelicHandler extends AbstractProcessingHandler
         }
 
         foreach ($record['context'] as $key => $parameter) {
-            newrelic_add_custom_parameter($key, $parameter);
+            newrelic_add_custom_parameter('context_' . $key, $parameter);
         }
 
         foreach ($record['extra'] as $key => $parameter) {
-            newrelic_add_custom_parameter($key, $parameter);
+            newrelic_add_custom_parameter('extra_' . $key, $parameter);
         }
     }
 

--- a/tests/Monolog/Handler/NewRelicHandlerTest.php
+++ b/tests/Monolog/Handler/NewRelicHandlerTest.php
@@ -45,7 +45,7 @@ class NewRelicHandlerTest extends TestCase
     {
         $handler = new StubNewRelicHandler();
         $handler->handle($this->getRecord(Logger::ERROR, 'log message', array('a' => 'b')));
-        $this->assertEquals(array('a' => 'b'), self::$customParameters);
+        $this->assertEquals(array('context_a' => 'b'), self::$customParameters);
     }
 
     public function testThehandlerCanAddExtraParamsToTheNewRelicTrace()
@@ -56,7 +56,7 @@ class NewRelicHandlerTest extends TestCase
         $handler = new StubNewRelicHandler();
         $handler->handle($record);
 
-        $this->assertEquals(array('c' => 'd'), self::$customParameters);
+        $this->assertEquals(array('extra_c' => 'd'), self::$customParameters);
     }
 
     public function testThehandlerCanAddExtraContextAndParamsToTheNewRelicTrace()
@@ -68,8 +68,8 @@ class NewRelicHandlerTest extends TestCase
         $handler->handle($record);
 
         $expected = array(
-            'a' => 'b',
-            'c' => 'd',
+            'context_a' => 'b',
+            'extra_c' => 'd',
         );
 
         $this->assertEquals($expected, self::$customParameters);


### PR DESCRIPTION
Add prefixes to the context and extra record keys. Needed as some processors have the same keys as the the context. Specifically, the `IntrospectionProcessor` has "line" and "file" that can overwrite an error context "line" and "file". If there is something like an E_PARSE error, the context variables are set, but the `IntrospectionProcessor` gets nulls. Tested on Lite account (screenshot below)

![newrelic](https://cloud.githubusercontent.com/assets/1920405/4444811/b9921802-47f3-11e4-88d7-9421ba7c7e35.jpg)
