### PR TITLE
NewRelicHandler: Account for arrays sent in context and extra parameters

### DIFF
--- a/tests/Monolog/Handler/NewRelicHandlerTest.php
+++ b/tests/Monolog/Handler/NewRelicHandlerTest.php
@@ -48,6 +48,20 @@ class NewRelicHandlerTest extends TestCase
         $this->assertEquals(array('context_a' => 'b'), self::$customParameters);
     }
 
+    public function testThehandlerCanAddExplodedContextParamsToTheNewRelicTrace()
+    {
+        $handler = new StubNewRelicHandler(Logger::ERROR, true, self::$appname, true);
+        $handler->handle($this->getRecord(
+            Logger::ERROR,
+            'log message',
+            array('a' => array('key1' => 'value1', 'key2' => 'value2'))
+        ));
+        $this->assertEquals(
+            array('context_a_key1' => 'value1', 'context_a_key2' => 'value2'),
+            self::$customParameters
+        );
+    }
+
     public function testThehandlerCanAddExtraParamsToTheNewRelicTrace()
     {
         $record = $this->getRecord(Logger::ERROR, 'log message');
@@ -57,6 +71,20 @@ class NewRelicHandlerTest extends TestCase
         $handler->handle($record);
 
         $this->assertEquals(array('extra_c' => 'd'), self::$customParameters);
+    }
+
+    public function testThehandlerCanAddExplodedExtraParamsToTheNewRelicTrace()
+    {
+        $record = $this->getRecord(Logger::ERROR, 'log message');
+        $record['extra'] = array('c' => array('key1' => 'value1', 'key2' => 'value2'));
+
+        $handler = new StubNewRelicHandler(Logger::ERROR, true, self::$appname, true);
+        $handler->handle($record);
+
+        $this->assertEquals(
+            array('extra_c_key1' => 'value1', 'extra_c_key2' => 'value2'),
+            self::$customParameters
+        );
     }
 
     public function testThehandlerCanAddExtraContextAndParamsToTheNewRelicTrace()


### PR DESCRIPTION
Account for context and extra params that are sent as arrays (GitProcessor for one). New protected parameter `explodeArrays` is optional and set to false to emulate current feature set.
