### PR TITLE
Update JsonFormatter.php

### DIFF
--- a/src/Monolog/Formatter/JsonFormatter.php
+++ b/src/Monolog/Formatter/JsonFormatter.php
@@ -20,11 +20,11 @@ namespace Monolog\Formatter;
  */
 class JsonFormatter implements FormatterInterface
 {
-    protected $batchMode;
-    protected $appendNewline;
-
     const BATCH_MODE_JSON = 1;
     const BATCH_MODE_NEWLINES = 2;
+    
+    protected $batchMode;
+    protected $appendNewline;
 
     /**
      * @param int $batchMode


### PR DESCRIPTION
It's more clear and proper this way to put all class constants on top.
