### PR TITLE
Added PSR Handler

### DIFF
--- a/src/Monolog/Handler/PsrHandler.php
+++ b/src/Monolog/Handler/PsrHandler.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Logger;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Proxies log messages to an existing PSR-3 compliant logger.
+ *
+ * @author Michael Moussa <michael.moussa@gmail.com>
+ */
+class PsrHandler extends AbstractHandler
+{
+    /**
+     * PSR-3 compliant logger
+     *
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @param LoggerInterface $logger The underlying PSR-3 compliant logger to which messages will be proxied
+     * @param int             $level  The minimum logging level at which this handler will be triggered
+     * @param Boolean         $bubble Whether the messages that are handled can bubble up the stack or not
+     */
+    public function __construct(LoggerInterface $logger, $level = Logger::DEBUG, $bubble = true)
+    {
+        parent::__construct($level, $bubble);
+
+        $this->logger = $logger;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handle(array $record)
+    {
+        if (!$this->isHandling($record)) {
+            return false;
+        }
+
+        $logMethodName = strtolower($record['level_name']);
+        call_user_func([$this->logger, $logMethodName], $record['message'], $record['context']);
+
+        return false === $this->bubble;
+    }
+}

--- a/tests/Monolog/Handler/PsrHandlerTest.php
+++ b/tests/Monolog/Handler/PsrHandlerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\TestCase;
+use Monolog\Logger;
+
+/**
+ * @covers Monolog\Handler\PsrHandler::handle
+ */
+class PsrHandlerTest extends TestCase
+{
+    public function logLevelProvider()
+    {
+        $levels = [];
+        $monologLogger = new Logger('', [], []);
+
+        foreach ($monologLogger->getLevels() as $levelName => $level) {
+            $levels[] = [$levelName, $level];
+        }
+
+        return $levels;
+    }
+
+    /**
+     * @dataProvider logLevelProvider
+     */
+    public function testHandlesAllLevels($levelName, $level)
+    {
+        $message = 'Hello, world!';
+        $context = ['foo' => 'bar'];
+
+        $psrLogger = $this->getMock('Psr\Log\NullLogger');
+        $psrLogger->expects($this->once())
+            ->method(strtolower($levelName))
+            ->with($message, $context);
+
+        $handler = new PsrHandler($psrLogger);
+        $handler->handle(['level' => $level, 'level_name' => $levelName, 'message' => $message, 'context' => $context]);
+    }
+}


### PR DESCRIPTION
I have an application into which I need to introduce Monolog in order to use some of its other handlers, but I have an existing PSR-3 compliant logger class that I do not wish to change. Rather than port all of the formatting/processing/writing logic from my logger to match patterns established by Monolog, I'd like to simply tell Monolog to use my logger - just pass it whatever information it knows how to handle.

This handler allows anyone integrating Monolog in their application to continue using their existing PSR-3 compliant logger(s), if any, in addition to the variety of other handlers that Monolog makes available. The handler simply proxies to the `Psr\Log\LoggerInterface` log methods, which are the all lowercased versions of the standard Monolog severity levels.
