### PR TITLE
Adds exception codes to the exception data in NormalizeFormatter

### DIFF
--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -100,6 +100,7 @@ class NormalizerFormatter implements FormatterInterface
         $data = array(
             'class' => get_class($e),
             'message' => $e->getMessage(),
+            'code' => $e->getCode(),
             'file' => $e->getFile().':'.$e->getLine(),
         );
 

--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -66,7 +66,8 @@ class NormalizerFormatterTest extends \PHPUnit_Framework_TestCase
             'exception' => array(
                 'class'   => get_class($e2),
                 'message' => $e2->getMessage(),
-                'file'   => $e2->getFile().':'.$e2->getLine(),
+                'code'    => $e2->getCode(),
+                'file'    => $e2->getFile().':'.$e2->getLine(),
             )
         ), $formatted);
     }

--- a/tests/Monolog/Formatter/ScalarFormatterTest.php
+++ b/tests/Monolog/Formatter/ScalarFormatterTest.php
@@ -55,6 +55,7 @@ class ScalarFormatterTest extends \PHPUnit_Framework_TestCase
             'ban' => $this->encodeJson(array(
                 'class'   => get_class($exception),
                 'message' => $exception->getMessage(),
+                'code'    => $exception->getCode(),
                 'file'    => $exception->getFile() . ':' . $exception->getLine(),
                 'trace'   => $this->buildTrace($exception)
             ))
@@ -87,6 +88,7 @@ class ScalarFormatterTest extends \PHPUnit_Framework_TestCase
                 'exception' => array(
                     'class'   => get_class($exception),
                     'message' => $exception->getMessage(),
+                    'code'    => $exception->getCode(),
                     'file'    => $exception->getFile() . ':' . $exception->getLine(),
                     'trace'   => $this->buildTrace($exception)
                 )


### PR DESCRIPTION
I wasn't sure if this was just an oversight, or if there was a specific reason for code to not be included. Feel free to close with an explanation if this doesn't seem like a good change.

Thanks for considering it!
