### PR TITLE
Fix header injection in NativeMailerHandler

### DIFF
--- a/src/Monolog/Handler/NativeMailerHandler.php
+++ b/src/Monolog/Handler/NativeMailerHandler.php
@@ -95,7 +95,7 @@ class NativeMailerHandler extends MailHandler
      */
     protected function send($content, array $records)
     {
-	$this->addHeader(sprintf('Content-type: %s; charset=%s', $this->getContentType(), $this->getEncoding()));
+        $this->addHeader(sprintf('Content-type: %s; charset=%s', $this->getContentType(), $this->getEncoding()));
         $content = wordwrap($content, $this->maxColumnWidth);
         $headers = ltrim(implode("\r\n", $this->headers) . "\r\n", "\r\n");
         if ($this->getContentType() == 'text/html' && false === strpos($headers, 'MIME-Version:')) {


### PR DESCRIPTION
Hopefully attacker controlled data is never used to set the encoding
or content type, but just in case, prevent:

$nmh = new NativeMailerHandler($to, $subject, $from);
$nmh->setEncoding( "utf-8\r\nFrom: faked@attacker.org");

Since the injection happened in send(), there doesn't seem to be a good
way to add a unit test for this.
