### PR TITLE
Callback for Mandril Handler

### DIFF
--- a/src/Monolog/Handler/MandrillHandler.php
+++ b/src/Monolog/Handler/MandrillHandler.php
@@ -62,9 +62,7 @@ class MandrillHandler extends MailHandler
 
         curl_setopt($ch, CURLOPT_URL, 'https://mandrillapp.com/api/1.0/messages/send-raw.json');
         curl_setopt($ch, CURLOPT_POST, 1);
-        if ($this->responseHandler !== null) {
-            curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-        }
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query(array(
             'key' => $this->apiKey,
             'raw_message' => (string) $message,


### PR DESCRIPTION
The following code can be used to silence the curl response. It also allows you to pass in a call back function which can then be used to process the response from mandrill. 
We were using this project in a website and upon sending an email to mandrill, the response was being echoed out on our site. 
