### PR TITLE
SyslogUdpHandler: Send a valid rfc5424 version

### DIFF
--- a/src/Monolog/Handler/SyslogUdpHandler.php
+++ b/src/Monolog/Handler/SyslogUdpHandler.php
@@ -63,11 +63,11 @@ class SyslogUdpHandler extends AbstractSyslogHandler
     /**
      * Make common syslog header (see rfc5424)
      */
-    private function makeCommonSyslogHeader($severity)
+    protected function makeCommonSyslogHeader($severity)
     {
         $priority = $severity + $this->facility;
 
-        return "<$priority>: ";
+        return "<$priority>1 ";
     }
 
     /**

--- a/tests/Monolog/Handler/SyslogUdpHandlerTest.php
+++ b/tests/Monolog/Handler/SyslogUdpHandlerTest.php
@@ -32,10 +32,10 @@ class SyslogUdpHandlerTest extends \PHPUnit_Framework_TestCase
         $socket = $this->getMock('\Monolog\Handler\SyslogUdp\UdpSocket', array('write'), array('lol', 'lol'));
         $socket->expects($this->at(0))
             ->method('write')
-            ->with("lol", "<".(LOG_AUTHPRIV + LOG_WARNING).">: ");
+            ->with("lol", "<".(LOG_AUTHPRIV + LOG_WARNING).">1 ");
         $socket->expects($this->at(1))
             ->method('write')
-            ->with("hej", "<".(LOG_AUTHPRIV + LOG_WARNING).">: ");
+            ->with("hej", "<".(LOG_AUTHPRIV + LOG_WARNING).">1 ");
 
         $handler->setSocket($socket);
 


### PR DESCRIPTION
I had some problems getting my log messages parsed correctly by Papertrail. As far as I can see from [this guide](http://help.papertrailapp.com/kb/configuration/configuring-remote-syslog-from-embedded-or-proprietary-systems/), the current header format of SyslogUdpHandler is neither valid [rfc5424](https://tools.ietf.org/html/rfc5424) nor [rfc3164](http://www.ietf.org/rfc/rfc3164.txt) (I had a quick look at the standards themselves too, but I haven't studied them thouroughly). 

I also made the class protected rather than private, so it can be overridden in case anyone wants to use RFC 3164 instead.
