### PR TITLE
Recursively check for resource arguments if trace is coming from internal function

### DIFF
--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -108,6 +108,7 @@ class NormalizerFormatter implements FormatterInterface
             if (isset($frame['file'])) {
                 $data['trace'][] = $frame['file'].':'.$frame['line'];
             } else {
+                $this->convertResourceArgs($frame);
                 $data['trace'][] = json_encode($frame);
             }
         }
@@ -135,5 +136,27 @@ class NormalizerFormatter implements FormatterInterface
         }
 
         return json_encode($data);
+    }
+
+    /**
+     * This method checks recursively for resource args inside the frame, since json_encode is choking on them.
+     *
+     * @param array &$frame Reference to current frame
+     */
+    private function convertResourceArgs(array &$frame)
+    {
+        foreach ($frame as $key => &$item) {
+            if (is_scalar($item)) {
+                continue;
+            }
+
+            if (is_resource($item)) {
+                $frame[$key] = (string) $item;
+            }
+
+            if (is_array($item)) {
+                $this->convertResourceArgs($item);
+            }
+        }
     }
 }


### PR DESCRIPTION
With `React` or `Guzzle`, that register stream wrappers with PHP, the traces are treated as coming from internal functions with no line and file inside the frame. But they almost always contain resources as arguments, on which the `json_encode()` call will choke (probably this should be addressed in `json_encode` internally, since it is very easy to cast a resource to a string).

I added a test case proving the situation and a pretty basic recursive checker for resources which just casts them as a string into the frame again.
