### PR TITLE
Fix warnings in case of incorrect data

### DIFF
--- a/src/Monolog/Formatter/GelfMessageFormatter.php
+++ b/src/Monolog/Formatter/GelfMessageFormatter.php
@@ -67,6 +67,10 @@ class GelfMessageFormatter extends NormalizerFormatter
     public function format(array $record)
     {
         $record = parent::format($record);
+        if (!$this->isInputValid($record))
+        {
+            return $record;
+        }
         $message = new Message();
         $message
             ->setTimestamp($record['datetime'])
@@ -97,5 +101,22 @@ class GelfMessageFormatter extends NormalizerFormatter
         }
 
         return $message;
+    }
+
+    private function isInputValid(array $input)
+    {
+        return (
+            !empty($input) &&
+            is_array($input) &&
+            isset($input['datetime']) &&
+            isset($input['message']) &&
+            isset($input['channel']) &&
+            isset($input['level']) &&
+            isset($this->logLevels[$input['level']]) &&
+            isset($input['extra']) &&
+            is_array(['extra']) &&
+            isset($input['context']) &&
+            is_array($input['context'])
+        );
     }
 }

--- a/src/Monolog/Formatter/GelfMessageFormatter.php
+++ b/src/Monolog/Formatter/GelfMessageFormatter.php
@@ -114,7 +114,7 @@ class GelfMessageFormatter extends NormalizerFormatter
             isset($input['level']) &&
             isset($this->logLevels[$input['level']]) &&
             isset($input['extra']) &&
-            is_array(['extra']) &&
+            is_array($input['extra']) &&
             isset($input['context']) &&
             is_array($input['context'])
         );

--- a/src/Monolog/Formatter/GelfMessageFormatter.php
+++ b/src/Monolog/Formatter/GelfMessageFormatter.php
@@ -69,7 +69,7 @@ class GelfMessageFormatter extends NormalizerFormatter
         $record = parent::format($record);
         if (!$this->isInputValid($record))
         {
-            return $record;
+            throw new \InvalidArgumentException('Please check keys in input array');
         }
         $message = new Message();
         $message
@@ -103,11 +103,14 @@ class GelfMessageFormatter extends NormalizerFormatter
         return $message;
     }
 
+    /**
+     * @param array $input
+     * @return bool is input valid of not
+     */
     private function isInputValid(array $input)
     {
         return (
             !empty($input) &&
-            is_array($input) &&
             isset($input['datetime']) &&
             isset($input['message']) &&
             isset($input['channel']) &&

--- a/tests/Monolog/Formatter/GelfMessageFormatterTest.php
+++ b/tests/Monolog/Formatter/GelfMessageFormatterTest.php
@@ -43,6 +43,8 @@ class GelfMessageFormatterTest extends \PHPUnit_Framework_TestCase
     /**
      * @param array $input
      * @covers Monolog\Formatter\GelfMessageFormatter::format
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Please check keys in input array
      * @dataProvider formatterIncorrectInputDataProvider
      */
     public function testFormatterWithIncorrectInput(array $input)

--- a/tests/Monolog/Formatter/GelfMessageFormatterTest.php
+++ b/tests/Monolog/Formatter/GelfMessageFormatterTest.php
@@ -15,11 +15,39 @@ use Monolog\Logger;
 
 class GelfMessageFormatterTest extends \PHPUnit_Framework_TestCase
 {
+    /** @var GelfMessageFormatter  */
+    private $formatter = null;
+
     public function setUp()
     {
         if (!class_exists('\Gelf\Message')) {
             $this->markTestSkipped("graylog2/gelf-php or mlehner/gelf-php is not installed");
         }
+        $this->formatter = new GelfMessageFormatter();
+    }
+
+    public function formatterIncorrectInputDataProvider()
+    {
+        return [
+            [[]],
+            [['datetime' => 1]],
+            [['datetime' => 1, 'message' => 1]],
+            [['datetime' => 1, 'message' => 1, 'channel' => 1]],
+            [['datetime' => 1, 'message' => 1, 'channel' => 1, 'level' => 255]],
+            [['datetime' => 1, 'message' => 1, 'channel' => 1, 'level' => Logger::EMERGENCY]],
+            [['datetime' => 1, 'message' => 1, 'channel' => 1, 'level' => Logger::EMERGENCY, 'extra' => 1]],
+            [['datetime' => 1, 'message' => 1, 'channel' => 1, 'level' => Logger::EMERGENCY, 'extra' => [], 'context' => 1]],
+        ];
+    }
+
+    /**
+     * @param array $input
+     * @covers Monolog\Formatter\GelfMessageFormatter::format
+     * @dataProvider formatterIncorrectInputDataProvider
+     */
+    public function testFormatterWithIncorrectInput(array $input)
+    {
+        $this->assertEquals($input, $this->formatter->format($input));
     }
 
     /**
@@ -27,7 +55,6 @@ class GelfMessageFormatterTest extends \PHPUnit_Framework_TestCase
      */
     public function testDefaultFormatter()
     {
-        $formatter = new GelfMessageFormatter();
         $record = array(
             'level' => Logger::ERROR,
             'level_name' => 'ERROR',
@@ -38,7 +65,7 @@ class GelfMessageFormatterTest extends \PHPUnit_Framework_TestCase
             'message' => 'log',
         );
 
-        $message = $formatter->format($record);
+        $message = $this->formatter->format($record);
 
         $this->assertInstanceOf('Gelf\Message', $message);
         $this->assertEquals(0, $message->getTimestamp());
@@ -62,7 +89,6 @@ class GelfMessageFormatterTest extends \PHPUnit_Framework_TestCase
      */
     public function testFormatWithFileAndLine()
     {
-        $formatter = new GelfMessageFormatter();
         $record = array(
             'level' => Logger::ERROR,
             'level_name' => 'ERROR',
@@ -73,7 +99,7 @@ class GelfMessageFormatterTest extends \PHPUnit_Framework_TestCase
             'message' => 'log',
         );
 
-        $message = $formatter->format($record);
+        $message = $this->formatter->format($record);
 
         $this->assertInstanceOf('Gelf\Message', $message);
         $this->assertEquals('test', $message->getFile());
@@ -85,7 +111,6 @@ class GelfMessageFormatterTest extends \PHPUnit_Framework_TestCase
      */
     public function testFormatWithContext()
     {
-        $formatter = new GelfMessageFormatter();
         $record = array(
             'level' => Logger::ERROR,
             'level_name' => 'ERROR',
@@ -96,7 +121,7 @@ class GelfMessageFormatterTest extends \PHPUnit_Framework_TestCase
             'message' => 'log'
         );
 
-        $message = $formatter->format($record);
+        $message = $this->formatter->format($record);
 
         $this->assertInstanceOf('Gelf\Message', $message);
 
@@ -122,7 +147,6 @@ class GelfMessageFormatterTest extends \PHPUnit_Framework_TestCase
      */
     public function testFormatWithContextContainingException()
     {
-        $formatter = new GelfMessageFormatter();
         $record = array(
             'level' => Logger::ERROR,
             'level_name' => 'ERROR',
@@ -137,7 +161,7 @@ class GelfMessageFormatterTest extends \PHPUnit_Framework_TestCase
             'message' => 'log'
         );
 
-        $message = $formatter->format($record);
+        $message = $this->formatter->format($record);
 
         $this->assertInstanceOf('Gelf\Message', $message);
 
@@ -150,7 +174,6 @@ class GelfMessageFormatterTest extends \PHPUnit_Framework_TestCase
      */
     public function testFormatWithExtra()
     {
-        $formatter = new GelfMessageFormatter();
         $record = array(
             'level' => Logger::ERROR,
             'level_name' => 'ERROR',
@@ -161,7 +184,7 @@ class GelfMessageFormatterTest extends \PHPUnit_Framework_TestCase
             'message' => 'log'
         );
 
-        $message = $formatter->format($record);
+        $message = $this->formatter->format($record);
 
         $this->assertInstanceOf('Gelf\Message', $message);
 

--- a/tests/Monolog/Formatter/GelfMessageFormatterTest.php
+++ b/tests/Monolog/Formatter/GelfMessageFormatterTest.php
@@ -28,16 +28,16 @@ class GelfMessageFormatterTest extends \PHPUnit_Framework_TestCase
 
     public function formatterIncorrectInputDataProvider()
     {
-        return [
-            [[]],
-            [['datetime' => 1]],
-            [['datetime' => 1, 'message' => 1]],
-            [['datetime' => 1, 'message' => 1, 'channel' => 1]],
-            [['datetime' => 1, 'message' => 1, 'channel' => 1, 'level' => 255]],
-            [['datetime' => 1, 'message' => 1, 'channel' => 1, 'level' => Logger::EMERGENCY]],
-            [['datetime' => 1, 'message' => 1, 'channel' => 1, 'level' => Logger::EMERGENCY, 'extra' => 1]],
-            [['datetime' => 1, 'message' => 1, 'channel' => 1, 'level' => Logger::EMERGENCY, 'extra' => [], 'context' => 1]],
-        ];
+        return array(
+            array(array()),
+            array(array('datetime' => 1)),
+            array(array('datetime' => 1, 'message' => 1)),
+            array(array('datetime' => 1, 'message' => 1, 'channel' => 1)),
+            array(array('datetime' => 1, 'message' => 1, 'channel' => 1, 'level' => 255)),
+            array(array('datetime' => 1, 'message' => 1, 'channel' => 1, 'level' => Logger::EMERGENCY)),
+            array(array('datetime' => 1, 'message' => 1, 'channel' => 1, 'level' => Logger::EMERGENCY, 'extra' => 1)),
+            array(array('datetime' => 1, 'message' => 1, 'channel' => 1, 'level' => Logger::EMERGENCY, 'extra' => array(), 'context' => 1)),
+        );
     }
 
     /**


### PR DESCRIPTION
If somebody pass incorrect input array to `format`, php will raise several notices, because no any checks performed before access to array indexes.
Please review.