### PR TITLE
Added support for swift message customization in SwiftMailerHandler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "ruflin/elastica": "0.90.*",
         "doctrine/couchdb": "~1.0@dev",
         "aws/aws-sdk-php": "~2.4, >2.4.8",
-        "videlalvaro/php-amqplib": "~2.4"
+        "videlalvaro/php-amqplib": "~2.4",
+        "swiftmailer/swiftmailer": "5.*"
     },
     "suggest": {
         "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
@@ -34,7 +35,8 @@
         "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
         "ext-mongo": "Allow sending log messages to a MongoDB server",
         "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
-        "rollbar/rollbar": "Allow sending log messages to Rollbar"
+        "rollbar/rollbar": "Allow sending log messages to Rollbar",
+        "swiftmailer/swiftmailer": "Allow sending (buffered) log messages via Swiftmailer"
     },
     "autoload": {
         "psr-4": {"Monolog\\": "src/Monolog"}

--- a/src/Monolog/Handler/SwiftMailerHandler.php
+++ b/src/Monolog/Handler/SwiftMailerHandler.php
@@ -43,14 +43,26 @@ class SwiftMailerHandler extends MailHandler
     }
 
     /**
-     * {@inheritdoc}
+     * Returns a \Swift_Message instance
+     *
+     * @param string $content
+     * @param array  $records
+     * @return \Swift_Message
      */
-    protected function send($content, array $records)
+    protected function getMessage($content, array $records)
     {
         $message = clone $this->message;
         $message->setBody($content);
         $message->setDate(time());
 
-        $this->mailer->send($message);
+        return $message;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function send($content, array $records)
+    {
+        $this->mailer->send($this->getMessage($content, $records));
     }
 }

--- a/tests/Monolog/Handler/SwiftMailerHandlerTest.php
+++ b/tests/Monolog/Handler/SwiftMailerHandlerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Logger;
+use Monolog\TestCase;
+
+/**
+ * @author Iltar van der Berg <ivanderberg@hostnet.nl>
+ * @covers Monolog\Handler\SwiftMailerHandler
+ */
+class SwiftMailerHandlerTest extends TestCase
+{
+    private $mailer;
+
+    public function setUp()
+    {
+        $this->mailer = $this
+            ->getMockBuilder('Swift_Mailer')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * @dataProvider sendProvider
+     */
+    public function testSend($message)
+    {
+        $handler = new SwiftMailerHandler($this->mailer, $message);
+        $this->send($handler, is_callable($message) ? $message() : $message);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testConstructorSafeGuard()
+    {
+        new SwiftMailerHandler($this->mailer, null);
+    }
+
+
+    public function sendProvider()
+    {
+        $message = new \Swift_Message();
+        return array(
+            array(new \Swift_Message()),
+            array(function () use ($message) { return $message; }), // to make sure we have the same instance every call
+        );
+    }
+
+    private function send(SwiftMailerHandler $handler, \Swift_Message $message)
+    {
+        $newBody = 'henk';
+
+        $this->mailer
+            ->expects($this->once())
+            ->method('send')
+            ->with($this->callback(function ($value) use ($message, $newBody) {
+                return $value instanceof \Swift_Message && $value !== $message && $value->getBody() === $newBody;
+            }));
+
+        $oldBody = $message->getBody();
+
+        $c = new \ReflectionClass($handler);
+        $m = $c->getMethod('send');
+        $m->setAccessible(true);
+        $m->invoke($handler, $newBody, array());
+        $m->setAccessible(false);
+
+        $this->assertEquals($oldBody, $message->getBody());
+    }
+}


### PR DESCRIPTION
Currently it's not possible to dynamically alter the `Swift_Message` instance. This because the message is created and injected in the constructor. My goal is to create a dynamic subject and optionally add custom headers based on the `$context` provided in the `$records`. This will allow proper filtering to inboxes and make it easier to determine what the log is about if you decide to customize it. 

I couldn't change the `Swift_Message` instance because I had no access to it. The only existing way of doing so would be to overwrite the `send()` method. This however, seems very ugly when you work in Symfony for example. The problem here is that Symfony extends the Swift handler and [adds some custom logic to the `send()` method](https://github.com/symfony/MonologBridge/blob/master/Handler/SwiftMailerHandler.php#L64-L66). If I want to omit the parent `send()`, I will have to overwrite this `send()` which will make it fragile with updates/bug fixes.

This PR will allow people to extend the whole tree and only overwrite the `getMessage()` method. This will allow you to "pre-process" the data and add headers, a different subject, a CC on critical messages etc. 

List of things added:
 - `getMessage()` in `SwiftMailerHandler`.
 - `suggest` on `swiftmailer/swiftmailer`.
 - `require-dev` on `swiftmailer/swiftmailer` for unit-tests.
 - A unit-test for the `SwiftMailerHandler`.