### PR TITLE
Restore ability to continue using mlehner/gelf-php in test

### DIFF
--- a/tests/Monolog/Handler/GelfHandlerLegacyTest.php
+++ b/tests/Monolog/Handler/GelfHandlerLegacyTest.php
@@ -23,6 +23,8 @@ class GelfHandlerLegacyTest extends TestCase
         if (!class_exists('Gelf\MessagePublisher') || !class_exists('Gelf\Message')) {
             $this->markTestSkipped("mlehner/gelf-php not installed");
         }
+
+        require_once __DIR__ . '/GelfMocks.php';
     }
 
     /**

--- a/tests/Monolog/Handler/GelfMocks.php
+++ b/tests/Monolog/Handler/GelfMocks.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Gelf\MessagePublisher;
+use Gelf\Message;
+
+class MockMessagePublisher extends MessagePublisher
+{
+    public function publish(Message $message)
+    {
+        $this->lastMessage = $message;
+    }
+
+    public $lastMessage = null;
+}


### PR DESCRIPTION
Was previously broken by a coding standard commit 392ef35fd470638e08d0160d6b1cbab63cb23174 that removed some mock files necessary to execute the tests when graylog2/gelf-php is deleted and mlehner/gelf-php is installed instead. This is hidden from normal test suite runs because the tests are skipped when mlehner/gelf-php is not installed.

You can check that this wasn't working against the master branch by doing the following:

    $ composer require --dev mlehner/gelf-php
    $ rm -rfd vendor/graylog2
    $ vendor/bin/phpunit

I was working on another contribution and wondered why so many tests were skipped in the Monolog test suite. I found this issue after digging into a few of the skips.

I'm not 100% sure on the history of the mlehner/gelf-php and graylog2/gelf-php packages, but the tests showed they should support both packages. So maybe we either accept this PR, or remove support for mlehner/gelf-php?