### PR TITLE
Nette Framework integration

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -271,6 +271,7 @@ Frameworks Integration
 - [Slim](http://www.slimframework.com/) is usable with Monolog via the [Slim-Monolog](https://github.com/Flynsarmy/Slim-Monolog) log writer.
 - [XOOPS 2.6](http://xoops.org/) comes out of the box with Monolog.
 - [Aura.Web_Project](https://github.com/auraphp/Aura.Web_Project) comes out of the box with Monolog.
+- [Nette Framework](http://nette.org/en/) can be used with Monolog via [Kdyby/Monolog](https://github.com/Kdyby/Monolog) extension.
 
 Author
 ------


### PR DESCRIPTION
Hi, I've made an integration of Monolog into [Nette Framework](http://nette.org/en/) which has [reasonably big userbase](https://packagist.org/packages/nette/) and is the most popular PHP framework in Czech Republic.