### PR TITLE
#493 Include context in slack extra info.

### DIFF
--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -157,26 +157,47 @@ class SlackHandler extends SocketHandler
             }
 
             if ($this->includeExtra) {
-                $extra = '';
-                foreach ($record['extra'] as $var => $val) {
-                    $extra .= $var.': '.$this->lineFormatter->stringify($val)." | ";
+
+                if (!empty($record['extra'])) {
+
+                    if ($this->useShortAttachment) {
+
+                        $attachment['fields'][] = array(
+                            'title' => "Extra",
+                            'value' => $this->stringify($record['extra']),
+                            'short' => $this->useShortAttachment
+                        );
+                    } else {
+                        // Add all extra fields as individual fields in attachment
+                        foreach ($record['extra'] as $var => $val) {
+                           $attachment['fields'][] = array(
+                                'title' => $var,
+                                'value' => $val,
+                                'short' => $this->useShortAttachment
+                           );
+                        }
+                    }
                 }
 
-                $extra = rtrim($extra, " |");
+                if (!empty($record['context'])) {
 
-                $attachment['fields'][] = array(
-                    'title' => "Extra",
-                    'value' => $extra,
-                    'short' => false
-                );
+                    if ($this->useShortAttachment) {
 
-                // Add all context items as individual fields
-                foreach ($record['context'] as $var => $val) {
-                    $attachment['fields'][] = array(
-                        'title' => $var,
-                        'value' => $val,
-                        'short' => true
-                    );
+                        $attachment['fields'][] = array(
+                            'title' => "Context",
+                            'value' => $this->stringify($record['context']),
+                            'short' => $this->useShortAttachment
+                        );
+                    } else {
+                        // Add all context fields as individual fields in attachment
+                        foreach ($record['context'] as $var => $val) {
+                           $attachment['fields'][] = array(
+                                'title' => $var,
+                                'value' => $val,
+                                'short' => $this->useShortAttachment
+                           );
+                        }
+                    }
                 }
             }
 
@@ -239,5 +260,24 @@ class SlackHandler extends SocketHandler
             default:
                 return '#e3e4e6';
         }
+    }
+
+    /**
+     * Stringifys an array of key/value pairs to be used in attachment fields
+     *
+     * @param array $fields
+     * @access protected
+     * @return string
+     */
+    protected function stringify($fields)
+    {
+        $string = '';
+        foreach ($fields as $var => $val) {
+            $string .= $var.': '.$this->lineFormatter->stringify($val)." | ";
+        }
+
+        $string = rtrim($string, " |");
+
+        return $string;
     }
 }

--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -169,6 +169,15 @@ class SlackHandler extends SocketHandler
                     'value' => $extra,
                     'short' => false
                 );
+
+                // Add all context items as individual fields
+                foreach ($record['context'] as $var => $val) {
+                    $attachment['fields'][] = array(
+                        'title' => $var,
+                        'value' => $val,
+                        'short' => true
+                    );
+                }
             }
 
             $dataArray['attachments'] = json_encode(array($attachment));


### PR DESCRIPTION
Adds the context items to Slack attachments.

```
$handler->addError('Foo', array('foo' => 'bar'));
```
![screen shot 2015-02-09 at 22 42 36](https://cloud.githubusercontent.com/assets/33498/6117543/219ff654-b0ad-11e4-8958-30ea93c1fa40.png)
