### PR TITLE
Added overwriting of user context to RavenHandler

### DIFF
--- a/src/Monolog/Handler/RavenHandler.php
+++ b/src/Monolog/Handler/RavenHandler.php
@@ -127,6 +127,8 @@ class RavenHandler extends AbstractProcessingHandler
      */
     protected function write(array $record)
     {
+        // ensures user context is empty
+        $this->ravenClient->user_context(null);
         $options = array();
         $options['level'] = $this->logLevels[$record['level']];
         $options['tags'] = array();
@@ -146,6 +148,10 @@ class RavenHandler extends AbstractProcessingHandler
         }
         if (!empty($record['context'])) {
             $options['extra']['context'] = $record['context'];
+            if (!empty($record['context']['user'])) {
+                $this->ravenClient->user_context($record['context']['user']);
+                unset($options['extra']['context']['user']);
+            }
         }
         if (!empty($record['extra'])) {
             $options['extra']['extra'] = $record['extra'];

--- a/tests/Monolog/Handler/RavenHandlerTest.php
+++ b/tests/Monolog/Handler/RavenHandlerTest.php
@@ -85,6 +85,26 @@ class RavenHandlerTest extends TestCase
         $this->assertEquals($tags, $ravenClient->lastData['tags']);
     }
 
+    public function testUserContext()
+    {        
+        $ravenClient = $this->getRavenClient();
+        $handler = $this->getHandler($ravenClient);
+
+        $user = array(
+            'id' => '123', 
+            'email' => 'test@test.com'
+        );
+        $record = $this->getRecord(Logger::INFO, "test", array('user' => $user));
+
+        $handler->handle($record);
+        $this->assertEquals($user, $ravenClient->context->user);
+
+        $secondRecord = $this->getRecord(Logger::INFO, "test without user");
+
+        $handler->handle($secondRecord);
+        $this->assertNull($ravenClient->context->user);
+    }
+
     public function testException()
     {
         $ravenClient = $this->getRavenClient();


### PR DESCRIPTION
Its not currently possible to set user context in RavenHandler (for getsentry.com), this PR adds the functionality and related test. 