### PR TITLE
Make Swift_Message more easily customizable and lazy when sending email

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "ruflin/elastica": "0.90.*",
         "doctrine/couchdb": "~1.0@dev",
         "aws/aws-sdk-php": "~2.4, >2.4.8",
-        "videlalvaro/php-amqplib": "~2.4"
+        "videlalvaro/php-amqplib": "~2.4",
+        "swiftmailer/swiftmailer": "~5.3"
     },
     "suggest": {
         "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",

--- a/src/Monolog/Handler/SwiftMailerHandler.php
+++ b/src/Monolog/Handler/SwiftMailerHandler.php
@@ -42,22 +42,23 @@ class SwiftMailerHandler extends MailHandler
      */
     protected function send($content, array $records)
     {
-        $this->mailer->send($this->buildMessage($content));
+        $this->mailer->send($this->buildMessage($content, $records));
     }
 
     /**
      * Creates instance of Swift_Message to be sent
      *
      * @param string $content
+     * @param array  $records Log records that formed the content
      * @return \Swift_Message
      */
-    protected function buildMessage($content)
+    protected function buildMessage($content, array $records)
     {
         $message = null;
         if ($this->message instanceof \Swift_Message) {
             $message = clone $this->message;
         } else if (is_callable($this->message)) {
-            $message = call_user_func($this->message);
+            $message = call_user_func($this->message, $content, $records);
         }
 
         if (!$message instanceof \Swift_Message) {

--- a/tests/Monolog/Handler/SwiftMailerHandlerTest.php
+++ b/tests/Monolog/Handler/SwiftMailerHandlerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Monolog\Handler;
+
+use Monolog\Logger;
+use Monolog\TestCase;
+
+class SwiftMailerHandlerTest extends TestCase
+{
+    /** @var \Swift_Mailer|\PHPUnit_Framework_MockObject_MockObject */
+    private $mailer;
+
+    public function setUp()
+    {
+        $this->mailer = $this
+            ->getMockBuilder('Swift_Mailer')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function testMessageCreationIsLazyWhenUsingCallback()
+    {
+        $this->mailer->expects($this->never())
+            ->method('send');
+
+        $callback = function () {
+            throw new \RuntimeException('Swift_Message creation callback should not have been called in this test');
+        };
+        $handler = new SwiftMailerHandler($this->mailer, $callback);
+
+        $records = [
+            $this->getRecord(Logger::DEBUG),
+            $this->getRecord(Logger::INFO),
+        ];
+        $handler->handleBatch($records);
+    }
+}


### PR DESCRIPTION
This is an alternate implementation of #497 that not only allows customization of Swift_Message based on logged data, but also adds a performance gain when using the Swift_Message callback option. There is one possible BC break for anyone extending SwiftMailerHandler. See the bottom of this PR.

### Added Swift_Mailer as a dev dependency

New test cases exercise SwiftMailerHandler using real instances of Swift_Message.

### SwiftMailerHandler subclasses can customize Swift_Message given logged data

Prior to this PR a `SwiftMailerHandler` subclass had to override the entire `send()` method to customize the sent Swift_Message. After this PR subclasses can instead override the `buildMessage()` function. This was originally proposed in #497 and the implementation here is mostly the same.

Customizing the sent Swift_Message in a subclass:
```php
class CustomSwiftMailerHandler extends SwiftMailerHandler
{
    protected function buildMessage($content, array $records)
    {
        $subject = 'Error Occurred';
        if (count($records) > 1) {
            $subject = 'Many Errors Occurred';
        }

        $message = new \Swift_Message;
        $message->setSubject($subject);

        return $message;
    }
}
```

### SwiftMailerHandler Swift_Message callback now supports customization given logged data

The constructor callable is now passed two new arguments: the logged contents and logged records. Either could be used to further customized the sent Swift_Message.

```php
$callback = function ($content, array $records) {
    $subject = 'Error Occurred';
    if (count($records) > 1) {
        $subject = 'Many Errors Occurred';
    }

    $message = new \Swift_Message;
    $message->setSubject($subject);

    return $message;
};

$handler = new SwiftMailerHandler($mailer, $callback);
```

Using a callback to customize Swift_Message has been supported by the Symfony MonologBundle for some time: https://github.com/symfony/MonologBundle/blob/master/DependencyInjection/MonologExtension.php#L389

```yaml
monolog:
    handlers:
        # ... snipped some other config here ...
        swift:
            type:       swift_mailer
            level:      error
            # Below service builds the Swift_Message that will be sent
            email_prototype:
                id: my_error_email_prototype
                method: buildMessage
```

### Swift_Message callback is now only invoked when mail will be sent

For most applications, sending email as part of any request is a rare event. In addition, SwiftMailerHandler currently only sends email when a message is logged with ERROR severity. Handling an ERROR message in most applications should be even more rare than sending normal lifecycle emails.

Laziness is desired for performance reasons. Prior to this PR, a Swift_Message object would be instantiated even if no email was sent because SwiftMailerHandler constructor required an injected Swift_Message OR the callback to create a Swift_Message was always invoked. After this PR the callback is only invoked if an email is going to be sent. (Any code injecting a Swift_Message object will of course still incur the expense to instantiate it.)

In fact Symfony MonologBundle specifically [makes Swift_Message creation lazy](https://github.com/symfony/MonologBundle/pull/109) when not specifying a callback function. (The linked PR alludes to how expensive it is to instantiate Swift_Message.) This PR adds lazy support to MonologBundle when a callback is configured.

### Potential Backwards Compatibility break for subclasses using SwiftMailerHandler `$this->message`

Before this PR a SwiftMailerHandler subclass could always assume `$this->message` was an instance of Swift_Message because the constructor stores the injected Swift_Message or resolves the callable to create a Swift_Message.

If you always inject a Swift_Message object, no change is necessary. But if your subclass allows a developer to inject a Swift_Message OR a callback, you'll need to call `$this->buildMessage()` instead of `$this->message`

I would be open to fully removing `protected $message;` and replacing it with `private $template;` and `protected function buildMessage()`. This way the callable vs injected Swift_Message is private implementation details, and anyone relying on `$this->message` being present would see a more obvious error message that it no longer exists.