### PR TITLE
Use data.logentries.com and port 443 instead of api

### DIFF
--- a/src/Monolog/Handler/LogEntriesHandler.php
+++ b/src/Monolog/Handler/LogEntriesHandler.php
@@ -37,7 +37,7 @@ class LogEntriesHandler extends SocketHandler
             throw new MissingExtensionException('The OpenSSL PHP plugin is required to use SSL encrypted connection for LogEntriesHandler');
         }
 
-        $endpoint = $useSSL ? 'ssl://api.logentries.com:20000' : 'data.logentries.com:80';
+        $endpoint = $useSSL ? 'ssl://data.logentries.com:443' : 'data.logentries.com:80';
         parent::__construct($endpoint, $level, $bubble);
         $this->logToken = $token;
     }


### PR DESCRIPTION
It's preferable to be using data.logentries.com when sending Token Based logs.

Also it's nicer if we use port 443 since it is more then likely going to be open compared to port 20000 in environments. 