### PR TITLE
Return self from NativeMailerHandler::addHeader().

### DIFF
--- a/src/Monolog/Handler/NativeMailerHandler.php
+++ b/src/Monolog/Handler/NativeMailerHandler.php
@@ -78,7 +78,7 @@ class NativeMailerHandler extends MailHandler
      * Add headers to the message
      *
      * @param  string|array $headers Custom added headers
-     * @return null
+     * @return self
      */
     public function addHeader($headers)
     {
@@ -88,6 +88,8 @@ class NativeMailerHandler extends MailHandler
             }
             $this->headers[] = $header;
         }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
NativeMailerHandler::setContentType() and NativeMailerHandler::setEncoding() both return the NativeMailerHandler object, allowing a fluent coding style.  This fix adds the same behaviour to NativeMailerHandler::addHeader() for so that all public non-inherited methods behave this way for consistency.