### PR TITLE
Add AirbrakeHandler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "doctrine/couchdb": "~1.0@dev",
         "aws/aws-sdk-php": "~2.4, >2.4.8",
         "videlalvaro/php-amqplib": "~2.4",
-        "swiftmailer/swiftmailer": "~5.3"
+        "swiftmailer/swiftmailer": "~5.3",
+        "dbtlr/php-airbrake": "~1.1"
     },
     "suggest": {
         "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
@@ -35,7 +36,8 @@
         "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
         "ext-mongo": "Allow sending log messages to a MongoDB server",
         "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
-        "rollbar/rollbar": "Allow sending log messages to Rollbar"
+        "rollbar/rollbar": "Allow sending log messages to Rollbar",
+        "dbtlr/php-airbrake": "Allow sending log messages to Airbrake/Errbit"
     },
     "autoload": {
         "psr-4": {"Monolog\\": "src/Monolog"}

--- a/src/Monolog/Handler/AirbrakeHandler.php
+++ b/src/Monolog/Handler/AirbrakeHandler.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Airbrake\Client;
+use Airbrake\Notice;
+use Exception;
+use Monolog\Logger;
+
+/**
+ * Sends errors to Airbrake
+ */
+class AirbrakeHandler extends AbstractProcessingHandler
+{
+    /**
+     * Airbrake client
+     *
+     * @var Client
+     */
+    protected $airbrakeClient;
+
+    /**
+     * @param Client  $airbrakeClient The Airbrake client object which will be used to send the log messages
+     * @param integer $level          The minimum logging level at which this handler will be triggered
+     * @param boolean $bubble         Whether the messages that are handled can bubble up the stack or not
+     */
+    public function __construct(Client $airbrakeClient, $level = Logger::ERROR, $bubble = true)
+    {
+        $this->airbrakeClient = $airbrakeClient;
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function write(array $record)
+    {
+        if (isset($record['context']['exception']) && $record['context']['exception'] instanceof Exception) {
+            $this->airbrakeClient->notifyOnException($record['context']['exception']);
+        } else {
+            $extraParameters = array(
+                'level'    => $record['level'],
+                'channel'  => $record['channel'],
+                'datetime' => $record['datetime']->format('U'),
+            );
+
+            $notice = new Notice();
+            $notice->load(array(
+                'errorClass'      => $record['level_name'],
+                'errorMessage'    => $record['message'],
+                'backtrace'       => debug_backtrace(),
+                'extraParameters' => array_merge($record['context'], $record['extra'], $extraParameters),
+            ));
+
+            $this->airbrakeClient->notify($notice);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds `AirbrakeHandler` to send logs to [Airbrake][1] or any self-hosted [Errbit][2] instance.

At the moment the constructor takes an `Airbrake\Client` object (very similar to `RollbarHandler`). Just leave me a message if I should do the instantiation and configuration of the `Client` object in the constructor.

Any feedback is welcome!

[1]: https://airbrake.io/
[2]: http://errbit.github.io/errbit/