### PR TITLE
Add strpos based TestHandler methods

### DIFF
--- a/src/Monolog/Handler/TestHandler.php
+++ b/src/Monolog/Handler/TestHandler.php
@@ -129,6 +129,61 @@ class TestHandler extends AbstractProcessingHandler
         return false;
     }
 
+    public function hasEmergencyThatContains($message)
+    {
+        return $this->hasRecordThatContains($message, Logger::EMERGENCY);
+    }
+
+    public function hasAlertThatContains($message)
+    {
+        return $this->hasRecordThatContains($message, Logger::ALERT);
+    }
+
+    public function hasCriticalThatContains($message)
+    {
+        return $this->hasRecordThatContains($message, Logger::CRITICAL);
+    }
+
+    public function hasErrorThatContains($message)
+    {
+        return $this->hasRecordThatContains($message, Logger::ERROR);
+    }
+
+    public function hasWarningThatContains($message)
+    {
+        return $this->hasRecordThatContains($message, Logger::WARNING);
+    }
+
+    public function hasNoticeThatContains($message)
+    {
+        return $this->hasRecordThatContains($message, Logger::NOTICE);
+    }
+
+    public function hasInfoThatContains($message)
+    {
+        return $this->hasRecordThatContains($message, Logger::INFO);
+    }
+
+    public function hasDebugThatContains($message)
+    {
+        return $this->hasRecordThatContains($message, Logger::DEBUG);
+    }
+
+    public function hasRecordThatContains($message, $level)
+    {
+        if (!isset($this->recordsByLevel[$level])) {
+            return false;
+        }
+
+        foreach ($this->recordsByLevel[$level] as $rec) {
+            if (strpos($rec['message'], $message) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/tests/Monolog/Handler/TestHandlerTest.php
+++ b/tests/Monolog/Handler/TestHandlerTest.php
@@ -27,12 +27,14 @@ class TestHandlerTest extends TestCase
         $handler = new TestHandler;
         $record = $this->getRecord($level, 'test'.$method);
         $this->assertFalse($handler->{'has'.$method}($record));
+        $this->assertFalse($handler->{'has'.$method.'ThatContains'}('test'));
         $this->assertFalse($handler->{'has'.$method.'Records'}());
         $handler->handle($record);
 
         $this->assertFalse($handler->{'has'.$method}('bar'));
         $this->assertTrue($handler->{'has'.$method}($record));
         $this->assertTrue($handler->{'has'.$method}('test'.$method));
+        $this->assertTrue($handler->{'has'.$method.'ThatContains'}('test'));
         $this->assertTrue($handler->{'has'.$method.'Records'}());
 
         $records = $handler->getRecords();


### PR DESCRIPTION
These methods allow for writing tests with partial log matches. For example:

```php
$this->assertTrue(
   $this->logHandler->hasErrorThatContains('The connection to the server has failed')
);

$this->assertTrue(
   $this->logHandler->hasErrorThatContains('status 500')
);
```