### PR TITLE
Making SlackHandler more extendable

### DIFF
--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -121,18 +121,31 @@ class SlackHandler extends SocketHandler
      */
     private function buildContent($record)
     {
+        $dataArray = $this->prepareContentData($record);
+
+        return http_build_query($dataArray);
+    }
+
+    /**
+     * Prepares content data
+     *
+     * @param  array $record
+     * @return array
+     */
+    protected function prepareContentData($record)
+    {
         $dataArray = array(
-            'token' => $this->token,
-            'channel' => $this->channel,
-            'username' => $this->username,
-            'text' => '',
+            'token'       => $this->token,
+            'channel'     => $this->channel,
+            'username'    => $this->username,
+            'text'        => '',
             'attachments' => array()
         );
 
         if ($this->useAttachment) {
             $attachment = array(
                 'fallback' => $record['message'],
-                'color' => $this->getAttachmentColor($record['level'])
+                'color'    => $this->getAttachmentColor($record['level'])
             );
 
             if ($this->useShortAttachment) {
@@ -173,7 +186,7 @@ class SlackHandler extends SocketHandler
                                 'title' => $var,
                                 'value' => $val,
                                 'short' => $this->useShortAttachment
-                           );
+                            );
                         }
                     }
                 }
@@ -192,7 +205,7 @@ class SlackHandler extends SocketHandler
                                 'title' => $var,
                                 'value' => $val,
                                 'short' => $this->useShortAttachment
-                           );
+                            );
                         }
                     }
                 }
@@ -206,8 +219,7 @@ class SlackHandler extends SocketHandler
         if ($this->iconEmoji) {
             $dataArray['icon_emoji'] = ":{$this->iconEmoji}:";
         }
-
-        return http_build_query($dataArray);
+        return $dataArray;
     }
 
     /**


### PR DESCRIPTION
Now it is impossible to add additional data fields to Slack request without copying large pieces of code or without dirty hacks. Fixing this.