### PR TITLE
Added a continue if we encounter a function/method.

### DIFF
--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -56,7 +56,12 @@ class IntrospectionProcessor
 
         $i = 0;
 
-        while (isset($trace[$i]['class'])) {
+        while ($i < = count($trace)) {
+            
+            if (array_key_exists('class', $trace[$i]) === false) {
+                continue;
+            }
+            
             foreach ($this->skipClassesPartials as $part) {
                 if (strpos($trace[$i]['class'], $part) !== false) {
                     $i++;

--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -56,7 +56,7 @@ class IntrospectionProcessor
 
         $i = 0;
 
-        while ($i < = count($trace)) {
+        while ($i <= count($trace)) {
             
             if (array_key_exists('class', $trace[$i]) === false) {
                 continue;

--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -59,6 +59,7 @@ class IntrospectionProcessor
         while ($i <= count($trace)) {
             
             if (array_key_exists('class', $trace[$i]) === false) {
+                $i++;
                 continue;
             }
             


### PR DESCRIPTION
Because IntrospectionProcessor has made the assumption that the calling would never be within a plain old function it doesn't work properly in frameworks like Laravel who relies heavily on call_user_func.

As the code is now when you call it, it stops at the call_user_func and looks one back which may or may not be accurate and causes unexpected behavior.

The changes I've made removed the hard dependency on every part of the trace being in a class.