### PR TITLE
made raven user context less destructive

### DIFF
--- a/src/Monolog/Handler/RavenHandler.php
+++ b/src/Monolog/Handler/RavenHandler.php
@@ -127,8 +127,7 @@ class RavenHandler extends AbstractProcessingHandler
      */
     protected function write(array $record)
     {
-        // ensures user context is empty
-        $this->ravenClient->user_context(null);
+        $previousUserContext = false;
         $options = array();
         $options['level'] = $this->logLevels[$record['level']];
         $options['tags'] = array();
@@ -149,6 +148,7 @@ class RavenHandler extends AbstractProcessingHandler
         if (!empty($record['context'])) {
             $options['extra']['context'] = $record['context'];
             if (!empty($record['context']['user'])) {
+                $previousUserContext = $this->ravenClient->context->user;
                 $this->ravenClient->user_context($record['context']['user']);
                 unset($options['extra']['context']['user']);
             }
@@ -160,11 +160,14 @@ class RavenHandler extends AbstractProcessingHandler
         if (isset($record['context']['exception']) && $record['context']['exception'] instanceof \Exception) {
             $options['extra']['message'] = $record['formatted'];
             $this->ravenClient->captureException($record['context']['exception'], $options);
-
-            return;
+        } else {
+            $this->ravenClient->captureMessage($record['formatted'], array(), $options);
         }
 
-        $this->ravenClient->captureMessage($record['formatted'], array(), $options);
+        if ($previousUserContext !== false) {
+            $this->ravenClient->user_context($previousUserContext);
+        }
+
     }
 
     /**

--- a/tests/Monolog/Handler/MockRavenClient.php
+++ b/tests/Monolog/Handler/MockRavenClient.php
@@ -17,6 +17,7 @@ class MockRavenClient extends Raven_Client
 {
     public function capture($data, $stack, $vars = null)
     {
+        $data = array_merge($this->get_user_data(), $data);
         $this->lastData = $data;
         $this->lastStack = $stack;
     }


### PR DESCRIPTION
as discussed in c1fd9cddf2f2d4f49dc56cb647681ee086c6fca3, the `$this->ravenClient->user_context(null)` was too destructive in a hybrid use case. This PR fixes it. 

Changes made:

* changed logic from "reset first" into a "reset if user context exists"
* added assertions that verify newly discovered use cases won't break
* used single quotes for strings