### PR TITLE
Optimize replace new lines for LineFormatter

### DIFF
--- a/src/Monolog/Formatter/LineFormatter.php
+++ b/src/Monolog/Formatter/LineFormatter.php
@@ -154,6 +154,6 @@ class LineFormatter extends NormalizerFormatter
             return $str;
         }
 
-        return strtr($str, array("\r\n" => ' ', "\r" => ' ', "\n" => ' '));
+        return str_replace(array("\r\n", "\r", "\n"), ' ', $str);
     }
 }


### PR DESCRIPTION
After profile code with XHProf, i find a many uses for LineFormatter::replaceNewLines. After replace calls strtr to str_replace, called time is halved.

With use strtr: http://prntscr.com/6tycs1
With use str_replace: http://prntscr.com/6tycw8

Script:

```php
$replaceTime = 0;
$trTime = 0;

$line = "This is a testing line for benchmarking:\nstrtr vs str_replace\r\nSecond line\nThird line";

for ($i = 0; $i < 10000; $i++) {
    $time = microtime(true);
    $newLine = str_replace(["\r\n", "\n"], '', $line);
    $replaceTime += microtime(true) - $time;

    $time = microtime(true);
    $newLine = strtr($line, ["\r\n" => ' ', "\n" => ' ']);
    $trTime += microtime(true) - $time;
}

print sprintf(
    "Replace: %f\nStrtr: %s\n",
    $replaceTime,
    $trTime
);
```

Thank.