### PR TITLE
Added Lumen to list of supported frameworks

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -266,6 +266,7 @@ Frameworks Integration
 - [Symfony2](http://symfony.com) comes out of the box with Monolog.
 - [Silex](http://silex.sensiolabs.org/) comes out of the box with Monolog.
 - [Laravel 4 & 5](http://laravel.com/) come out of the box with Monolog.
+- [Lumen](http://lumen.laravel.com/) comes out of the box with Monolog.
 - [PPI](http://www.ppi.io/) comes out of the box with Monolog.
 - [CakePHP](http://cakephp.org/) is usable with Monolog via the [cakephp-monolog](https://github.com/jadb/cakephp-monolog) plugin.
 - [Slim](http://www.slimframework.com/) is usable with Monolog via the [Slim-Monolog](https://github.com/Flynsarmy/Slim-Monolog) log writer.


### PR DESCRIPTION
Added Lumen, because why not.

Signed-off-by: Jeroen v.d. Gulik <jeroen@isset.nl>