### PR TITLE
Removed a small code duplication, and added Logger::toMonologLevel() tests.

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -438,10 +438,8 @@ class Logger implements LoggerInterface
      */
     public function log($level, $message, array $context = array())
     {
-        if (is_string($level) && defined(__CLASS__.'::'.strtoupper($level))) {
-            $level = constant(__CLASS__.'::'.strtoupper($level));
-        }
-
+        $level = static::toMonologLevel($level);
+        
         return $this->addRecord($level, $message, $context);
     }
 

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -34,6 +34,21 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Monolog\Logger::toMonologLevel
+     */
+    public function testConvertPSR3ToMonologLevel()
+    {
+        $this->assertEquals(Logger::toMonologLevel('debug'), 100);
+        $this->assertEquals(Logger::toMonologLevel('info'), 200);
+        $this->assertEquals(Logger::toMonologLevel('notice'), 250);
+        $this->assertEquals(Logger::toMonologLevel('warning'), 300);
+        $this->assertEquals(Logger::toMonologLevel('error'), 400);
+        $this->assertEquals(Logger::toMonologLevel('critical'), 500);
+        $this->assertEquals(Logger::toMonologLevel('alert'), 550);
+        $this->assertEquals(Logger::toMonologLevel('emergency'), 600);
+    }
+
+    /**
      * @covers Monolog\Logger::getLevelName
      * @expectedException InvalidArgumentException
      */


### PR DESCRIPTION
This is a rather small change, but keeping things DRY is always a good thing.
I removed the duplicated logic and replaced it with a `Monolog\Logger::toMonologLevel()` call.
Plus added the tests that cover that method.