### PR TITLE
Update LogglyHandler.php

### DIFF
--- a/src/Monolog/Handler/LogglyHandler.php
+++ b/src/Monolog/Handler/LogglyHandler.php
@@ -19,6 +19,7 @@ use Monolog\Formatter\LogglyFormatter;
  *
  * @author Przemek Sobstel <przemek@sobstel.org>
  * @author Adam Pancutt <adam@pancutt.com>
+ * @author Gregory Barchard <gregory@barchard.net>
  */
 class LogglyHandler extends AbstractProcessingHandler
 {
@@ -28,7 +29,7 @@ class LogglyHandler extends AbstractProcessingHandler
 
     protected $token;
 
-    protected $tag;
+    protected $tags = array();
 
     public function __construct($token, $level = Logger::DEBUG, $bubble = true)
     {
@@ -43,12 +44,16 @@ class LogglyHandler extends AbstractProcessingHandler
 
     public function setTag($tag)
     {
-        $this->tag = $tag;
+        $tag = !empty($tag) ? $tag : array();
+        $this->tags = is_array($tag) ? $tag : array($tag);
     }
 
     public function addTag($tag)
     {
-        $this->tag = (strlen($this->tag) > 0) ? $this->tag .','. $tag : $tag;
+        if (!empty($tag)) {
+            $tag = is_array($tag) ? $tag : array($tag);
+            $this->tags = array_merge($this->tags, $tag);
+        }
     }
 
     protected function write(array $record)
@@ -75,8 +80,8 @@ class LogglyHandler extends AbstractProcessingHandler
 
         $headers = array('Content-Type: application/json');
 
-        if ($this->tag) {
-            $headers[] = "X-LOGGLY-TAG: {$this->tag}";
+        if (!empty($this->tags)) {
+            $headers[] = 'X-LOGGLY-TAG: '.implode(',', $this->tags);
         }
 
         $ch = curl_init();

--- a/src/Monolog/Handler/LogglyHandler.php
+++ b/src/Monolog/Handler/LogglyHandler.php
@@ -29,7 +29,7 @@ class LogglyHandler extends AbstractProcessingHandler
 
     protected $token;
 
-    protected $tags = array();
+    protected $tag = array();
 
     public function __construct($token, $level = Logger::DEBUG, $bubble = true)
     {
@@ -45,14 +45,14 @@ class LogglyHandler extends AbstractProcessingHandler
     public function setTag($tag)
     {
         $tag = !empty($tag) ? $tag : array();
-        $this->tags = is_array($tag) ? $tag : array($tag);
+        $this->tag = is_array($tag) ? $tag : array($tag);
     }
 
     public function addTag($tag)
     {
         if (!empty($tag)) {
             $tag = is_array($tag) ? $tag : array($tag);
-            $this->tags = array_merge($this->tags, $tag);
+            $this->tag = array_unique(array_merge($this->tag, $tag));
         }
     }
 
@@ -80,8 +80,8 @@ class LogglyHandler extends AbstractProcessingHandler
 
         $headers = array('Content-Type: application/json');
 
-        if (!empty($this->tags)) {
-            $headers[] = 'X-LOGGLY-TAG: '.implode(',', $this->tags);
+        if (!empty($this->tag)) {
+            $headers[] = 'X-LOGGLY-TAG: '.implode(',', $this->tag);
         }
 
         $ch = curl_init();


### PR DESCRIPTION
Add the ability to set multiple tags via a single call. Tags are now an array and imploded instead of appended. This prevents duplicate tags from being added.