### PR TITLE
Multi array

### DIFF
--- a/src/Monolog/Processor/PsrLogMessageProcessor.php
+++ b/src/Monolog/Processor/PsrLogMessageProcessor.php
@@ -37,7 +37,7 @@ class PsrLogMessageProcessor
             } elseif (is_object($val)) {
                 $replacements['{'.$key.'}'] = '[object '.get_class($val).']';
             } else {
-                $replacements['{'.$key.'}'] = '['.gettype($val).']';
+                $replacements['{'.$key.'}'] = '['.gettype($val). ' ' .$key. ']';
             }
         }
 

--- a/tests/Monolog/Processor/PsrLogMessageProcessorTest.php
+++ b/tests/Monolog/Processor/PsrLogMessageProcessorTest.php
@@ -37,7 +37,7 @@ class PsrLogMessageProcessorTest extends \PHPUnit_Framework_TestCase
             array(true,     '1'),
             array(false,    ''),
             array(new \stdClass, '[object stdClass]'),
-            array(array(), '[array]'),
+            array(array(), '[array foo]'),
         );
     }
 }


### PR DESCRIPTION
When we have more than other one array (or non scalar type) the log message after replacement looks like "some string ... [array] [array]". 

I think we should add the key to identity the array or maybe we can create a special case for array using json_decode or implode? 