### PR TITLE
Added self-referenced returns to get fluent interfaces

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -152,10 +152,12 @@ class Logger implements LoggerInterface
      * Pushes a handler on to the stack.
      *
      * @param HandlerInterface $handler
+     * @return $this
      */
     public function pushHandler(HandlerInterface $handler)
     {
         array_unshift($this->handlers, $handler);
+        return $this;
     }
 
     /**
@@ -184,6 +186,7 @@ class Logger implements LoggerInterface
      * Adds a processor on to the stack.
      *
      * @param callable $callback
+     * @return $this
      */
     public function pushProcessor($callback)
     {
@@ -191,6 +194,7 @@ class Logger implements LoggerInterface
             throw new \InvalidArgumentException('Processors must be valid callables (callback or object with an __invoke method), '.var_export($callback, true).' given');
         }
         array_unshift($this->processors, $callback);
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Added self-referenced returns to get fluent interfaces for `Monolog\Logger::pushProcessor` and `Monolog\Logger::pushHandler`

For more information, look at the [comment in this file](https://github.com/LoggerEssentials/LoggerEssentials/blob/3e17d9807d0f83cebd0ea183cb43c45c904f8347/docs/index.md#combine-with-monolog).