### PR TITLE
Add SystemdJournalHandler

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -144,6 +144,7 @@ Handlers
 - _LogglyHandler_: Logs records to a [Loggly](http://www.loggly.com/) account.
 - _RollbarHandler_: Logs records to a [Rollbar](https://rollbar.com/) account.
 - _SyslogUdpHandler_: Logs records to a remote [Syslogd](http://www.rsyslog.com/) server.
+- _SystemdJournalHandler_: Logs records to [systemd](http://www.freedesktop.org/wiki/Software/systemd/) journal service.
 - _LogEntriesHandler_: Logs records to a [LogEntries](http://logentries.com/) account.
 
 ### Logging in development

--- a/src/Monolog/Handler/AbstractPosixBasedHandler.php
+++ b/src/Monolog/Handler/AbstractPosixBasedHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Logger;
+
+/**
+ * Base handler for handlers that need to use syslog log priorities.
+ *
+ * @author Damián Nohales <damiannohales@gmail.com>
+ */
+abstract class AbstractPosixBasedHandler extends AbstractProcessingHandler
+{
+    /**
+     * Translates Monolog log levels to syslog log priorities.
+     */
+    protected $logLevels = array(
+        Logger::DEBUG     => LOG_DEBUG,
+        Logger::INFO      => LOG_INFO,
+        Logger::NOTICE    => LOG_NOTICE,
+        Logger::WARNING   => LOG_WARNING,
+        Logger::ERROR     => LOG_ERR,
+        Logger::CRITICAL  => LOG_CRIT,
+        Logger::ALERT     => LOG_ALERT,
+        Logger::EMERGENCY => LOG_EMERG,
+    );
+}

--- a/src/Monolog/Handler/AbstractSyslogHandler.php
+++ b/src/Monolog/Handler/AbstractSyslogHandler.php
@@ -17,23 +17,9 @@ use Monolog\Formatter\LineFormatter;
 /**
  * Common syslog functionality
  */
-abstract class AbstractSyslogHandler extends AbstractProcessingHandler
+abstract class AbstractSyslogHandler extends AbstractPosixBasedHandler
 {
     protected $facility;
-
-    /**
-     * Translates Monolog log levels to syslog log priorities.
-     */
-    protected $logLevels = array(
-        Logger::DEBUG     => LOG_DEBUG,
-        Logger::INFO      => LOG_INFO,
-        Logger::NOTICE    => LOG_NOTICE,
-        Logger::WARNING   => LOG_WARNING,
-        Logger::ERROR     => LOG_ERR,
-        Logger::CRITICAL  => LOG_CRIT,
-        Logger::ALERT     => LOG_ALERT,
-        Logger::EMERGENCY => LOG_EMERG,
-    );
 
     /**
      * List of valid log facility names.

--- a/src/Monolog/Handler/SystemdJournalHandler.php
+++ b/src/Monolog/Handler/SystemdJournalHandler.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Logger;
+
+/**
+ * Logs to systemd-journald service.
+ *
+ * This handler requires the sd_journal_send function from php-systemd
+ * extension (https://github.com/systemd/php-systemd).
+ *
+ * @author Damián Nohales <damiannohales@gmail.com>
+ */
+class SystemdJournalHandler extends AbstractPosixBasedHandler
+{
+    protected $extraFields;
+
+    /**
+     * @param array   $extraFields Extra fields to send to the journal, Monolog will prepend the
+     *                             MONOLOG prefix and will normalize each field name according to
+     *                             the restrictions pointed in sd_journal_print(3) manpage.
+     *                             Example: array(FIELD1 => 'field 1 content', 'FIELD2' => 'field 2 content')
+     * @param integer $level       The minimum logging level at which this handler will be triggered
+     * @param Boolean $bubble      Whether the messages that are handled can bubble up the stack or not
+     */
+    public function __construct($extraFields = array(), $level = Logger::DEBUG, $bubble = true)
+    {
+        $this->checkSystemdExtension();
+
+        parent::__construct($level, $bubble);
+
+        $this->extraFields = $extraFields;
+    }
+
+    /**
+     * Check if the php-systemd extension is properly enabled.
+     */
+    public function checkSystemdExtension()
+    {
+        if (!function_exists('sd_journal_send')) {
+            throw new MissingExtensionException('php-systemd extension is required to use Monolog\'s SystemdJournalHandler (see https://github.com/systemd/php-systemd)');
+        }
+    }
+
+    /**
+     * Convert a "key => value" array to an array of fields to be used with
+     * sd_journal_send.
+     *
+     * @param array  $arr    The array to be converted, the key of each item will be
+     *                       used to generate the field name and the value to set the
+     *                       field value.
+     * @param string $prefix A prefix to prepend to each field name.
+     */
+    private function fieldsFromArray(array $arr, $prefix)
+    {
+        $fields = array();
+
+        foreach ($arr as $name => $value) {
+            $fieldName = preg_replace('/[^A-Z0-9_]/', '', strtoupper($name));
+            $fieldName = ltrim($fieldName, '_');
+            $fields[] = sprintf('%s%s=%s', $prefix, $fieldName, $value);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function write(array $record)
+    {
+        $fields = array();
+
+        $fields[] = sprintf('MESSAGE=%s', (string) $record['message']);
+        $fields[] = sprintf('PRIORITY=%d', $this->logLevels[$record['level']]);
+        $fields[] = sprintf('MONOLOG_CHANNEL=%s', $record['channel']);
+
+        $fields = array_merge($fields, $this->fieldsFromArray($record['context'], 'MONOLOG_CONTEXT_'));
+        $fields = array_merge($fields, $this->fieldsFromArray($record['extra'], 'MONOLOG_EXTRA_'));
+        $fields = array_merge($fields, $this->fieldsFromArray($this->extraFields, 'MONOLOG_HANDLEREXTRA_'));
+
+        $this->sendToJournal($fields);
+    }
+
+    /**
+     * Send log entry to the journal.
+     *
+     * @param array $fields Log entry fields
+     */
+    public function sendToJournal(array $fields)
+    {
+        call_user_func_array('sd_journal_send', $fields);
+    }
+}

--- a/tests/Monolog/Handler/SystemdJournalHandlerTest.php
+++ b/tests/Monolog/Handler/SystemdJournalHandlerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\TestCase;
+use Monolog\Logger;
+
+/**
+ * @covers Monolog\Handler\SystemdJournalHandler
+ */
+class SystemdJournalHandlerTest extends TestCase
+{
+    private function getHandlerMock($arguments)
+    {
+        return $this->getMock('Monolog\Handler\SystemdJournalHandler', array('checkSystemdExtension', 'sendToJournal'), $arguments);
+    }
+
+    public function testWrite()
+    {
+        $handler = $this->getHandlerMock(array());
+
+        $handler->expects($this->exactly(3))
+                ->method('sendToJournal')
+                ->withConsecutive(
+                    array(array(
+                        'MESSAGE=tést1',
+                        'PRIORITY=6',
+                        'MONOLOG_CHANNEL=test',
+                        'MONOLOG_CONTEXT_USERNAME=john'
+                    )),
+                    array(array(
+                        'MESSAGE=tuasst2',
+                        'PRIORITY=4',
+                        'MONOLOG_CHANNEL=test',
+                        'MONOLOG_CONTEXT_USERNAME=mary',
+                        'MONOLOG_CONTEXT_FOOANDBAR_=foo'
+                    )),
+                    array(array(
+                        'MESSAGE= My message',
+                        'PRIORITY=3',
+                        'MONOLOG_CHANNEL=test',
+                        'MONOLOG_CONTEXT_USERNAME=rich',
+                        'MONOLOG_EXTRA_THISISTHEKEY=The value',
+                        'MONOLOG_EXTRA_ANOTHERKEY=Another value',
+                        'MONOLOG_EXTRA_LAST_ONE=This one is well formatted',
+                    ))
+                );
+
+        $handler->handle($this->getRecord(Logger::INFO, 'tést1', array('username' => 'john')));
+        $handler->handle($this->getRecord(Logger::WARNING, 'tuasst2', array('username' => 'mary', '   _foo and BaR_ ' => 'foo')));
+
+        $handler->pushProcessor(function(array $record) {
+            $record['extra']['·$%$&/  This is the Key!!  '] = 'The value';
+            $record['extra']['AnotherKey'] = 'Another value';
+            $record['extra']['LAST_ONE'] = 'This one is well formatted';
+
+            return $record;
+        });
+        $handler->handle($this->getRecord(Logger::ERROR, ' My message', array('username' => 'rich')));
+    }
+
+    public function testWriteWithExtraFields()
+    {
+        $handler = $this->getHandlerMock(array(
+            'extraFields' => array(
+                ' _?¿?¡ T  he key  ' => 'value 1',
+                'FIELD2' => 'value2'
+            )
+        ));
+
+        $handler->expects($this->once())
+                ->method('sendToJournal')
+                ->with(array(
+                    'MESSAGE= My message',
+                    'PRIORITY=0',
+                    'MONOLOG_CHANNEL=test',
+                    'MONOLOG_CONTEXT_USERNAME=rich',
+                    'MONOLOG_EXTRA_THISISTHEKEY=The value',
+                    'MONOLOG_EXTRA_ANOTHERKEY=Another value',
+                    'MONOLOG_EXTRA_LAST_ONE=This one is well formatted',
+                    'MONOLOG_HANDLEREXTRA_THEKEY=value 1',
+                    'MONOLOG_HANDLEREXTRA_FIELD2=value2',
+                ));
+
+        $handler->pushProcessor(function(array $record) {
+            $record['extra']['·$%$&/  This is the Key!!  '] = 'The value';
+            $record['extra']['AnotherKey'] = 'Another value';
+            $record['extra']['LAST_ONE'] = 'This one is well formatted';
+
+            return $record;
+        });
+        $handler->handle($this->getRecord(Logger::EMERGENCY, ' My message', array('username' => 'rich')));
+    }
+}


### PR DESCRIPTION
I just wanted to propose a handler to log to `systemd-journal` service, this is going to give us all the benefits of this service (better search and indexing, better integration with the OS, richer metadata for log records).

To use it, you're gonna need to have [php-systemd extension](https://github.com/systemd/php-systemd) installed in your system.

I have one concern for this PR though, I had to make `checkSystemdExtension` and `sendToJournal` public methods instead of private or protected to make it easy to mock in the tests (we don't want for sure to send real log records during test execution). I could wrap those methods functionality in a separated class but it looked like too much just for test cases stuff. You tell me :)

Thanks!