### PR TITLE
Fix: Wrong raven/raven version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "graylog2/gelf-php": "~1.0",
-        "raven/raven": "~0.5",
+        "raven/raven": "~0.8",
         "ruflin/elastica": "0.90.*",
         "doctrine/couchdb": "~1.0@dev",
         "aws/aws-sdk-php": "~2.4, >2.4.8",


### PR DESCRIPTION
RavenHandler uses Raven_Client::user_context(). This method is available since 0.8.0.

see https://github.com/getsentry/raven-php/commit/7dd1fb3a353eb2b456336a996e5265fc5756a085