### PR TITLE
Add Logger::setTimezone()

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -614,4 +614,14 @@ class Logger implements LoggerInterface
     {
         return $this->addRecord(static::EMERGENCY, $message, $context);
     }
+
+    /**
+     * Set the timezone to be used for the timestamp of log records.
+     *
+     * @param string $tz Timezone name
+     */
+    public static function setTimezone($tz)
+    {
+        self::$timezone = new \DateTimeZone($tz);
+    }
 }

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -421,4 +421,27 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
             array('emerg',  Logger::EMERGENCY),
         );
     }
+
+    /**
+     * @dataProvider setTimezoneProvider
+     * @covers Monolog\Logger::setTimezone
+     */
+    public function testSetTimezone($tz)
+    {
+        Logger::setTimezone($tz);
+        $logger = new Logger('foo');
+        $handler = new TestHandler;
+        $logger->pushHandler($handler);
+        $logger->info('test');
+        list($record) = $handler->getRecords();
+        $this->assertEquals($tz, $record['datetime']->getTimezone()->getName());
+    }
+
+    public function setTimezoneProvider()
+    {
+        return array_map(
+            function ($tz) { return array($tz); },
+            \DateTimeZone::listIdentifiers()
+        );
+    }
 }


### PR DESCRIPTION
Add a setter method to allow changing the timezone used when creating
new log records. This provides a means to correct a behavioral change
introduced by 6cbdc04 where use of the PHP runtime default timezone
provided by `date_default_timezone_get()` was introduced. In most
environments the new default behavior is preferable, but if an
application allows the default timezone to vary between requests it
causes confusing log output.