### PR TITLE
Add support for Javascript output in BrowserConsoleHandler

### DIFF
--- a/src/Monolog/Handler/BrowserConsoleHandler.php
+++ b/src/Monolog/Handler/BrowserConsoleHandler.php
@@ -55,15 +55,19 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
 
     /**
      * Convert records to javascript console commands and send it to the browser.
-     * This method is automatically called on PHP shutdown if output is HTML.
+     * This method is automatically called on PHP shutdown if output is HTML or Javascript.
      */
     public static function send()
     {
+        $htmlTags = true;
         // Check content type
         foreach (headers_list() as $header) {
             if (stripos($header, 'content-type:') === 0) {
-                if (stripos($header, 'text/html') === false) {
-                    // This handler only works with HTML outputs
+            	// This handler only works with HTML and javascript outputs
+            	// text/javascript is obsoute in favour of application/javascript, but still used
+                if (stripos($header, 'application/javascript') !== false || stripos($header, 'text/javascript') !== false) {
+                    $htmlTags = false;
+                } elseif (stripos($header, 'text/html') === false) {
                     return;
                 }
                 break;
@@ -71,7 +75,11 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
         }
 
         if (count(self::$records)) {
-            echo '<script>' , self::generateScript() , '</script>';
+            if ($htmlTags) {
+                echo '<script>' , self::generateScript() , '</script>';
+            } else {
+                echo self::generateScript();
+            }
             self::reset();
         }
     }

--- a/src/Monolog/Handler/BrowserConsoleHandler.php
+++ b/src/Monolog/Handler/BrowserConsoleHandler.php
@@ -64,7 +64,7 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
         foreach (headers_list() as $header) {
             if (stripos($header, 'content-type:') === 0) {
             	// This handler only works with HTML and javascript outputs
-            	// text/javascript is obsoute in favour of application/javascript, but still used
+            	// text/javascript is obsolete in favour of application/javascript, but still used
                 if (stripos($header, 'application/javascript') !== false || stripos($header, 'text/javascript') !== false) {
                     $htmlTags = false;
                 } elseif (stripos($header, 'text/html') === false) {


### PR DESCRIPTION
Up to now, BrowserConsoleHandler only shows output when output header is text/html. However many of our applications also use application/javascript (and obsolete text/javascript). With this PR, generated javascript will also be returned, but without the script tags.