### PR TITLE
Update SwiftMailerHandler.php

### DIFF
--- a/src/Monolog/Handler/SwiftMailerHandler.php
+++ b/src/Monolog/Handler/SwiftMailerHandler.php
@@ -66,7 +66,7 @@ class SwiftMailerHandler extends MailHandler
         }
 
         $message->setBody($content);
-        $message->setDate(time());
+        $message->setDate(new \DateTime);
 
         return $message;
     }


### PR DESCRIPTION
Swift_Message setDate now requires a DateTime object

Catchable fatal error: Argument 1 passed to Swift_Mime_SimpleMessage::setDate() must implement interface DateTimeInterface, integer given, called in monolog/monolog/src/Monolog/Handler/SwiftMailerHandler.php on line 69 and defined in swiftmailer/swiftmailer/lib/classes/Swift/Mime/SimpleMessage.php on line 98

Using:

"monolog/monolog": "dev-master"
"swiftmailer/swiftmailer": "dev-master",