### PR TITLE
Adds ability to cap log size in redis

### DIFF
--- a/src/Monolog/Handler/RedisHandler.php
+++ b/src/Monolog/Handler/RedisHandler.php
@@ -79,9 +79,11 @@ class RedisHandler extends AbstractProcessingHandler
                 ->ltrim($this->redisKey, 0, $this->capSize)
                 ->execute();
         } else {
-            $this->redisClient->transaction(function($tx) use($record) {
-                $tx->lpush($this->redisKey, $record["formatted"]);
-                $tx->ltrim($this->redisKey, 0, $this->capSize);
+            $redisKey = $this->redisKey;
+            $capSize = $this->capSize;
+            $this->redisClient->transaction(function($tx) use($record, $redisKey, $capSize) {
+                $tx->lpush($redisKey, $record["formatted"]);
+                $tx->ltrim($redisKey, 0, $capSize);
             });
         }
     }

--- a/src/Monolog/Handler/RedisHandler.php
+++ b/src/Monolog/Handler/RedisHandler.php
@@ -75,15 +75,15 @@ class RedisHandler extends AbstractProcessingHandler
     {
         if($this->redisClient instanceof \Redis) {
             $this->redisClient->multi()
-                ->lpush($this->redisKey, $record["formatted"])
-                ->ltrim($this->redisKey, 0, $this->capSize)
+                ->rpush($this->redisKey, $record["formatted"])
+                ->ltrim($this->redisKey, -$this->capSize, -1)
                 ->execute();
         } else {
             $redisKey = $this->redisKey;
             $capSize = $this->capSize;
             $this->redisClient->transaction(function($tx) use($record, $redisKey, $capSize) {
-                $tx->lpush($redisKey, $record["formatted"]);
-                $tx->ltrim($redisKey, 0, $capSize);
+                $tx->rpush($redisKey, $record["formatted"]);
+                $tx->ltrim($redisKey, -$capSize, -1);
             });
         }
     }

--- a/tests/Monolog/Handler/RedisHandlerTest.php
+++ b/tests/Monolog/Handler/RedisHandlerTest.php
@@ -101,21 +101,20 @@ class RedisHandlerTest extends TestCase
     {
         $redis = $this->getMock('Predis\Client', array('transaction'));
 
+        $redisTransaction = $this->getMock('Predis\Client', array('lpush', 'ltrim'));
+
+        $redisTransaction->expects($this->once())
+            ->method('lpush')
+            ->will($this->returnSelf());
+
+        $redisTransaction->expects($this->once())
+            ->method('ltrim')
+            ->will($this->returnSelf());
+
         // Redis uses multi
         $redis->expects($this->once())
             ->method('transaction')
-            ->will($this->returnCallback(function($cb){
-
-                $redisTransaction = $this->getMock('Predis\Client', array('lpush', 'ltrim'));
-
-                $redisTransaction->expects($this->once())
-                    ->method('lpush')
-                    ->will($this->returnSelf());
-
-                $redisTransaction->expects($this->once())
-                    ->method('ltrim')
-                    ->will($this->returnSelf());
-
+            ->will($this->returnCallback(function($cb) use ($redisTransaction){
                 $cb($redisTransaction);
             }));
 

--- a/tests/Monolog/Handler/RedisHandlerTest.php
+++ b/tests/Monolog/Handler/RedisHandlerTest.php
@@ -71,7 +71,7 @@ class RedisHandlerTest extends TestCase
 
     public function testRedisHandleCapped()
     {
-        $redis = $this->getMock('Redis', array('multi', 'lpush', 'ltrim', 'execute'));
+        $redis = $this->getMock('Redis', array('multi', 'rpush', 'ltrim', 'execute'));
 
         // Redis uses multi
         $redis->expects($this->once())
@@ -79,7 +79,7 @@ class RedisHandlerTest extends TestCase
             ->will($this->returnSelf());
 
         $redis->expects($this->once())
-            ->method('lpush')
+            ->method('rpush')
             ->will($this->returnSelf());
 
         $redis->expects($this->once())
@@ -101,10 +101,10 @@ class RedisHandlerTest extends TestCase
     {
         $redis = $this->getMock('Predis\Client', array('transaction'));
 
-        $redisTransaction = $this->getMock('Predis\Client', array('lpush', 'ltrim'));
+        $redisTransaction = $this->getMock('Predis\Client', array('rpush', 'ltrim'));
 
         $redisTransaction->expects($this->once())
-            ->method('lpush')
+            ->method('rpush')
             ->will($this->returnSelf());
 
         $redisTransaction->expects($this->once())


### PR DESCRIPTION
100% backward compatible, defaults to not capping collection size.

Additional constructor param of $capSize added which will ensure logs
list is treated as a FILO queue

Test coverage on new functionality