### PR TITLE
Fix: Type should be bool

### DIFF
--- a/src/Monolog/Handler/SocketHandler.php
+++ b/src/Monolog/Handler/SocketHandler.php
@@ -80,7 +80,7 @@ class SocketHandler extends AbstractProcessingHandler
     /**
      * Set socket connection to nbe persistent. It only has effect before the connection is initiated.
      *
-     * @param type $boolean
+     * @param boolean $boolean
      */
     public function setPersistent($boolean)
     {

--- a/src/Monolog/Handler/SocketHandler.php
+++ b/src/Monolog/Handler/SocketHandler.php
@@ -80,11 +80,11 @@ class SocketHandler extends AbstractProcessingHandler
     /**
      * Set socket connection to nbe persistent. It only has effect before the connection is initiated.
      *
-     * @param boolean $boolean
+     * @param boolean $persistent
      */
-    public function setPersistent($boolean)
+    public function setPersistent($persistent)
     {
-        $this->persistent = (boolean) $boolean;
+        $this->persistent = (boolean) $persistent;
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] fixes a docblock where `type` should be `boolean` instead
* [x] renames a parameter from `$boolean` to `$parameter`