### PR TITLE
Ignore "call_user_func" from debug backtrace

### DIFF
--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -56,15 +56,20 @@ class IntrospectionProcessor
 
         $i = 0;
 
-        while (isset($trace[$i]['class'])) {
-            foreach ($this->skipClassesPartials as $part) {
-                if (strpos($trace[$i]['class'], $part) !== false) {
-                    $i++;
-                    continue 2;
-                }
-            }
-            break;
-        }
+        while (isset($trace[$i]['class']) || $trace[$i]['function'] == 'call_user_func') {
+			if(isset($trace[$i]['class'])) {
+				foreach ($this->skipClassesPartials as $part) {
+					if (strpos($trace[$i]['class'], $part) !== false) {
+						$i++;
+						continue 2;
+					}
+				}
+			} elseif($trace[$i]['function'] == 'call_user_func') {
+				$i++;
+			}
+			
+			break;
+		}
 
         // we should have the call source now
         $record['extra'] = array_merge(

--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -71,6 +71,7 @@ class IntrospectionProcessor
 				}
 			} elseif(in_array($trace[$i]['function'], $this->skipFunctions)) {
 				$i++;
+				continue;
 			}
 			
 			break;

--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -29,6 +29,11 @@ class IntrospectionProcessor
     private $level;
 
     private $skipClassesPartials;
+    
+	private $skipFunctions = array(
+		'call_user_func',
+		'call_user_func_array',
+	);
 
     public function __construct($level = Logger::DEBUG, array $skipClassesPartials = array('Monolog\\'))
     {
@@ -56,7 +61,7 @@ class IntrospectionProcessor
 
         $i = 0;
 
-        while (isset($trace[$i]['class']) || $trace[$i]['function'] == 'call_user_func') {
+        while (isset($trace[$i]['class']) || in_array($trace[$i]['function'], $this->skipFunctions)) {
 			if(isset($trace[$i]['class'])) {
 				foreach ($this->skipClassesPartials as $part) {
 					if (strpos($trace[$i]['class'], $part) !== false) {
@@ -64,7 +69,7 @@ class IntrospectionProcessor
 						continue 2;
 					}
 				}
-			} elseif($trace[$i]['function'] == 'call_user_func') {
+			} elseif(in_array($trace[$i]['function'], $this->skipFunctions)) {
 				$i++;
 			}
 			


### PR DESCRIPTION
Helps make this compliant where there is no class defined