### PR TITLE
Prevent Monolog from ever being introspected

### DIFF
--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -30,10 +30,10 @@ class IntrospectionProcessor
 
     private $skipClassesPartials;
 
-    public function __construct($level = Logger::DEBUG, array $skipClassesPartials = [])
+    public function __construct($level = Logger::DEBUG, array $skipClassesPartials = array())
     {
         $this->level = Logger::toMonologLevel($level);
-        $this->skipClassesPartials = array_merge(array['Monolog\\'], $skipClassesPartials);
+        $this->skipClassesPartials = array_merge(array('Monolog\\'), $skipClassesPartials);
     }
 
     /**

--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -30,10 +30,10 @@ class IntrospectionProcessor
 
     private $skipClassesPartials;
 
-    public function __construct($level = Logger::DEBUG, array $skipClassesPartials = array('Monolog\\'))
+    public function __construct($level = Logger::DEBUG, array $skipClassesPartials = [])
     {
         $this->level = Logger::toMonologLevel($level);
-        $this->skipClassesPartials = $skipClassesPartials;
+        $this->skipClassesPartials = array_merge(array['Monolog\\'], $skipClassesPartials);
     }
 
     /**


### PR DESCRIPTION
Ensure the Monolog namespace is always ignored, and doesn't have to be defined in use.