### PR TITLE
Symlink today's file in rotation handler

### DIFF
--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -97,6 +97,13 @@ class RotatingFileHandler extends StreamHandler
         $this->url = $this->getTimedFilename();
         $this->nextRotation = new \DateTime('tomorrow');
 
+        // symlink today's file
+        if (file_exists($this->filename)) {
+            unlink($this->filename);
+        }
+
+        symlink($this->url, $this->filename);
+
         // skip GC of old logs if files are unlimited
         if (0 === $this->maxFiles) {
             return;

--- a/tests/Monolog/Handler/RotatingFileHandlerTest.php
+++ b/tests/Monolog/Handler/RotatingFileHandlerTest.php
@@ -45,6 +45,9 @@ class RotatingFileHandlerTest extends TestCase
      */
     public function testRotation($createFile)
     {
+        $filename = __DIR__.'/Fixtures/foo.rot';
+
+        touch($filename);
         touch($old1 = __DIR__.'/Fixtures/foo-'.date('Y-m-d', time() - 86400).'.rot');
         touch($old2 = __DIR__.'/Fixtures/foo-'.date('Y-m-d', time() - 86400 * 2).'.rot');
         touch($old3 = __DIR__.'/Fixtures/foo-'.date('Y-m-d', time() - 86400 * 3).'.rot');
@@ -56,11 +59,16 @@ class RotatingFileHandlerTest extends TestCase
             touch($log);
         }
 
-        $handler = new RotatingFileHandler(__DIR__.'/Fixtures/foo.rot', 2);
+        $handler = new RotatingFileHandler($filename, 2);
         $handler->setFormatter($this->getIdentityFormatter());
         $handler->handle($this->getRecord());
 
         $handler->close();
+
+        if (!$createFile) {
+            $this->assertTrue(is_link($filename));
+            $this->assertEquals($log, readlink($filename));
+        }
 
         $this->assertTrue(file_exists($log));
         $this->assertTrue(file_exists($old1));


### PR DESCRIPTION
It would be very useful to edit/tail today's log file without having to handle the date in the filename. This PR adds a simple symlink to the current log file. Ex: 

```
prod.log -> /var/www/acme/app/logs/prod-2015-07-21.log
prod-2015-07-21.log
prod-2015-07-20.log
prod-2015-07-19.log
...
```