### PR TITLE
Added Logger::setHandlers()

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -176,6 +176,25 @@ class Logger implements LoggerInterface
     }
 
     /**
+     * Set handlers, removing all existing ones.
+     * Falsey values will be ignored, and if a map is passed, keys will be ignored.
+     *
+     * @param array $handlers All elements must be of type HandlerInterface
+     * @return $this
+     */
+    public function setHandlers(array $handlers)
+    {
+        $this->handlers = array();
+        foreach ($handlers as $handler) {
+            if ($handler) {
+                $this->pushHandler($handler);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * @return HandlerInterface[]
      */
     public function getHandlers()

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -140,6 +140,30 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Monolog\Logger::setHandlers
+     */
+    public function testSetHandlers()
+    {
+        $logger = new Logger(__METHOD__);
+        $handler1 = new TestHandler;
+        $handler2 = new TestHandler;
+
+        $logger->pushHandler($handler1);
+        $logger->setHandlers(array($handler2));
+
+        // handler1 has been removed
+        $this->assertEquals(array($handler2), $logger->getHandlers());
+
+        $logger->setHandlers(array(
+            "AMapKey" => $handler1,
+            "Falsey" => null,
+        ));
+
+        // Keys have been scrubbed
+        $this->assertEquals(array($handler1), $logger->getHandlers());
+    }
+
+    /**
      * @covers Monolog\Logger::pushProcessor
      * @covers Monolog\Logger::popProcessor
      * @expectedException LogicException


### PR DESCRIPTION
Logger::setHandlers() is intended to help dependency injection systems that deal more elegantly with property setters than constructor arguments. Alongside getHandlers(), pushHandler(), popHandler(), it is
a logical addition to the API. 

More controversially. It also attempts to address some possible errors in the format of the data passed:

 - If a map is passed, the keys are removed, as these aren’t expected
   by Monolog
 - If falsey values are included, these are stripped

It relies on Logger::pushHandler() internally, so that if any special behaviour is added in the future, this only needs to be added in one place.

Does anyone else benefit from this facility?