### PR TITLE
Update Util.php

### DIFF
--- a/src/Monolog/Handler/Curl/Util.php
+++ b/src/Monolog/Handler/Curl/Util.php
@@ -33,12 +33,18 @@ class Util
     {
         while ($retries--) {
             if (curl_exec($ch) === false) {
-                if (false === in_array(curl_errno($ch), self::$retriableErrorCodes, true) || !$retries) {
+                
+                $curlErrno = curl_errno($ch);
+                
+                if (false === in_array($curlErrno, self::$retriableErrorCodes, true) || !$retries) {
+                    
+                    $curlError = curl_error($ch);
+                    
                     if ($closeAfterDone) {
                         curl_close($ch);
                     }
 
-                    throw new \RuntimeException(sprintf('Curl error (code %s): %s', curl_errno($ch), curl_error($ch)));
+                    throw new \RuntimeException(sprintf('Curl error (code %s): %s', $curlErrno, $curlError));
                 }
 
                 continue;


### PR DESCRIPTION
Fixes bug with error handler. Once `curl_close($ch)` is called, then `curl_errno($ch)` and `curl_error($ch)` makes no sense and will cause an error in the exception handler.