### PR TITLE
Ensure RollbarHandler can handle fatal errors

### DIFF
--- a/src/Monolog/Handler/RollbarHandler.php
+++ b/src/Monolog/Handler/RollbarHandler.php
@@ -23,6 +23,14 @@ use Monolog\Logger;
 class RollbarHandler extends AbstractProcessingHandler
 {
     /**
+     * Array of fatal types that need the queue to be flushed immediately
+     * as the destructor will not be called.
+     *
+     * @var array
+     */
+    protected $fatalTypes = [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR];
+
+    /**
      * Rollbar notifier
      *
      * @var RollbarNotifier
@@ -60,6 +68,11 @@ class RollbarHandler extends AbstractProcessingHandler
                 $record['level_name'],
                 array_merge($record['context'], $record['extra'], $extraData)
             );
+        }
+
+        // If the record is of a 'fatal' nature, close the handler
+        if (isset($record['context']['code']) && in_array($record['context']['code'], $this->fatalTypes)) {
+            $this->close();
         }
     }
 


### PR DESCRIPTION
I ran into an interesting issue while using the _RollbarHandler_ recently and this PR resolves the problem. When a fatal error was being thrown in our application, we were not getting any logs pushed to Rollbar while running in batched mode (which is the default).

This was because the `close()` method was never called to flush the log queue as _AbstractHandler::__destruct()_ is not called during fatal errors. Research seems to suggest that this is expected, as fatal errors do not trigger's PHP's usual shutdown sequence. _RollbarHandler_ currently relies on the destructor to send queued items at the end of a request when it is run in batched mode (where batched mode prevents the Handler for hitting the Rollbar API every time a record appears). 

This PR will inspect the record as it's being written and if the code (`$record['context']['code']`) matches one of PHP's fatal error constants, it will do a force flush. After implementing this, we were able to get all logs for a request, even if it did end in tears :)