### PR TITLE
Added IFTTT Handler

### DIFF
--- a/src/Monolog/Handler/IFTTTHandler.php
+++ b/src/Monolog/Handler/IFTTTHandler.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Logger;
+
+/**
+ * IFTTTHandler uses cURL to trigger IFTTT Maker actions
+ *
+ * @author Nehal Patel <nehal@nehalpatel.me>
+ */
+class IFTTTHandler extends AbstractProcessingHandler
+{
+	protected $_eventName;
+	protected $_secretKey;
+
+	/**
+	 * @param string                  $eventName  The name of the IFTTT Maker event that should be triggered
+	 * @param string                  $secretKey  A valid IFTTT secret key
+	 * @param integer                 $level      The minimum logging level at which this handler will be triggered
+	 * @param Boolean                 $bubble     Whether the messages that are handled can bubble up the stack or not
+	 */
+	public function __construct($eventName, $secretKey, $level = Logger::ERROR, $bubble = true)
+	{
+		$this->_eventName = $eventName;
+		$this->_secretKey = $secretKey;
+
+		parent::__construct($level, $bubble);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function write(array $record)
+	{
+		$postData = array(
+			"value1" => $record["channel"],
+			"value2" => $record["level_name"],
+			"value3" => $record["message"]
+		);
+		$postString = json_encode($postData);
+
+		$ch = curl_init();
+
+		curl_setopt($ch, CURLOPT_URL, "https://maker.ifttt.com/trigger/" . $this->_eventName . "/with/key/" . $this->_secretKey);
+		curl_setopt($ch, CURLOPT_POST, 1);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+		curl_setopt($ch, CURLOPT_POSTFIELDS, $postString);
+		curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+			"Content-Type: application/json"
+		));
+
+		Curl\Util::execute($ch);
+	}
+}


### PR DESCRIPTION
I've added a fairly simple handler that allows you to trigger Maker actions on IFTTT.

The great thing about IFTTT is, you can essentially do anything you want with the logs, for free:
- You want to get a text alert when there's a database error? Yep.
- You want to create a GitHub issue when there's a critical error? Yep.
- You want your house to go lockdown mode and start blinking red lights when there's an emergency logged? Sure. 

On a more serious note though, how should the tests be handled for this? I looked through the other handlers that use cURL, such as Mandrill and Loggly, and they don't seem to have tests, so I didn't add one to this. **However**, if you do want one, should I just mock a cURL object? Or would you prefer I do something else?