### PR TITLE
RavenHandler supports extra parameters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "phpunit/phpunit": "~4.5",
         "graylog2/gelf-php": "~1.0",
-        "raven/raven": "~0.8",
+        "raven/raven": "~0.11",
         "ruflin/elastica": ">=0.90 <3.0",
         "doctrine/couchdb": "~1.0@dev",
         "aws/aws-sdk-php": "^2.4.9",

--- a/src/Monolog/Handler/RavenHandler.php
+++ b/src/Monolog/Handler/RavenHandler.php
@@ -145,13 +145,13 @@ class RavenHandler extends AbstractProcessingHandler
         } else {
             $options['logger'] = $record['channel'];
         }
-        if (!empty($record['extra']['checksum'])) {
-            $options['checksum'] = $record['extra']['checksum'];
-            unset($record['extra']['checksum']);
-        }
-        if (!empty($record['context']['checksum'])) {
-            $options['checksum'] = $record['context']['checksum'];
-            unset($record['context']['checksum']);
+        foreach ($this->getExtraParameters() as $key) {
+            foreach (array('extra', 'context') as $source) {
+                if (!empty($record[$source][$key])) {
+                    $options[$key] = $record[$source][$key];
+                    unset($record[$source][$key]);
+                }
+            }
         }
         if (!empty($record['context'])) {
             $options['extra']['context'] = $record['context'];
@@ -193,5 +193,15 @@ class RavenHandler extends AbstractProcessingHandler
     protected function getDefaultBatchFormatter()
     {
         return new LineFormatter();
+    }
+
+    /**
+     * Gets extra parameters supported by Raven that can be found in "extra" and "context"
+     *
+     * @return array
+     */
+    protected function getExtraParameters()
+    {
+        return array('checksum', 'release');
     }
 }

--- a/tests/Monolog/Handler/RavenHandlerTest.php
+++ b/tests/Monolog/Handler/RavenHandlerTest.php
@@ -85,16 +85,18 @@ class RavenHandlerTest extends TestCase
         $this->assertEquals($tags, $ravenClient->lastData['tags']);
     }
 
-    public function testChecksum()
+    public function testExtraParameters()
     {
         $ravenClient = $this->getRavenClient();
         $handler = $this->getHandler($ravenClient);
 
         $checksum = '098f6bcd4621d373cade4e832627b4f6';
-        $record = $this->getRecord(Logger::INFO, 'test', array('checksum' => $checksum));
+        $release = '05a671c66aefea124cc08b76ea6d30bb';
+        $record = $this->getRecord(Logger::INFO, 'test', array('checksum' => $checksum, 'release' => $release));
         $handler->handle($record);
 
         $this->assertEquals($checksum, $ravenClient->lastData['checksum']);
+        $this->assertEquals($release, $ravenClient->lastData['release']);
     }
 
     public function testUserContext()


### PR DESCRIPTION
refactored RavenHandler a bit to support many additional parameters, not only `checksum` but also (added in 0.11) `release` parameter
ref: https://github.com/getsentry/raven-php/blob/master/CHANGES

`release` allows to track the version of an application that the logs came from