### PR TITLE
Add getUid() to UidProcessor

### DIFF
--- a/src/Monolog/Processor/UidProcessor.php
+++ b/src/Monolog/Processor/UidProcessor.php
@@ -35,4 +35,12 @@ class UidProcessor
 
         return $record;
     }
+
+    /**
+     * @return string
+     */
+    public function getUid()
+    {
+        return $this->uid;
+    }
 }

--- a/tests/Monolog/Processor/UidProcessorTest.php
+++ b/tests/Monolog/Processor/UidProcessorTest.php
@@ -24,4 +24,9 @@ class UidProcessorTest extends TestCase
         $record = $processor($this->getRecord());
         $this->assertArrayHasKey('uid', $record['extra']);
     }
+    public function testGetUid()
+    {
+        $processor = new UidProcessor(10);
+        $this->assertEquals(10, strlen($processor->getUid()));
+    }
 }


### PR DESCRIPTION
Would be nice to have an easy way to get Uid from UidProcessor. I have a scenario where I want to pass a parent's Uid to children processes for log grouping.