### PR TITLE
Added the capability of handling a message multiple times

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -285,9 +285,11 @@ class Logger implements LoggerInterface
         foreach ($this->processors as $processor) {
             $record = call_user_func($processor, $record);
         }
-        while (isset($this->handlers[$handlerKey]) &&
-            false === $this->handlers[$handlerKey]->handle($record)) {
-            $handlerKey++;
+
+        foreach ($this->handlers as $handler) {
+            if ($handler->isHandling(array('level' => $level))) {
+                $handler->handle($record);
+            }
         }
 
         return true;

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -393,6 +393,46 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @test
+     */
+    public function multipleHandlersCanHandleTheSameRecord()
+    {
+        $logger = new Logger(__METHOD__);
+
+        $handler1 = $this->getMock('Monolog\Handler\HandlerInterface');
+        $handler1->expects($this->any())
+            ->method('isHandling')
+            ->will($this->returnValue(false));
+
+        $handler1->expects($this->never())
+            ->method('handle');
+
+        $handler2 = $this->getMock('Monolog\Handler\HandlerInterface');
+        $handler2->expects($this->any())
+            ->method('isHandling')
+            ->will($this->returnValue(true));
+
+        $handler2->expects($this->once())
+            ->method('handle')
+            ->will($this->returnValue(true))
+            ;
+
+        $handler3 = $this->getMock('Monolog\Handler\HandlerInterface');
+        $handler3->expects($this->any())
+            ->method('isHandling')
+            ->will($this->returnValue(true));
+
+        $handler3->expects($this->once())
+            ->method('handle');
+
+        $logger->pushHandler($handler1);
+        $logger->pushHandler($handler2);
+        $logger->pushHandler($handler3);
+
+        $this->assertTrue($logger->addRecord(Logger::DEBUG, 'foo'));
+    }
+
+    /**
      * @dataProvider logMethodProvider
      * @covers Monolog\Logger::addDebug
      * @covers Monolog\Logger::addInfo


### PR DESCRIPTION
What if I want error messages to be logged, but critical messages to be logged, mailed and sent to slack channel?

If I understood correctly this is currently not possible. This is why I created this PR, to add such capability.

```php
$log = new Logger('name');
$log->pushHandler(new StreamHandler('path/to/your.log', Logger::ERROR));
$log->pushHandler(new StreamHandler('path/to/your.log', Logger::CRITICAL));
$log->pushHandler(new MyEmailHandler(Logger::CRITICAL));
$log->pushHandler(new SlackHandler($connectionString, Logger::CRITICAL));
```

Note that 2 tests are now failing. I did not change them because I was not sure if that was testing the expected behavior or if it was just very strict expectations, since the [commit](https://github.com/Seldaek/monolog/commit/64009a58) that introduced those tests seemed just to be increasing the test coverage.