### PR TITLE
Prevent HipChat API failure from throwing an exception

### DIFF
--- a/src/Monolog/Handler/HipChatHandler.php
+++ b/src/Monolog/Handler/HipChatHandler.php
@@ -205,8 +205,12 @@ class HipChatHandler extends SocketHandler
      */
     protected function write(array $record)
     {
-        parent::write($record);
-        $this->closeSocket();
+        try{
+            parent::write($record);
+            $this->closeSocket();
+        } catch (\Exception $e){
+            // socket creation failed. Cannot connect to hipchat API.
+        }
     }
 
     /**


### PR DESCRIPTION
When a connection to HipChat API cannot be established, the 'createSocketResource' method from the 'SocketHandler' class throws an exception. 

To prevent this, I've wrapped the "write" method from the 'HipChatHandler' class in a try-catch block. While the call specifically throws an 'UnexpectedValueException', the catch is using '\Exception' since no action is actually needed and the exception type doesn't really matter is this particular case.