### PR TITLE
Use `text` and `title` fields for SlackHandler

### DIFF
--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -145,29 +145,20 @@ class SlackHandler extends SocketHandler
         if ($this->useAttachment) {
             $attachment = array(
                 'fallback' => $record['message'],
-                'color'    => $this->getAttachmentColor($record['level'])
+                'color'    => $this->getAttachmentColor($record['level']),
+                'fields'   => array()
             );
 
             if ($this->useShortAttachment) {
-                $attachment['fields'] = array(
-                    array(
-                        'title' => $record['level_name'],
-                        'value' => $record['message'],
-                        'short' => false
-                    )
-                );
+                $attachment['title'] = $record['level_name'];
+                $attachment['text'] = $record['message'];
             } else {
-                $attachment['fields'] = array(
-                    array(
-                        'title' => 'Message',
-                        'value' => $record['message'],
-                        'short' => false
-                    ),
-                    array(
-                        'title' => 'Level',
-                        'value' => $record['level_name'],
-                        'short' => true
-                    )
+                $attachment['title'] = 'Message';
+                $attachment['text'] = $record['message'];
+                $attachment['fields'][] = array(
+                    'title' => 'Level',
+                    'value' => $record['level_name'],
+                    'short' => true
                 );
             }
 


### PR DESCRIPTION
According to slack documentation (https://api.slack.com/docs/attachments),  an attachment may have a title and a text. The log message and title should use these fields. One of the benefits of using these two properties instead of adding a field is that it's shortened (with a "show more" button) and expandable by slack. It adds a bit of hierarchy in the attachement. Message is the content. Extra and context are additional fields.