### PR TITLE
Reduce memory consumption of the debug_backtrace call

### DIFF
--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -52,7 +52,7 @@ class IntrospectionProcessor
             return $record;
         }
 
-        $trace = debug_backtrace();
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 
         // skip first since it's always the current method
         array_shift($trace);


### PR DESCRIPTION
Since the code does not need neither the 'object' not 'args' keys from backtrace, we can save some memory by not requesting them.

I have a better idea planned too: first attempt getting the trace with limited back trace (limit to only about 5 results), and get the full one only if those were not enough