### PR TITLE
Add linting to Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ before_script:
   - if [ "$deps" == "low" ]; then composer update --prefer-source --prefer-lowest --prefer-stable; fi
   - if [ "$deps" != "low" ]; then composer install --prefer-source; fi
 
-script: ./vendor/bin/phpunit
+script: composer test

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "videlalvaro/php-amqplib": "~2.4",
         "swiftmailer/swiftmailer": "~5.3",
         "php-console/php-console": "^3.1.3",
-        "phpunit/phpunit-mock-objects": "2.3.0"
+        "phpunit/phpunit-mock-objects": "2.3.0",
+        "jakub-onderka/php-parallel-lint": "0.9"
     },
     "_": "phpunit/phpunit-mock-objects required in 2.3.0 due to https://github.com/sebastianbergmann/phpunit-mock-objects/issues/223 - needs hhvm 3.8+ on travis",
     "suggest": {
@@ -56,6 +57,9 @@
         }
     },
     "scripts": {
-        "test": "phpunit"
+        "test": [
+            "parallel-lint . --exclude vendor",
+            "phpunit"
+        ]
     }
 }


### PR DESCRIPTION
Protect against syntax compatibility issues such as the non-5.3
compatible array syntax corrected in 5785a9a by running a linter during
Travis CI testing for pull requests.