### PR TITLE
Optionally reduce timestamp resolution for performance

### DIFF
--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -468,4 +468,30 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
             \DateTimeZone::listIdentifiers()
         );
     }
+
+    /**
+     * @dataProvider useMicrosecondTimestampsProvider
+     * @covers Monolog\Logger::useMicrosecondTimestamps
+     * @covers Monolog\Logger::addRecord
+     */
+    public function testUseMicrosecondTimestamps($micro, $assert)
+    {
+        $logger = new Logger('foo');
+        $logger->useMicrosecondTimestamps($micro);
+        $handler = new TestHandler;
+        $logger->pushHandler($handler);
+        $logger->info('test');
+        list($record) = $handler->getRecords();
+        $this->{$assert}('000000', $record['datetime']->format('u'));
+    }
+
+    public function useMicrosecondTimestampsProvider()
+    {
+        return array(
+            // this has a very small chance of a false negative (1/10^6)
+            'with microseconds' => array(true, 'assertNotSame'),
+            'without microseconds' => array(false, 'assertSame'),
+        );
+    }
+
 }


### PR DESCRIPTION
Introduce a new `useMicrosecondTimestamps()` static method to Logger
that allows runtime selection of whether or not to create microsecond
resolution timestamps for log records.

Generating microsecond resolution timestamps by calling
`microtime(true)`, formatting the result via `sprintf()` and then
parsing the resulting string via `DateTime::createFromFormat` can incur
a measurable runtime overhead vs simple usage of `new DateTime` to
capture a second resolution timestamp in systems which generate a large
number of log events.

The default behavior of generating high precision timestamps remains the
same, but may be changed in a future release. Users requiring high
precision timestamps are encouraged to explicitly call
`Monolog\Logger::useMicrosecondTimestamps(true)` in their setup code.

Closes #657