### PR TITLE
Catch errors sending messages to Pushover

### DIFF
--- a/src/Monolog/Handler/PushoverHandler.php
+++ b/src/Monolog/Handler/PushoverHandler.php
@@ -154,11 +154,16 @@ class PushoverHandler extends SocketHandler
 
     protected function write(array $record)
     {
-        foreach ($this->users as $user) {
-            $this->user = $user;
+        try {
+            foreach ($this->users as $user) {
+                $this->user = $user;
 
-            parent::write($record);
-            $this->closeSocket();
+                parent::write($record);
+                $this->closeSocket();
+            }
+        }
+        catch (\Exception $e) {
+            // Do nothing if there are errors sending to PushOver
         }
 
         $this->user = null;


### PR DESCRIPTION
This change is in response to a production issue I encountered where it seems the Pushover service was unavailable for a time--or there was some other connectivity issue .  This change is just meant to catch any exceptions thrown by the `SocketHandler`.  I just want to make sure that monolog itself isn't breaking the larger application by throwing uncaught exceptions.

Here is the error we saw:
```
[14-Oct-2015 06:32:56 America/New_York] PHP Fatal error:  Uncaught exception 'UnexpectedValueException' with message 'Failed connecting to ssl://api.pushover.net:443 (0: php_network_getaddresses: getaddrinfo failed: Name or service not known)' in /var/www/career_center/releases/546ea47b3d5fa742286dfd6b38738aef081a3792/vendor/monolog/monolog/src/Monolog/Handler/SocketHandler.php:249;
```