### PR TITLE
Avoid infinite loops when no data is written on a socket for a time 

### DIFF
--- a/src/Monolog/Handler/SocketHandler.php
+++ b/src/Monolog/Handler/SocketHandler.php
@@ -321,6 +321,8 @@ class SocketHandler extends AbstractProcessingHandler
         if ($sent !== $this->lastSentBytes) {
             $this->lastWritingAt = time();
             $this->lastSentBytes = $sent;
+
+            return false;
         } else {
             usleep(100);
         }

--- a/src/Monolog/Handler/SocketHandler.php
+++ b/src/Monolog/Handler/SocketHandler.php
@@ -25,7 +25,7 @@ class SocketHandler extends AbstractProcessingHandler
     private $connectionTimeout;
     private $resource;
     private $timeout = 0;
-    private $writingTimeout = 0;
+    private $writingTimeout = 10;
     private $lastSentBytes = null;
     private $persistent = false;
     private $errno;

--- a/tests/Monolog/Handler/SocketHandlerTest.php
+++ b/tests/Monolog/Handler/SocketHandlerTest.php
@@ -235,6 +235,26 @@ class SocketHandlerTest extends TestCase
         $this->assertTrue(is_resource($this->res));
     }
 
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testAvoidInfiniteLoopWhenNoDataIsWrittenForAWritingTimeoutSeconds()
+    {
+        $this->setMockHandler(array('fwrite', 'streamGetMetadata'));
+
+        $this->handler->expects($this->any())
+            ->method('fwrite')
+            ->will($this->returnValue(0));
+
+        $this->handler->expects($this->any())
+            ->method('streamGetMetadata')
+            ->will($this->returnValue(array('timed_out' => false)));
+
+        $this->handler->setWritingTimeout(1);
+
+        $this->writeRecord('Hello world');
+    }
+
     private function createHandler($connectionString)
     {
         $this->handler = new SocketHandler($connectionString);

--- a/tests/Monolog/Handler/SocketHandlerTest.php
+++ b/tests/Monolog/Handler/SocketHandlerTest.php
@@ -70,6 +70,13 @@ class SocketHandlerTest extends TestCase
         $this->assertEquals(10.25, $this->handler->getTimeout());
     }
 
+    public function testSetWritingTimeout()
+    {
+        $this->createHandler('localhost:1234');
+        $this->handler->setWritingTimeout(10.25);
+        $this->assertEquals(10.25, $this->handler->getWritingTimeout());
+    }
+
     public function testSetConnectionString()
     {
         $this->createHandler('tcp://localhost:9090');


### PR DESCRIPTION
greater than writingTimeout settings.

When a remote socket is closed without the FIN packet, it may be that the local socket is not closed but the data is not sent anymore so php entering in an infinite loop.

To reproduce the issue you can:
- start netcat in listening mode on 1234 port:
    `nc -l 1234`

- run the script locateted here: https://gist.github.com/silvadanilo/5043fc2d16b5346b1db1

- after a few logs entry, interrupt netcat with Ctrl+c
