### PR TITLE
Added functionality to IntrospectionProcessor to customize stack trace

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -248,7 +248,7 @@ class Logger implements LoggerInterface
      * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function addRecord($level, $message, array $context = array(), $arguments = array())
+    public function addRecord($level, $message, array $context = array(), array $arguments = array())
     {
         if (!$this->handlers) {
             $this->pushHandler(new StreamHandler('php://stderr', static::DEBUG));
@@ -302,7 +302,7 @@ class Logger implements LoggerInterface
      * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function addDebug($message, array $context = array(), $arguments = array())
+    public function addDebug($message, array $context = array(), array $arguments = array())
     {
         return $this->addRecord(static::DEBUG, $message, $context, $arguments);
     }
@@ -315,7 +315,7 @@ class Logger implements LoggerInterface
      * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function addInfo($message, array $context = array(), $arguments = array())
+    public function addInfo($message, array $context = array(), array $arguments = array())
     {
         return $this->addRecord(static::INFO, $message, $context, $arguments);
     }
@@ -328,7 +328,7 @@ class Logger implements LoggerInterface
      * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function addNotice($message, array $context = array(), $arguments = array())
+    public function addNotice($message, array $context = array(), array $arguments = array())
     {
         return $this->addRecord(static::NOTICE, $message, $context, $arguments);
     }
@@ -341,7 +341,7 @@ class Logger implements LoggerInterface
      * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function addWarning($message, array $context = array(), $arguments = array())
+    public function addWarning($message, array $context = array(), array $arguments = array())
     {
         return $this->addRecord(static::WARNING, $message, $context, $arguments);
     }
@@ -354,7 +354,7 @@ class Logger implements LoggerInterface
      * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function addError($message, array $context = array(), $arguments = array())
+    public function addError($message, array $context = array(), array $arguments = array())
     {
         return $this->addRecord(static::ERROR, $message, $context, $arguments);
     }
@@ -367,7 +367,7 @@ class Logger implements LoggerInterface
      * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function addCritical($message, array $context = array(), $arguments = array())
+    public function addCritical($message, array $context = array(), array $arguments = array())
     {
         return $this->addRecord(static::CRITICAL, $message, $context, $arguments);
     }
@@ -380,7 +380,7 @@ class Logger implements LoggerInterface
      * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function addAlert($message, array $context = array(), $arguments = array())
+    public function addAlert($message, array $context = array(), array $arguments = array())
     {
         return $this->addRecord(static::ALERT, $message, $context, $arguments);
     }
@@ -393,9 +393,9 @@ class Logger implements LoggerInterface
      * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function addEmergency($message, array $context = array(), $extra_stack = 0)
+    public function addEmergency($message, array $context = array(), array $arguments = array())
     {
-        return $this->addRecord(static::EMERGENCY, $message, $context, $extra_stack);
+        return $this->addRecord(static::EMERGENCY, $message, $context, $arguments);
     }
 
     /**
@@ -467,13 +467,14 @@ class Logger implements LoggerInterface
      * @param  mixed   $level   The log level
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function log($level, $message, array $context = array())
+    public function log($level, $message, array $context = array(), array $arguments = array())
     {
         $level = static::toMonologLevel($level);
 
-        return $this->addRecord($level, $message, $context);
+        return $this->addRecord($level, $message, $context, $arguments);
     }
 
     /**
@@ -483,11 +484,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function debug($message, array $context = array())
+    public function debug($message, array $context = array(), array $arguments = array())
     {
-        return $this->addRecord(static::DEBUG, $message, $context);
+        return $this->addRecord(static::DEBUG, $message, $context, $arguments);
     }
 
     /**
@@ -497,11 +499,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function info($message, array $context = array())
+    public function info($message, array $context = array(), array $arguments = array())
     {
-        return $this->addRecord(static::INFO, $message, $context);
+        return $this->addRecord(static::INFO, $message, $context, $arguments);
     }
 
     /**
@@ -511,11 +514,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function notice($message, array $context = array())
+    public function notice($message, array $context = array(), array $arguments = array())
     {
-        return $this->addRecord(static::NOTICE, $message, $context);
+        return $this->addRecord(static::NOTICE, $message, $context, $arguments);
     }
 
     /**
@@ -525,11 +529,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function warn($message, array $context = array())
+    public function warn($message, array $context = array(), array $arguments = array())
     {
-        return $this->addRecord(static::WARNING, $message, $context);
+        return $this->addRecord(static::WARNING, $message, $context, $arguments);
     }
 
     /**
@@ -539,11 +544,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function warning($message, array $context = array())
+    public function warning($message, array $context = array(), array $arguments = array())
     {
-        return $this->addRecord(static::WARNING, $message, $context);
+        return $this->addRecord(static::WARNING, $message, $context, $arguments);
     }
 
     /**
@@ -553,11 +559,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function err($message, array $context = array())
+    public function err($message, array $context = array(), array $arguments = array())
     {
-        return $this->addRecord(static::ERROR, $message, $context);
+        return $this->addRecord(static::ERROR, $message, $context, $arguments);
     }
 
     /**
@@ -567,11 +574,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function error($message, array $context = array())
+    public function error($message, array $context = array(), array $arguments = array())
     {
-        return $this->addRecord(static::ERROR, $message, $context);
+        return $this->addRecord(static::ERROR, $message, $context, $arguments);
     }
 
     /**
@@ -581,11 +589,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function crit($message, array $context = array())
+    public function crit($message, array $context = array(), array $arguments = array())
     {
-        return $this->addRecord(static::CRITICAL, $message, $context);
+        return $this->addRecord(static::CRITICAL, $message, $context, $arguments);
     }
 
     /**
@@ -595,11 +604,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function critical($message, array $context = array())
+    public function critical($message, array $context = array(), array $arguments = array())
     {
-        return $this->addRecord(static::CRITICAL, $message, $context);
+        return $this->addRecord(static::CRITICAL, $message, $context, $arguments);
     }
 
     /**
@@ -609,11 +619,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function alert($message, array $context = array())
+    public function alert($message, array $context = array(), array $arguments = array())
     {
-        return $this->addRecord(static::ALERT, $message, $context);
+        return $this->addRecord(static::ALERT, $message, $context, $arguments);
     }
 
     /**
@@ -623,11 +634,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function emerg($message, array $context = array())
+    public function emerg($message, array $context = array(), array $arguments = array())
     {
-        return $this->addRecord(static::EMERGENCY, $message, $context);
+        return $this->addRecord(static::EMERGENCY, $message, $context, $arguments);
     }
 
     /**
@@ -637,11 +649,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function emergency($message, array $context = array())
+    public function emergency($message, array $context = array(), array $arguments = array())
     {
-        return $this->addRecord(static::EMERGENCY, $message, $context);
+        return $this->addRecord(static::EMERGENCY, $message, $context, $arguments);
     }
 
     /**

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -245,10 +245,10 @@ class Logger implements LoggerInterface
      * @param  integer $level   The logging level
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  integer $extra_stack for IntrospectionProcessor stacktrace
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function addRecord($level, $message, array $context = array(), $extra_stack = 0)
+    public function addRecord($level, $message, array $context = array(), $arguments = array())
     {
         if (!$this->handlers) {
             $this->pushHandler(new StreamHandler('php://stderr', static::DEBUG));
@@ -284,7 +284,7 @@ class Logger implements LoggerInterface
         );
 
         foreach ($this->processors as $processor) {
-            $record = call_user_func($processor, $record, $extra_stack);
+            $record = call_user_func($processor, $record, $arguments);
         }
         while (isset($this->handlers[$handlerKey]) &&
             false === $this->handlers[$handlerKey]->handle($record)) {
@@ -299,12 +299,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  integer $extra_stack for IntrospectionProcessor stacktrace
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function addDebug($message, array $context = array(), $extra_stack = 0)
+    public function addDebug($message, array $context = array(), $arguments = array())
     {
-        return $this->addRecord(static::DEBUG, $message, $context, $extra_stack);
+        return $this->addRecord(static::DEBUG, $message, $context, $arguments);
     }
 
     /**
@@ -312,12 +312,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  integer $extra_stack for IntrospectionProcessor stacktrace
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function addInfo($message, array $context = array(), $extra_stack = 0)
+    public function addInfo($message, array $context = array(), $arguments = array())
     {
-        return $this->addRecord(static::INFO, $message, $context, $extra_stack);
+        return $this->addRecord(static::INFO, $message, $context, $arguments);
     }
 
     /**
@@ -325,12 +325,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  integer $extra_stack for IntrospectionProcessor stacktrace
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function addNotice($message, array $context = array(), $extra_stack = 0)
+    public function addNotice($message, array $context = array(), $arguments = array())
     {
-        return $this->addRecord(static::NOTICE, $message, $context, $extra_stack);
+        return $this->addRecord(static::NOTICE, $message, $context, $arguments);
     }
 
     /**
@@ -338,12 +338,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  integer $extra_stack for IntrospectionProcessor stacktrace
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function addWarning($message, array $context = array(), $extra_stack = 0)
+    public function addWarning($message, array $context = array(), $arguments = array())
     {
-        return $this->addRecord(static::WARNING, $message, $context, $extra_stack);
+        return $this->addRecord(static::WARNING, $message, $context, $arguments);
     }
 
     /**
@@ -351,12 +351,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  integer $extra_stack for IntrospectionProcessor stacktrace
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function addError($message, array $context = array(), $extra_stack = 0)
+    public function addError($message, array $context = array(), $arguments = array())
     {
-        return $this->addRecord(static::ERROR, $message, $context, $extra_stack);
+        return $this->addRecord(static::ERROR, $message, $context, $arguments);
     }
 
     /**
@@ -364,12 +364,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  integer $extra_stack for IntrospectionProcessor stacktrace
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function addCritical($message, array $context = array(), $extra_stack = 0)
+    public function addCritical($message, array $context = array(), $arguments = array())
     {
-        return $this->addRecord(static::CRITICAL, $message, $context, $extra_stack);
+        return $this->addRecord(static::CRITICAL, $message, $context, $arguments);
     }
 
     /**
@@ -377,12 +377,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  integer $extra_stack for IntrospectionProcessor stacktrace
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
-    public function addAlert($message, array $context = array(), $extra_stack = 0)
+    public function addAlert($message, array $context = array(), $arguments = array())
     {
-        return $this->addRecord(static::ALERT, $message, $context, $extra_stack);
+        return $this->addRecord(static::ALERT, $message, $context, $arguments);
     }
 
     /**
@@ -390,7 +390,7 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  integer $extra_stack for IntrospectionProcessor stacktrace
+     * @param  array   $arguments for additional input for processors
      * @return Boolean Whether the record has been processed
      */
     public function addEmergency($message, array $context = array(), $extra_stack = 0)

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -245,9 +245,10 @@ class Logger implements LoggerInterface
      * @param  integer $level   The logging level
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  integer $extra_stack for IntrospectionProcessor stacktrace
      * @return Boolean Whether the record has been processed
      */
-    public function addRecord($level, $message, array $context = array())
+    public function addRecord($level, $message, array $context = array(), $extra_stack = 0)
     {
         if (!$this->handlers) {
             $this->pushHandler(new StreamHandler('php://stderr', static::DEBUG));
@@ -283,7 +284,7 @@ class Logger implements LoggerInterface
         );
 
         foreach ($this->processors as $processor) {
-            $record = call_user_func($processor, $record);
+            $record = call_user_func($processor, $record, $extra_stack);
         }
         while (isset($this->handlers[$handlerKey]) &&
             false === $this->handlers[$handlerKey]->handle($record)) {
@@ -298,11 +299,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  integer $extra_stack for IntrospectionProcessor stacktrace
      * @return Boolean Whether the record has been processed
      */
-    public function addDebug($message, array $context = array())
+    public function addDebug($message, array $context = array(), $extra_stack = 0)
     {
-        return $this->addRecord(static::DEBUG, $message, $context);
+        return $this->addRecord(static::DEBUG, $message, $context, $extra_stack);
     }
 
     /**
@@ -310,11 +312,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  integer $extra_stack for IntrospectionProcessor stacktrace
      * @return Boolean Whether the record has been processed
      */
-    public function addInfo($message, array $context = array())
+    public function addInfo($message, array $context = array(), $extra_stack = 0)
     {
-        return $this->addRecord(static::INFO, $message, $context);
+        return $this->addRecord(static::INFO, $message, $context, $extra_stack);
     }
 
     /**
@@ -322,11 +325,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  integer $extra_stack for IntrospectionProcessor stacktrace
      * @return Boolean Whether the record has been processed
      */
-    public function addNotice($message, array $context = array())
+    public function addNotice($message, array $context = array(), $extra_stack = 0)
     {
-        return $this->addRecord(static::NOTICE, $message, $context);
+        return $this->addRecord(static::NOTICE, $message, $context, $extra_stack);
     }
 
     /**
@@ -334,11 +338,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  integer $extra_stack for IntrospectionProcessor stacktrace
      * @return Boolean Whether the record has been processed
      */
-    public function addWarning($message, array $context = array())
+    public function addWarning($message, array $context = array(), $extra_stack = 0)
     {
-        return $this->addRecord(static::WARNING, $message, $context);
+        return $this->addRecord(static::WARNING, $message, $context, $extra_stack);
     }
 
     /**
@@ -346,11 +351,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  integer $extra_stack for IntrospectionProcessor stacktrace
      * @return Boolean Whether the record has been processed
      */
-    public function addError($message, array $context = array())
+    public function addError($message, array $context = array(), $extra_stack = 0)
     {
-        return $this->addRecord(static::ERROR, $message, $context);
+        return $this->addRecord(static::ERROR, $message, $context, $extra_stack);
     }
 
     /**
@@ -358,11 +364,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  integer $extra_stack for IntrospectionProcessor stacktrace
      * @return Boolean Whether the record has been processed
      */
-    public function addCritical($message, array $context = array())
+    public function addCritical($message, array $context = array(), $extra_stack = 0)
     {
-        return $this->addRecord(static::CRITICAL, $message, $context);
+        return $this->addRecord(static::CRITICAL, $message, $context, $extra_stack);
     }
 
     /**
@@ -370,11 +377,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  integer $extra_stack for IntrospectionProcessor stacktrace
      * @return Boolean Whether the record has been processed
      */
-    public function addAlert($message, array $context = array())
+    public function addAlert($message, array $context = array(), $extra_stack = 0)
     {
-        return $this->addRecord(static::ALERT, $message, $context);
+        return $this->addRecord(static::ALERT, $message, $context, $extra_stack);
     }
 
     /**
@@ -382,11 +390,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  integer $extra_stack for IntrospectionProcessor stacktrace
      * @return Boolean Whether the record has been processed
      */
-    public function addEmergency($message, array $context = array())
+    public function addEmergency($message, array $context = array(), $extra_stack = 0)
     {
-        return $this->addRecord(static::EMERGENCY, $message, $context);
+        return $this->addRecord(static::EMERGENCY, $message, $context, $extra_stack);
     }
 
     /**

--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -35,17 +35,12 @@ class IntrospectionProcessor
         'call_user_func_array',
     );
 
-    public function __construct($level = Logger::DEBUG, array $skipClassesPartials = array())
-    {
-        $this->level = Logger::toMonologLevel($level);
-        $this->skipClassesPartials = array_merge(array('Monolog\\'), $skipClassesPartials);
-    }
-
     /**
-     * @param  array $record
+     * @param array   $record
+     * @param integer $extra_stack  -- customize logging of stack trace to extend usability
      * @return array
      */
-    public function __invoke(array $record)
+    public function __invoke(array $record, $extra_stack = 0)
     {
         // return if the level is not high enough
         if ($record['level'] < $this->level) {
@@ -81,14 +76,20 @@ class IntrospectionProcessor
         $record['extra'] = array_merge(
             $record['extra'],
             array(
-                'file'      => isset($trace[$i - 1]['file']) ? $trace[$i - 1]['file'] : null,
-                'line'      => isset($trace[$i - 1]['line']) ? $trace[$i - 1]['line'] : null,
-                'class'     => isset($trace[$i]['class']) ? $trace[$i]['class'] : null,
-                'function'  => isset($trace[$i]['function']) ? $trace[$i]['function'] : null,
+                'file'      => isset($trace[$i + $extra_stack - 1]['file']) ? $trace[$i + $extra_stack - 1]['file'] : null,
+                'line'      => isset($trace[$i + $extra_stack - 1]['line']) ? $trace[$i + $extra_stack - 1]['line'] : null,
+                'class'     => isset($trace[$i + $extra_stack]['class']) ? $trace[$i + $extra_stack]['class'] : null,
+                'function'  => isset($trace[$i + $extra_stack]['function']) ? $trace[$i + $extra_stack]['function'] : null,
             )
         );
 
         return $record;
+    }
+
+    public function __construct($level = Logger::DEBUG, array $skipClassesPartials = array())
+    {
+        $this->level = Logger::toMonologLevel($level);
+        $this->skipClassesPartials = array_merge(array('Monolog\\'), $skipClassesPartials);
     }
 
     private function isTraceClassOrSkippedFunction(array $trace, $index)

--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -36,12 +36,15 @@ class IntrospectionProcessor
     );
 
     /**
-     * @param array   $record
-     * @param integer $extra_stack  -- customize logging of stack trace to extend usability
+     * @param array  $record
+     * @param array  $arguments  -- customize logging of stack trace to extend usability
      * @return array
      */
-    public function __invoke(array $record, $extra_stack = 0)
+    public function __invoke(array $record, $arguments = array())
     {
+        // check for 'extra_stack' in $arguments, set accordingly
+        $extra_stack = isset($arguments['extra_stack']) ? $arguments['extra_stack'] : 0;
+
         // return if the level is not high enough
         if ($record['level'] < $this->level) {
             return $record;


### PR DESCRIPTION
Hello! For starters- I think monolog is very cool. I'm really enjoying using it. One thing that I found I needed was the ability to modify the stack trace in introspection processor, not only so I could have a wrapper around my loggers but so each time I call an add___() I can customize what will end up in the logs stack trace. It seemed like I would be able to achieve this using the $context param, but it doesn't seem like the purpose of the $context param so I added another param to all the functions that call addRecord() called $arguments. I've only utilized it in IntrospectionProcessor but I can imagine other processors could benefit similarly. Please let me know if you think there's a better way to do this or if you have any thoughts. Thank you!