### PR TITLE
added param in InstrospectionProcessor __construct to allow stacktrac…

### DIFF
--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -30,18 +30,18 @@ class IntrospectionProcessor
 
     private $skipClassesPartials;
 
-    private $extra_stack;
+    private $extraStack;
 
     private $skipFunctions = array(
         'call_user_func',
         'call_user_func_array',
     );
 
-    public function __construct($level = Logger::DEBUG, array $skipClassesPartials = array(), $extra_stack = 0)
+    public function __construct($level = Logger::DEBUG, array $skipClassesPartials = array(), $extraStack = 0)
     {
         $this->level = Logger::toMonologLevel($level);
         $this->skipClassesPartials = array_merge(array('Monolog\\'), $skipClassesPartials);
-        $this->extra_stack = $extra_stack;
+        $this->extraStack = $extraStack;
     }
 
     /**
@@ -80,7 +80,7 @@ class IntrospectionProcessor
             break;
         }
 
-        $i += $this->extra_stack;
+        $i += $this->extraStack;
 
         // we should have the call source now
         $record['extra'] = array_merge(

--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -30,18 +30,18 @@ class IntrospectionProcessor
 
     private $skipClassesPartials;
 
-    private $extraStack;
+    private $skipStackFramesCount;
 
     private $skipFunctions = array(
         'call_user_func',
         'call_user_func_array',
     );
 
-    public function __construct($level = Logger::DEBUG, array $skipClassesPartials = array(), $extraStack = 0)
+    public function __construct($level = Logger::DEBUG, array $skipClassesPartials = array(), $skipStackFramesCount = 0)
     {
         $this->level = Logger::toMonologLevel($level);
         $this->skipClassesPartials = array_merge(array('Monolog\\'), $skipClassesPartials);
-        $this->extraStack = $extraStack;
+        $this->skipStackFramesCount = $skipStackFramesCount;
     }
 
     /**
@@ -80,7 +80,7 @@ class IntrospectionProcessor
             break;
         }
 
-        $i += $this->extraStack;
+        $i += $this->skipStackFramesCount;
 
         // we should have the call source now
         $record['extra'] = array_merge(

--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -30,15 +30,18 @@ class IntrospectionProcessor
 
     private $skipClassesPartials;
 
+    private $extra_stack;
+
     private $skipFunctions = array(
         'call_user_func',
         'call_user_func_array',
     );
 
-    public function __construct($level = Logger::DEBUG, array $skipClassesPartials = array())
+    public function __construct($level = Logger::DEBUG, array $skipClassesPartials = array(), $extra_stack = 0)
     {
         $this->level = Logger::toMonologLevel($level);
         $this->skipClassesPartials = array_merge(array('Monolog\\'), $skipClassesPartials);
+        $this->extra_stack = $extra_stack;
     }
 
     /**
@@ -76,6 +79,8 @@ class IntrospectionProcessor
 
             break;
         }
+
+        $i += $this->extra_stack;
 
         // we should have the call source now
         $record['extra'] = array_merge(


### PR DESCRIPTION
…e offset

Wanted to be able to have my handlers wrapped without compromising the value of the stack trace, also needed to be able to adjust stack trace on the fly depending on from where I am logging. Example usage--

```
function monolog_error_log($message = '', $extra_stack = 0) {
    $error_logger = new Logger('FOO_BAR');
    $error_stream = new StreamHandler('var/log/nginx/error.log');
    $formatter = new LineFormatter();
    $introspectionProcessor = new IntrospectionProcessor(Logger::DEBUG, array(), $extra_stack);
    $error_stream->setFormatter($formatter);
    $error_logger->pushProcessor($introspectionProcessor);
    $error_logger->pushHandler($error_stream);
    $error_logger->addError($message);
}
```