### PR TITLE
mongodb/mongodb support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
         "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
         "ext-mongo": "Allow sending log messages to a MongoDB server",
+        "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
         "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
         "rollbar/rollbar": "Allow sending log messages to Rollbar",
         "php-console/php-console": "Allow sending log messages to Google Chrome"

--- a/src/Monolog/Handler/MongoDBHandler.php
+++ b/src/Monolog/Handler/MongoDBHandler.php
@@ -31,8 +31,8 @@ class MongoDBHandler extends AbstractProcessingHandler
 
     public function __construct($mongo, $database, $collection, $level = Logger::DEBUG, $bubble = true)
     {
-        if (!($mongo instanceof \MongoClient || $mongo instanceof \Mongo)) {
-            throw new \InvalidArgumentException('MongoClient or Mongo instance required');
+        if (!($mongo instanceof \MongoClient || $mongo instanceof \Mongo || $mongo instanceof \MongoDB\Client)) {
+            throw new \InvalidArgumentException('MongoClient, Mongo or MongoDB\Client instance required');
         }
 
         $this->mongoCollection = $mongo->selectCollection($database, $collection);

--- a/src/Monolog/Handler/MongoDBHandler.php
+++ b/src/Monolog/Handler/MongoDBHandler.php
@@ -42,7 +42,11 @@ class MongoDBHandler extends AbstractProcessingHandler
 
     protected function write(array $record)
     {
-        $this->mongoCollection->save($record["formatted"]);
+        if ($this->mongoCollection instanceof \MongoDB\Collection) {
+            $this->mongoCollection->insertOne($record["formatted"]);
+        } else {
+            $this->mongoCollection->save($record["formatted"]);
+        }
     }
 
     /**


### PR DESCRIPTION
This should add support for new https://github.com/mongodb/mongo-php-library that deprecates old one (`ext-mongo`).

New library + extension is the only one that will get support for PHP7. It recently got released as beta / release candidate - and I believe this patch should help / ease everyone who's looking forward to PHP7 upgrade.

New client class has the required [`selectCollection`] (http://mongodb.github.io/mongo-php-library/api/class-MongoDB.Client.html#_selectCollection) method that is invoked, however I had to add a case for `MongoDB\Collection` which no longer has `save` method, but [`insertOne`] (http://mongodb.github.io/mongo-php-library/api/class-MongoDB.Collection.html#_insertOne) / [`insertMany`] (http://mongodb.github.io/mongo-php-library/api/class-MongoDB.Collection.html#_insertMany) instead. 

I hope I hadn't missed anything, but I'll happy to rework it if required. Thanks!