### PR TITLE
Add HTTP_X_FORWARDED_IP (if set) when user wants to log IP

### DIFF
--- a/src/Monolog/Processor/WebProcessor.php
+++ b/src/Monolog/Processor/WebProcessor.php
@@ -108,6 +108,13 @@ class WebProcessor
             $extra['unique_id'] = $this->serverData['UNIQUE_ID'];
         }
 
+        // Add forwarded IP, useful eg when application runs behind loadbalancer
+        if (array_key_exists('ip', $this->extraFields)) {
+            if (array_key_exists('HTTP_X_FORWARDED_FOR', $this->serverData)) {
+                $extra['forwarded_ip'] = $this->serverData['HTTP_X_FORWARDED_FOR'];
+            }
+        }
+
         return $extra;
     }
 }


### PR DESCRIPTION
Add HTTP_X_FORWARDED_IP (if set) when user wants to log IP from $_SERVER array, useful behind loadbalancer eg.

In our current setup the loadbalancer IP is in $_SERVER['REMOTE_ADDR'], which is not particularly useful in my case. Checking for the existence of HTTP_X_FORWARDED_IP can be useful in this case, and will only be added if user was requesting for the IP already.