### PR TITLE
Add fluentd formatter.

### DIFF
--- a/src/Monolog/Formatter/FluentdFormatter.php
+++ b/src/Monolog/Formatter/FluentdFormatter.php
@@ -35,6 +35,9 @@ namespace Monolog\Formatter;
 
 class FluentdFormatter implements FormatterInterface
 {
+    /**
+     * @var bool $levelTag - should message level be a part of the fluentd tag
+     */
     protected $levelTag = false;
 
     public function __construct($levelTag = false)
@@ -58,16 +61,22 @@ class FluentdFormatter implements FormatterInterface
             $tag .= '.' . strtolower($record['level_name']);
         }
 
+        $message = array(
+            'message' => $record['message'],
+            'extra' => $record['extra']
+        );
+
+        if (!$this->levelTag) {
+            $message['level'] = $record['level'];
+            $message['level_name'] = $record['level_name'];
+        }
+
         return '['
         . '"' . $tag . '"'
         . ', '
         . $record['datetime']->getTimestamp()
         . ', '
-        . json_encode(array(
-            'message' => $record['message'],
-            'level' => $record['level'],
-            'level_name' => $record['level_name'],
-            'extra' => $record['extra']))
+        . json_encode($message)
         . ']';
     }
 

--- a/src/Monolog/Formatter/FluentdFormatter.php
+++ b/src/Monolog/Formatter/FluentdFormatter.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+/**
+ * Class FluentdFormatter
+ *
+ * Serializes a log message to Fluetd unix socket protocol
+ *
+ * Fluentd config:
+ *
+ * <source>
+ *  type unix
+ *  path /var/run/td-agent/td-agent.sock
+ * </source>
+ *
+ * Monolog setup:
+ *
+ * $logger = new Monolog\Logger('fluent.tag');
+ * $fluentHandler = new Monolog\Handler\SocketHandler('unix:///var/run/td-agent/td-agent.sock');
+ * $fluentHandler->setFormatter(new Monolog\Formatter\FluentdFormatter());
+ * $logger->pushHandler($fluentHandler);
+ *
+ * @author Andrius Putna <fordnox@gmail.com>
+ */
+
+class FluentdFormatter implements FormatterInterface
+{
+    protected $levelTag = false;
+
+    public function __construct($levelTag = false)
+    {
+        if (!function_exists('json_encode')) {
+            throw new \RuntimeException('PHP\'s json extension is required to use Monolog\'s FluentdUnixFormatter');
+        }
+
+        $this->levelTag = (bool)$levelTag;
+    }
+
+    public function isUsingLevelsInTag()
+    {
+        return $this->levelTag;
+    }
+
+    public function format(array $record)
+    {
+        $tag = $record['channel'];
+        if ($this->levelTag) {
+            $tag .= '.' . strtolower($record['level_name']);
+        }
+
+        return '['
+        . '"' . $tag . '"'
+        . ', '
+        . $record['datetime']->getTimestamp()
+        . ', '
+        . json_encode([
+            'message' => $record['message'],
+            'level' => $record['level'],
+            'level_name' => $record['level_name'],
+            'extra' => $record['extra']])
+        . ']';
+    }
+
+    public function formatBatch(array $records)
+    {
+        $message = '';
+        foreach ($records as $record) {
+            $message .= $this->format($record);
+        }
+        return $message;
+    }
+}

--- a/src/Monolog/Formatter/FluentdFormatter.php
+++ b/src/Monolog/Formatter/FluentdFormatter.php
@@ -14,7 +14,7 @@ namespace Monolog\Formatter;
 /**
  * Class FluentdFormatter
  *
- * Serializes a log message to Fluetd unix socket protocol
+ * Serializes a log message to Fluentd unix socket protocol
  *
  * Fluentd config:
  *
@@ -63,11 +63,11 @@ class FluentdFormatter implements FormatterInterface
         . ', '
         . $record['datetime']->getTimestamp()
         . ', '
-        . json_encode([
+        . json_encode(array(
             'message' => $record['message'],
             'level' => $record['level'],
             'level_name' => $record['level_name'],
-            'extra' => $record['extra']])
+            'extra' => $record['extra']))
         . ']';
     }
 

--- a/tests/Monolog/Formatter/FluentdFormatterTest.php
+++ b/tests/Monolog/Formatter/FluentdFormatterTest.php
@@ -35,18 +35,26 @@ class FluentdFormatterTest extends TestCase
      */
     public function testFormat()
     {
-
         $record = $this->getRecord(Logger::WARNING);
         $record['datetime'] = new \DateTime("@0");
 
         $formatter = new FluentdFormatter();
         $this->assertEquals(
-            '["test", 0, {"message":"test","level":300,"level_name":"WARNING","extra":[]}]',
+            '["test", 0, {"message":"test","extra":[],"level":300,"level_name":"WARNING"}]',
             $formatter->format($record));
+    }
+
+    /**
+     * @covers Monolog\Formatter\FluentdFormatter::format
+     */
+    public function testFormatWithTag()
+    {
+        $record = $this->getRecord(Logger::ERROR);
+        $record['datetime'] = new \DateTime("@0");
 
         $formatter = new FluentdFormatter(true);
         $this->assertEquals(
-            '["test.warning", 0, {"message":"test","level":300,"level_name":"WARNING","extra":[]}]',
+            '["test.error", 0, {"message":"test","extra":[]}]',
             $formatter->format($record));
     }
 }

--- a/tests/Monolog/Formatter/FluentdFormatterTest.php
+++ b/tests/Monolog/Formatter/FluentdFormatterTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Monolog\Logger;
+use Monolog\TestCase;
+
+class FluentdFormatterTest extends TestCase
+{
+    /**
+     * @covers Monolog\Formatter\FluentdFormatter::__construct
+     * @covers Monolog\Formatter\FluentdFormatter::isUsingLevelsInTag
+     */
+    public function testConstruct()
+    {
+        $formatter = new FluentdFormatter();
+        $this->assertEquals(false, $formatter->isUsingLevelsInTag());
+        $formatter = new FluentdFormatter(false);
+        $this->assertEquals(false, $formatter->isUsingLevelsInTag());
+        $formatter = new FluentdFormatter(true);
+        $this->assertEquals(true, $formatter->isUsingLevelsInTag());
+    }
+
+    /**
+     * @covers Monolog\Formatter\FluentdFormatter::format
+     */
+    public function testFormat()
+    {
+
+        $record = $this->getRecord(Logger::WARNING);
+        $record['datetime'] = new \DateTime("@0");
+
+        $formatter = new FluentdFormatter();
+        $this->assertEquals(
+            '["test", 0, {"message":"test","level":300,"level_name":"WARNING","extra":[]}]',
+            $formatter->format($record));
+
+        $formatter = new FluentdFormatter(true);
+        $this->assertEquals(
+            '["test.warning", 0, {"message":"test","level":300,"level_name":"WARNING","extra":[]}]',
+            $formatter->format($record));
+    }
+}


### PR DESCRIPTION
Serializes a log message to Fluentd unix socket protocol.

Fluentd config:

```
<source>
   type unix
   path /var/run/td-agent/td-agent.sock
</source>
 ```

  Monolog setup:
```php
 $logger = new Monolog\Logger('fluent.tag');
 $fluentHandler = new Monolog\Handler\SocketHandler('unix:///var/run/td-agent/td-agent.sock');
 $fluentHandler->setFormatter(new Monolog\Formatter\FluentdFormatter());
 $logger->pushHandler($fluentHandler);
```