### PR TITLE
[HipChatHandler] Always send the "from" name

### DIFF
--- a/src/Monolog/Handler/HipChatHandler.php
+++ b/src/Monolog/Handler/HipChatHandler.php
@@ -141,12 +141,17 @@ class HipChatHandler extends SocketHandler
             'message' => $record['formatted'],
             'message_format' => $this->format,
             'color' => $this->getAlertColor($record['level']),
-            'from' => $this->name,
         );
 
         // if we are using the legacy API then we need to send some additional information
         if ($this->version == self::API_V1) {
             $dataArray['room_id'] = $this->room;
+        }
+
+        // append the sender name if it is set
+        // always append it if we use the v1 api (it is required in v1)
+        if ($this->version == self::API_V1 || $this->name !== null) {
+            $dataArray['from'] = (string) $this->name;
         }
 
         return http_build_query($dataArray);

--- a/src/Monolog/Handler/HipChatHandler.php
+++ b/src/Monolog/Handler/HipChatHandler.php
@@ -141,12 +141,12 @@ class HipChatHandler extends SocketHandler
             'message' => $record['formatted'],
             'message_format' => $this->format,
             'color' => $this->getAlertColor($record['level']),
+            'from' => $this->name,
         );
 
         // if we are using the legacy API then we need to send some additional information
         if ($this->version == self::API_V1) {
             $dataArray['room_id'] = $this->room;
-            $dataArray['from'] = $this->name;
         }
 
         return http_build_query($dataArray);

--- a/tests/Monolog/Handler/HipChatHandlerTest.php
+++ b/tests/Monolog/Handler/HipChatHandlerTest.php
@@ -21,6 +21,7 @@ use Monolog\Logger;
 class HipChatHandlerTest extends TestCase
 {
     private $res;
+    /** @var  HipChatHandler */
     private $handler;
 
     public function testWriteHeader()
@@ -91,6 +92,18 @@ class HipChatHandlerTest extends TestCase
         $this->assertRegexp('/notify=0&message=test1&message_format=text&color=red&room_id=room1&from=Monolog$/', $content);
     }
 
+    public function testWriteContentV1WithoutName()
+    {
+        $this->createHandler('myToken', 'room1', null, false, 'hipchat.foo.bar', 'v1');
+        $this->handler->handle($this->getRecord(Logger::CRITICAL, 'test1'));
+        fseek($this->res, 0);
+        $content = fread($this->res, 1024);
+
+        $this->assertRegexp('/notify=0&message=test1&message_format=text&color=red&room_id=room1&from=$/', $content);
+
+        return $content;
+    }
+
     /**
      * @depends testWriteCustomHostHeader
      */
@@ -104,7 +117,7 @@ class HipChatHandlerTest extends TestCase
      */
     public function testWriteContentV2($content)
     {
-        $this->assertRegexp('/notify=false&message=test1&message_format=text&color=red$/', $content);
+        $this->assertRegexp('/notify=false&message=test1&message_format=text&color=red&from=Monolog$/', $content);
     }
 
     /**
@@ -112,7 +125,19 @@ class HipChatHandlerTest extends TestCase
      */
     public function testWriteContentV2Notify($content)
     {
-        $this->assertRegexp('/notify=true&message=test1&message_format=text&color=red$/', $content);
+        $this->assertRegexp('/notify=true&message=test1&message_format=text&color=red&from=Monolog$/', $content);
+    }
+
+    public function testWriteContentV2WithoutName()
+    {
+        $this->createHandler('myToken', 'room1', null, false, 'hipchat.foo.bar', 'v2');
+        $this->handler->handle($this->getRecord(Logger::CRITICAL, 'test1'));
+        fseek($this->res, 0);
+        $content = fread($this->res, 1024);
+
+        $this->assertRegexp('/notify=false&message=test1&message_format=text&color=red$/', $content);
+
+        return $content;
     }
 
     public function testWriteWithComplexMessage()


### PR DESCRIPTION
Although the docs for API version v2 are very sparse, a quick test confirmed, that the name should always be sent:

Without the patch:
![2015-11-17 at 18 52](https://cloud.githubusercontent.com/assets/1032411/11219742/7570a3f0-8d5c-11e5-8796-a1b856e2e955.png)

With the patch (sorry for obfuscation, client name...):
![2015-11-17 at 18 53](https://cloud.githubusercontent.com/assets/1032411/11219754/8238a9fc-8d5c-11e5-88d3-0ef33b25fb0c.png)

(same config)
