### PR TITLE
Add php-cs-fixer to tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "swiftmailer/swiftmailer": "~5.3",
         "php-console/php-console": "^3.1.3",
         "phpunit/phpunit-mock-objects": "2.3.0",
-        "jakub-onderka/php-parallel-lint": "0.9"
+        "jakub-onderka/php-parallel-lint": "0.9",
+        "fabpot/php-cs-fixer": "^2.0@dev"
     },
     "_": "phpunit/phpunit-mock-objects required in 2.3.0 due to https://github.com/sebastianbergmann/phpunit-mock-objects/issues/223 - needs hhvm 3.8+ on travis",
     "suggest": {
@@ -60,7 +61,9 @@
     "scripts": {
         "test": [
             "parallel-lint . --exclude vendor",
-            "phpunit"
-        ]
+            "phpunit",
+            "php-cs-fixer -vv fix --dry-run"
+        ],
+        "php-cs-fixer": "php-cs-fixer -vv fix"
     }
 }


### PR DESCRIPTION
Add a step using `php-cs-fixer -vv fix --dry-run` to the `composer test`
script command used by Travis CI tests.