### PR TITLE
Logger iterating over an associate array of handlers

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -315,9 +315,17 @@ class Logger implements LoggerInterface
         foreach ($this->processors as $processor) {
             $record = call_user_func($processor, $record);
         }
-        while (isset($this->handlers[$handlerKey]) &&
-            false === $this->handlers[$handlerKey]->handle($record)) {
-            $handlerKey++;
+        $foundStartingKey = false;
+        foreach ($this->handlers as $key => $handler) {
+            if ($key === $handlerKey) {
+                $foundStartingKey = true;
+            }
+            if ($foundStartingKey === false) {
+                continue;
+            }
+            if (true === $handler->handle($record)) {
+                break;
+            }
         }
 
         return true;


### PR DESCRIPTION
Changed iterating over the $handlers array to allow for correct sequential processing regardless of array containing indexed numerical keys, or associative string keys in the array.

It iterates over the entire array until it finds the $handlerKey that was identified earlier using isHandling(). Once the starting position is found it will execute handle() on each handler unless a handler returns true indicating the handler completed the processing of the record, bubbling to the next handler should not occur, and the loop breaks.

This fixes an issue where an associative array of handlers is passed into the Logger constructor when instantiated.
magento/magento2#2529
Seldaek/monolog#691