### PR TITLE
Removed substr call in amqp routing key generator

### DIFF
--- a/src/Monolog/Handler/AmqpHandler.php
+++ b/src/Monolog/Handler/AmqpHandler.php
@@ -114,12 +114,7 @@ class AmqpHandler extends AbstractProcessingHandler
      */
     private function getRoutingKey(array $record)
     {
-        $routingKey = sprintf(
-            '%s.%s',
-            // TODO 2.0 remove substr call
-            substr($record['level_name'], 0, 4),
-            $record['channel']
-        );
+        $routingKey = sprintf('%s.%s', $record['level_name'], $record['channel']);
 
         return strtolower($routingKey);
     }

--- a/tests/Monolog/Handler/AmqpHandlerTest.php
+++ b/tests/Monolog/Handler/AmqpHandlerTest.php
@@ -61,7 +61,7 @@ class AmqpHandlerTest extends TestCase
                 'channel' => 'test',
                 'extra' => array(),
             ),
-            'warn.test',
+            'warning.test',
             0,
             array(
                 'delivery_mode' => 2,
@@ -111,7 +111,7 @@ class AmqpHandlerTest extends TestCase
                 'extra' => array(),
             ),
             'log',
-            'warn.test',
+            'warning.test',
             false,
             false,
             null,


### PR DESCRIPTION
Fixed todo from #197

> Remove substr TODO in AmqpHandler