### PR TITLE
Removed unnecessary php version checks after php dependency bump to 7.0

### DIFF
--- a/src/Monolog/Formatter/HtmlFormatter.php
+++ b/src/Monolog/Formatter/HtmlFormatter.php
@@ -132,10 +132,7 @@ class HtmlFormatter extends NormalizerFormatter
         }
 
         $data = $this->normalize($data);
-        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
-            return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
-        }
 
-        return str_replace('\\/', '/', json_encode($data));
+        return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 }

--- a/src/Monolog/Formatter/LineFormatter.php
+++ b/src/Monolog/Formatter/LineFormatter.php
@@ -141,11 +141,7 @@ class LineFormatter extends NormalizerFormatter
             return (string) $data;
         }
 
-        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
-            return $this->toJson($data, true);
-        }
-
-        return str_replace('\\/', '/', @json_encode($data));
+        return $this->toJson($data, true);
     }
 
     protected function replaceNewlines($str)

--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -168,11 +168,7 @@ class NormalizerFormatter implements FormatterInterface
      */
     private function jsonEncode($data)
     {
-        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
-            return json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
-        }
-
-        return json_encode($data);
+        return json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 
     /**

--- a/tests/Monolog/Formatter/LogstashFormatterTest.php
+++ b/tests/Monolog/Formatter/LogstashFormatterTest.php
@@ -296,10 +296,6 @@ class LogstashFormatterTest extends \PHPUnit_Framework_TestCase
 
     public function testFormatWithLatin9Data()
     {
-        if (version_compare(PHP_VERSION, '5.5.0', '<')) {
-            // Ignore the warning that will be emitted by PHP <5.5.0
-            \PHPUnit_Framework_Error_Warning::$enabled = false;
-        }
         $formatter = new LogstashFormatter('test', 'hostname');
         $record = array(
             'level' => Logger::ERROR,
@@ -322,12 +318,6 @@ class LogstashFormatterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(Logger::ERROR, $message['@fields']['level']);
         $this->assertEquals('test', $message['@type']);
         $this->assertEquals('hostname', $message['@source']);
-        if (version_compare(PHP_VERSION, '5.5.0', '>=')) {
-            $this->assertEquals('ÖWN; FBCR/OrangeEspaña; Versão/4.0; Färist', $message['@fields']['user_agent']);
-        } else {
-            // PHP <5.5 does not return false for an element encoding failure,
-            // instead it emits a warning (possibly) and nulls the value.
-            $this->assertEquals(null, $message['@fields']['user_agent']);
-        }
+        $this->assertEquals('ÖWN; FBCR/OrangeEspaña; Versão/4.0; Färist', $message['@fields']['user_agent']);
     }
 }

--- a/tests/Monolog/Formatter/ScalarFormatterTest.php
+++ b/tests/Monolog/Formatter/ScalarFormatterTest.php
@@ -37,11 +37,7 @@ class ScalarFormatterTest extends \PHPUnit_Framework_TestCase
 
     public function encodeJson($data)
     {
-        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
-            return json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
-        }
-
-        return json_encode($data);
+        return json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 
     public function testFormat()


### PR DESCRIPTION
Fixed todo from #197 

> Check all PHP_VERSION and version_compare checks for relevance