### PR TITLE
Changed LOG_LOCALx constants to their numeric values in AbstractSyslogHandler.php

### DIFF
--- a/src/Monolog/Handler/AbstractSyslogHandler.php
+++ b/src/Monolog/Handler/AbstractSyslogHandler.php
@@ -61,16 +61,14 @@ abstract class AbstractSyslogHandler extends AbstractProcessingHandler
     {
         parent::__construct($level, $bubble);
 
-        if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
-            $this->facilities['local0'] = LOG_LOCAL0;
-            $this->facilities['local1'] = LOG_LOCAL1;
-            $this->facilities['local2'] = LOG_LOCAL2;
-            $this->facilities['local3'] = LOG_LOCAL3;
-            $this->facilities['local4'] = LOG_LOCAL4;
-            $this->facilities['local5'] = LOG_LOCAL5;
-            $this->facilities['local6'] = LOG_LOCAL6;
-            $this->facilities['local7'] = LOG_LOCAL7;
-        }
+        $this->facilities['local0'] = 128; // LOG_LOCAL0
+        $this->facilities['local1'] = 136; // LOG_LOCAL1
+        $this->facilities['local2'] = 144; // LOG_LOCAL2
+        $this->facilities['local3'] = 152; // LOG_LOCAL3
+        $this->facilities['local4'] = 160; // LOG_LOCAL4
+        $this->facilities['local5'] = 168; // LOG_LOCAL5
+        $this->facilities['local6'] = 176; // LOG_LOCAL6
+        $this->facilities['local7'] = 184; // LOG_LOCAL7
 
         // convert textual description of facility to syslog constant
         if (array_key_exists(strtolower($facility), $this->facilities)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

LOG_LOCALx constants are unavailable in Windows so we cannot used them in cross-platform code, but the local facilities has to be defined to avoid throwing `Unknown facility value...` exceptions on Windows.

Our use case: We are using Symfony with enabled syslog logging in `config_prod.yml`:

```yml
monolog:
    handlers:
        syslog:
            type: syslog
            level: error
            ident: php-project
            facility: local3
```
Everything works OK on Linux, but in Windows (developer's machine) it ends with error: `Unknown facility value "local3" given`.