### PR TITLE
Fix \n characters in the ErrorHandler stack trace.

### DIFF
--- a/src/Monolog/Formatter/LineFormatter.php
+++ b/src/Monolog/Formatter/LineFormatter.php
@@ -147,7 +147,7 @@ class LineFormatter extends NormalizerFormatter
     protected function replaceNewlines($str)
     {
         if ($this->allowInlineLineBreaks) {
-            return $str;
+            return str_replace('\n', "\n", $str);
         }
 
         return str_replace(array("\r\n", "\r", "\n"), ' ', $str);


### PR DESCRIPTION
The stack trace generated by the LineFormatter contains \n characters instead of newlines with ErrorHandler errors. This should fix it.