### PR TITLE
Add Understand.io handler, formatter & tests

### DIFF
--- a/doc/02-handlers-formatters-processors.md
+++ b/doc/02-handlers-formatters-processors.md
@@ -53,6 +53,7 @@
 - _RollbarHandler_: Logs records to a [Rollbar](https://rollbar.com/) account.
 - _SyslogUdpHandler_: Logs records to a remote [Syslogd](http://www.rsyslog.com/) server.
 - _LogEntriesHandler_: Logs records to a [LogEntries](http://logentries.com/) account.
+- _UnderstandHandler_: Logs records to an [Understand.io](http://understand.io/) channel.
 
 ### Logging in development
 
@@ -121,6 +122,7 @@
 - _LogglyFormatter_: Used to format log records into Loggly messages, only useful for the LogglyHandler.
 - _FlowdockFormatter_: Used to format log records into Flowdock messages, only useful for the FlowdockHandler.
 - _MongoDBFormatter_: Converts \DateTime instances to \MongoDate and objects recursively to arrays, only useful with the MongoDBHandler.
+- _UnderstandFormatter_: Used to format log records into [Understand.io](http://understand.io/) messages, only useful with the UnderstandHandler.
 
 ## Processors
 

--- a/src/Monolog/Formatter/UnderstandFormatter.php
+++ b/src/Monolog/Formatter/UnderstandFormatter.php
@@ -1,0 +1,85 @@
+<?php 
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\JsonFormatter;
+
+/**
+ * Formats record into JSON in a format compatible with Understand.io API.
+ *
+ * @author Aivis Silins <aivis.silins@gmail.com>
+ */
+class UnderstandFormatter extends JsonFormatter implements FormatterInterface
+{
+
+    /**
+     * @param integer $batchMode
+     * @param boolean $appendNewline
+     */
+    public function __construct($batchMode = self::BATCH_MODE_JSON, $appendNewline = false)
+    {
+        parent::__construct($batchMode, $appendNewline);
+    }
+    
+    /**
+     * Format record
+     *
+     * @param array $record
+     * @return string
+     */
+    public function format(array $record)
+    {
+        $recordWithTimestamp = $this->convertDatetime($record);
+
+        return parent::format($recordWithTimestamp);
+    }
+
+    /**
+     * Format batch of records
+     *
+     * @param array $records
+     * @return string
+     */
+    public function formatBatch(array $records)
+    {
+        $batch = [];
+
+        foreach($records as $record)
+        {
+            $batch[] = $this->convertDatetime($record);
+        }
+
+        return parent::format($batch);
+    }
+
+    /**
+     * Convert datetime to timestamp format (milliseconds)
+     *
+     * @param array $record
+     * @return array
+     */
+    protected function convertDatetime(array $record)
+    {
+        if (isset($record['datetime']) && $record['datetime'] instanceof \DateTime)
+        {
+            // U - Seconds since the Unix Epoch
+            // u - Microseconds (added in PHP 5.2.2). Note that date() will always generate 000000
+            // http://php.net/manual/en/function.date.php
+            $record['timestamp'] = intval(round((float)$record['datetime']->format('U.u') * 1000));
+
+            unset($record['datetime']);
+        }
+
+        return $record;
+    }
+}

--- a/src/Monolog/Formatter/UnderstandFormatter.php
+++ b/src/Monolog/Formatter/UnderstandFormatter.php
@@ -52,7 +52,7 @@ class UnderstandFormatter extends JsonFormatter implements FormatterInterface
      */
     public function formatBatch(array $records)
     {
-        $batch = [];
+        $batch = array();
 
         foreach($records as $record)
         {

--- a/src/Monolog/Handler/UnderstandHandler.php
+++ b/src/Monolog/Handler/UnderstandHandler.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Logger;
+use Monolog\Formatter\UnderstandFormatter;
+
+/**
+ * Sends records to Understand.io
+ *
+ * Requirement is that CURL command line tool is installed and functioning correctly. 
+ * To check whether CURL is available on your system, 
+ * execute the following command in your console "curl -h"
+ * If you see instructions on how to use CURL 
+ * then your system has the CURL binary installed and you can use the async handler.
+ * 
+ * @author Aivis Silins <aivis.silins@gmail.com>
+ * @see    https://www.understand.io/docs
+ */
+class UnderstandHandler extends AbstractProcessingHandler
+{
+    
+    /**
+     * Input key
+     *
+     * @var string
+     */
+    protected $inputKey;
+
+    /**
+     * API url
+     *
+     * @var string
+     */
+    protected $apiUrl;
+
+    /**
+     * @param string $inputKey
+     * @param string $apiUrl
+     * @param integer $level
+     * @param boolean $bubble
+     */
+    public function __construct($inputKey, $apiUrl = 'https://api.understand.io', $level = Logger::DEBUG, $bubble = true)
+    {
+        $this->inputKey = $inputKey;
+        $this->apiUrl = $apiUrl;
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * Serialize data and send to storage
+     *
+     * @param array $record
+     * @return void
+     */
+    public function write(array $record)
+    {
+        $requestData = $record['formatted'];
+
+        $this->send($requestData);
+    }
+
+    /**
+     * Return endpoint
+     *
+     * @return string
+     */
+    protected function getEndpoint()
+    {
+        return implode('/', array($this->apiUrl, $this->inputKey));
+    }
+    
+    /**
+     * Send data 
+     *
+     * @param string $requestData
+     * @return void
+     */
+    protected function send($requestData)
+    {
+        $parts = array(
+            'curl',
+            '-X POST',
+            '-d',
+            escapeshellarg($requestData),
+            $this->getEndpoint(),
+            '> /dev/null 2>&1 &'
+        );
+
+        $cmd = implode(' ', $parts);
+
+        $this->exec($cmd);
+    }
+
+    /**
+     * Execute call
+     * 
+     * @param string $cmd
+     * @return void
+     */
+    protected function exec($cmd)
+    {
+        exec($cmd);
+    }
+    
+    /**
+     * Gets the default formatter.
+     *
+     * @return FormatterInterface
+     */
+    protected function getDefaultFormatter()
+    {
+        return new UnderstandFormatter();
+    }
+}

--- a/tests/Monolog/Formatter/UnderstandFormatterTest.php
+++ b/tests/Monolog/Formatter/UnderstandFormatterTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+class UnderstandFormatterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFormatArrayWithDatetime()
+    {
+        $formatter = new UnderstandFormatter();
+
+        $microtime = microtime(true);
+        $miliseconds = round($microtime * 1000);
+        $datetime = \DateTime::createFromFormat('U.u', sprintf('%.6F', $microtime));
+
+        $array = array(
+            'message' => 'test',
+            'datetime' => $datetime
+        );
+
+        $resultJson = $formatter->format($array);
+        $decoded = json_decode($resultJson, true);
+
+        $this->assertEquals($miliseconds, $decoded['timestamp']);
+        $this->assertEquals($array['message'], $decoded['message']);
+    }
+    
+    public function testFormatArrayWithoutDatetime()
+    {
+        $formatter = new UnderstandFormatter();
+
+        $array = array(
+            'message' => 'test'
+        );
+
+        $resultJson = $formatter->format($array);
+        $decoded = json_decode($resultJson, true);
+
+        $this->assertEquals($array['message'], $decoded['message']);
+    }
+    
+    public function testFormatBatch()
+    {
+        $formatter = new UnderstandFormatter();
+        $microtime = microtime(true);
+        $miliseconds = round($microtime * 1000);
+        $datetime = \DateTime::createFromFormat('U.u', sprintf('%.6F', $microtime));
+
+        $array = array(
+            array(
+                'message' => 'this is test',
+                'datetime' => $datetime
+            ),
+            array(
+                'message' => 'this is test 2',
+                'datetime' => $datetime
+            )
+        );
+
+        $resultJson = $formatter->formatBatch($array);
+        $decoded = json_decode($resultJson, true);
+
+        $this->assertEquals($miliseconds, $decoded[0]['timestamp']);
+        $this->assertEquals($miliseconds, $decoded[1]['timestamp']);
+
+        $this->assertEquals($array[0]['message'], $decoded[0]['message']);
+        $this->assertEquals($array[1]['message'], $decoded[1]['message']);
+    }
+}

--- a/tests/Monolog/Handler/UnderstandHandlerTest.php
+++ b/tests/Monolog/Handler/UnderstandHandlerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\TestCase;
+
+class UnderstandHandlerTest extends TestCase
+{
+    public function testHandler()
+    {
+        $inputKey = 'input-key';
+     
+        $constructorArgs = array($inputKey);
+        
+        $this->handler = $this->getMock(
+            '\Monolog\Handler\UnderstandHandler',
+            array('exec'),
+            $constructorArgs
+        );
+
+        $cmd = null;
+        
+        $this->handler->expects($this->any())
+        ->method('exec')
+        ->will($this->returnCallback(function($curlCall) use(&$cmd)
+        {
+            $cmd = $curlCall;
+        }));
+        
+        $record = $this->getRecord();
+        $this->handler->handle($record);
+
+        $this->assertNotEmpty($cmd);
+        $this->assertContains('curl -X POST -d', $cmd);
+        $this->assertContains(implode(' ', array('https://api.understand.io/' . $inputKey, '> /dev/null 2>&1 &')), $cmd);   
+    }
+}


### PR DESCRIPTION
Add handler for [Understand.io](https://www.understand.io)

Handler uses `curl` command line tool to deliver data.