### PR TITLE
add release number to every log

### DIFF
--- a/src/Monolog/Handler/RavenHandler.php
+++ b/src/Monolog/Handler/RavenHandler.php
@@ -39,6 +39,12 @@ class RavenHandler extends AbstractProcessingHandler
     );
 
     /**
+     * @var string should represent the current version of the calling
+     *             software. Can be any string (git commit, version number)
+     */
+    private $release;
+
+    /**
      * @var Raven_Client the client object that sends the message to the server
      */
     protected $ravenClient;
@@ -169,6 +175,10 @@ class RavenHandler extends AbstractProcessingHandler
             $options['extra']['extra'] = $record['extra'];
         }
 
+        if (!empty($this->release) && !isset($options['release'])) {
+            $options['release'] = $this->release;
+        }
+
         if (isset($record['context']['exception']) && $record['context']['exception'] instanceof \Exception) {
             $options['extra']['message'] = $record['formatted'];
             $this->ravenClient->captureException($record['context']['exception'], $options);
@@ -207,5 +217,15 @@ class RavenHandler extends AbstractProcessingHandler
     protected function getExtraParameters()
     {
         return array('checksum', 'release');
+    }
+
+    /**
+     * @param string $value
+     */
+    public function setRelease($value)
+    {
+        $this->release = $value;
+
+        return $this;
     }
 }

--- a/tests/Monolog/Handler/RavenHandlerTest.php
+++ b/tests/Monolog/Handler/RavenHandlerTest.php
@@ -204,6 +204,22 @@ class RavenHandlerTest extends TestCase
         $this->assertSame($formatter, $handler->getBatchFormatter());
     }
 
+    public function testRelease()
+    {
+        $ravenClient = $this->getRavenClient();
+        $handler = $this->getHandler($ravenClient);
+        $release = 'v42.42.42';
+        $handler->setRelease($release);
+        $record = $this->getRecord(Logger::INFO, 'test');
+        $handler->handle($record);
+        $this->assertEquals($release, $ravenClient->lastData['release']);
+
+        $localRelease = 'v41.41.41';
+        $record = $this->getRecord(Logger::INFO, 'test', array('release' => $localRelease));
+        $handler->handle($record);
+        $this->assertEquals($localRelease, $ravenClient->lastData['release']);
+    }
+
     private function methodThatThrowsAnException()
     {
         throw new \Exception('This is an exception');


### PR DESCRIPTION
This adds an internal release number to the raven handler. The release
number is added to what is sent to sentry unless something already is
present because a release number was sent via "context" or "extra".

An abstraction might be introduced somewhere to represent release number generators, so that different generators might be implemented, but I am not sure where, and I am also unsure whether such a class should be injected instead of the release number. In short, should it work like this : 

```
$releaseNumberGenerator = new GitDescribeReleaseNumberGenerator();
$ravenHandler->setRelease($releaseNumberGenerator->generate());
```

or like this : 

```
$ravenHandler->setReleaseGenerator($releaseNumberGenerator);
// the handler calls generate() internally
```

or if both things should be possible.

Finally, I named the internal variable "release" instead of "releaseNumber" because of what already existed, but I am ok to change that.