### PR TITLE
Instantiate LineFormatter only when configured to use short attachment

### DIFF
--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -96,7 +96,8 @@ class SlackHandler extends SocketHandler
         $this->useAttachment = $useAttachment;
         $this->useShortAttachment = $useShortAttachment;
         $this->includeContextAndExtra = $includeContextAndExtra;
-        if ($this->includeContextAndExtra) {
+
+        if ($this->includeContextAndExtra && $this->useShortAttachment) {
             $this->lineFormatter = new LineFormatter;
         }
     }


### PR DESCRIPTION
We don't need LineFormatter when not configured to use short attachment.
I think current tests will be enough to cover this behavior.