### PR TITLE
Fixed small syntax bug with BrowserConsoleHandler preventing console …

### DIFF
--- a/src/Monolog/Handler/BrowserConsoleHandler.php
+++ b/src/Monolog/Handler/BrowserConsoleHandler.php
@@ -65,7 +65,7 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
 
         if (count(self::$records)) {
             if ($format === 'html') {
-                self::writeOutput('<script>', self::generateScript(), '</script>');
+                self::writeOutput('<script>' . self::generateScript() . '</script>');
             } elseif ($format === 'js') {
                 self::writeOutput(self::generateScript());
             }


### PR DESCRIPTION
…output

Replaced commas in send() method when calling generateScript() - this was
preventing any javascript from being output