### PR TITLE
Fix content_type for AMQP Message

### DIFF
--- a/src/Monolog/Handler/AmqpHandler.php
+++ b/src/Monolog/Handler/AmqpHandler.php
@@ -65,7 +65,7 @@ class AmqpHandler extends AbstractProcessingHandler
                 0,
                 array(
                     'delivery_mode' => 2,
-                    'Content-type' => 'application/json',
+                    'content_type' => 'application/json',
                 )
             );
         } else {

--- a/tests/Monolog/Handler/AmqpHandlerTest.php
+++ b/tests/Monolog/Handler/AmqpHandlerTest.php
@@ -65,7 +65,7 @@ class AmqpHandlerTest extends TestCase
             0,
             array(
                 'delivery_mode' => 2,
-                'Content-type' => 'application/json',
+                'content_type' => 'application/json',
             ),
         );
 


### PR DESCRIPTION
If use the AmqpHandler with the php-ext amqp, the content type is `plain/text` for each message in the queue because the property name is wrong written.

This pull request, change the property name `Content-type` by correct property name `content_type`.

The patch work fine with RabbitMQ.