### PR TITLE
Add milliseconds to ElasticaFormatter as default

### DIFF
--- a/src/Monolog/Formatter/ElasticaFormatter.php
+++ b/src/Monolog/Formatter/ElasticaFormatter.php
@@ -36,7 +36,9 @@ class ElasticaFormatter extends NormalizerFormatter
      */
     public function __construct($index, $type)
     {
-        parent::__construct(\DateTime::ISO8601);
+        // elasticsearch requires a ISO 8601 format date with optional millisecond precision.
+        parent::__construct('Y-m-d\TH:i:s.uP');
+
         $this->index = $index;
         $this->type = $type;
     }

--- a/tests/Monolog/Formatter/ElasticaFormatterTest.php
+++ b/tests/Monolog/Formatter/ElasticaFormatterTest.php
@@ -42,7 +42,7 @@ class ElasticaFormatterTest extends \PHPUnit_Framework_TestCase
 
         // expected values
         $expected = $msg;
-        $expected['datetime'] = '1970-01-01T00:00:00+0000';
+        $expected['datetime'] = '1970-01-01T00:00:00.000000+0000';
         $expected['context'] = array(
             'class' => '[object] (stdClass: {})',
             'foo' => 7,


### PR DESCRIPTION
Milliseconds are more precise. The same change was already made for the `LogstashFormatter` in 899f7f52e5014feac069319df22e25cbd3b34d5f

Tested against ES 1.7.x and Kibana 4.1