### PR TITLE
Add phalconslayer in the lists

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -79,6 +79,7 @@ Bugs and feature request are tracked on [GitHub](https://github.com/Seldaek/mono
 - [Aura.Web_Project](https://github.com/auraphp/Aura.Web_Project) comes out of the box with Monolog.
 - [Nette Framework](http://nette.org/en/) can be used with Monolog via [Kdyby/Monolog](https://github.com/Kdyby/Monolog) extension.
 - [Proton Micro Framework](https://github.com/alexbilbie/Proton) comes out of the box with Monolog.
+- [Phalcon Slayer Framework](https://github.com/phalconslayer/slayer) comes out of the box with Monolog.
 
 ### Author
 


### PR DESCRIPTION
Adding Phalcon Slayer Framework that relies under the [Log Provider](https://github.com/phalconslayer/framework/blob/master/src/Clarity/Providers/Log.php)