### PR TITLE
use maintained package reference in suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "raven/raven": "Allow sending log messages to a Sentry server",
         "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
         "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-        "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+        "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
         "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
         "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
         "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",


### PR DESCRIPTION
videlalvaro/php-amqplib has been abandoned in favor of
php-amqplib/php-amqplib

Related : #744