### PR TITLE
missing property

### DIFF
--- a/src/Monolog/Handler/SocketHandler.php
+++ b/src/Monolog/Handler/SocketHandler.php
@@ -30,6 +30,7 @@ class SocketHandler extends AbstractProcessingHandler
     private $persistent = false;
     private $errno;
     private $errstr;
+    private $lastWritingAt;
 
     /**
      * @param string  $connectionString Socket connection string


### PR DESCRIPTION
This property is used, but not declared, in writingIsTimedOut

Don't know why it pass on travis, but locally I got

1) Monolog\Handler\SocketHandlerTest::testAvoidInfiniteLoopWhenNoDataIsWrittenForAWritingTimeoutSeconds
Undefined property: Mock_SocketHandler_4c030aea::$lastWritingAt

This trivial fix fix this
