### PR TITLE
(slack) fix for missing messages

### DIFF
--- a/src/Monolog/Handler/SocketHandler.php
+++ b/src/Monolog/Handler/SocketHandler.php
@@ -229,6 +229,16 @@ class SocketHandler extends AbstractProcessingHandler
 
     /**
      * Wrapper to allow mocking
+     *
+     * @param int $length
+     */
+    protected function fgets($length = 1024)
+    {
+        return @fgets($this->resource, $length);
+    }
+
+    /**
+     * Wrapper to allow mocking
      */
     protected function streamGetMetadata()
     {
@@ -314,6 +324,7 @@ class SocketHandler extends AbstractProcessingHandler
                 throw new \RuntimeException("Write timed-out, no data sent for `{$this->writingTimeout}` seconds, probably we got disconnected (sent $sent of $length)");
             }
         }
+        $this->fgets();
         if (!$this->isConnected() && $sent < $length) {
             throw new \RuntimeException("End-of-file reached, probably we got disconnected (sent $sent of $length)");
         }


### PR DESCRIPTION
while debugging why slack sometimes receives a message but does not send it to the chat i found out, that the solution is, to read the response from the buffer.