### PR TITLE
Provide means to manually activate a FingersCrossedHandler

### DIFF
--- a/src/Monolog/Handler/FingersCrossedHandler.php
+++ b/src/Monolog/Handler/FingersCrossedHandler.php
@@ -36,6 +36,7 @@ class FingersCrossedHandler extends AbstractHandler
     protected $buffer = array();
     protected $stopBuffering;
     protected $passthruLevel;
+    protected $overrideActivated = false;
 
     /**
      * @param callable|HandlerInterface       $handler            Handler or factory callable($record, $fingersCrossedHandler).
@@ -80,6 +81,14 @@ class FingersCrossedHandler extends AbstractHandler
     }
 
     /**
+     * Manually activate this logger regardless of the activation strategy
+     */
+    public function activate()
+    {
+        $this->overrideActivated = true;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function handle(array $record)
@@ -95,7 +104,7 @@ class FingersCrossedHandler extends AbstractHandler
             if ($this->bufferSize > 0 && count($this->buffer) > $this->bufferSize) {
                 array_shift($this->buffer);
             }
-            if ($this->activationStrategy->isHandlerActivated($record)) {
+            if ($this->overrideActivated || $this->activationStrategy->isHandlerActivated($record)) {
                 if ($this->stopBuffering) {
                     $this->buffering = false;
                 }


### PR DESCRIPTION
This is useful if you have a FingersCrossedHandler set up and some where in your application are interested in all output regardless of whether the threshold is actually reached. For example to temporarily debug some problem. One can replace the handler in that spot, but this is signifcantly easier to use.