### PR TITLE
Provide means to manually activate a FingersCrossedHandler

### DIFF
--- a/src/Monolog/Handler/FingersCrossedHandler.php
+++ b/src/Monolog/Handler/FingersCrossedHandler.php
@@ -36,6 +36,7 @@ class FingersCrossedHandler extends AbstractHandler
     protected $buffer = array();
     protected $stopBuffering;
     protected $passthruLevel;
+    protected $overrideActivated = false;
 
     /**
      * @param callable|HandlerInterface       $handler            Handler or factory callable($record, $fingersCrossedHandler).
@@ -80,6 +81,14 @@ class FingersCrossedHandler extends AbstractHandler
     }
 
     /**
+     * Manually activate this logger regardless of the activation strategy
+     */
+    public function activate()
+    {
+        $this->overrideActivated = true;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function handle(array $record)
@@ -95,7 +104,7 @@ class FingersCrossedHandler extends AbstractHandler
             if ($this->bufferSize > 0 && count($this->buffer) > $this->bufferSize) {
                 array_shift($this->buffer);
             }
-            if ($this->activationStrategy->isHandlerActivated($record)) {
+            if ($this->overrideActivated || $this->activationStrategy->isHandlerActivated($record)) {
                 if ($this->stopBuffering) {
                     $this->buffering = false;
                 }

--- a/src/Monolog/Handler/FingersCrossedHandler.php
+++ b/src/Monolog/Handler/FingersCrossedHandler.php
@@ -88,10 +88,7 @@ class FingersCrossedHandler extends AbstractHandler
             $this->buffering = false;
         }
         if (!$this->handler instanceof HandlerInterface) {
-            $record = end($this->buffer);
-            if ($record === false) {
-                $record = null;
-            }
+            $record = end($this->buffer) ?: null;
 
             $this->handler = call_user_func($this->handler, $record, $this);
             if (!$this->handler instanceof HandlerInterface) {
@@ -119,7 +116,7 @@ class FingersCrossedHandler extends AbstractHandler
                 array_shift($this->buffer);
             }
             if ($this->activationStrategy->isHandlerActivated($record)) {
-                $this->activate($record);
+                $this->activate();
             }
         } else {
             $this->handler->handle($record);

--- a/tests/Monolog/Handler/FingersCrossedHandlerTest.php
+++ b/tests/Monolog/Handler/FingersCrossedHandlerTest.php
@@ -174,6 +174,22 @@ class FingersCrossedHandlerTest extends TestCase
     }
 
     /**
+     * @covers Monolog\Handler\FingersCrossedHandler::__construct
+     * @covers Monolog\Handler\FingersCrossedHandler::activate
+     */
+    public function testOverrideActivationStrategy()
+    {
+        $test = new TestHandler();
+        $handler = new FingersCrossedHandler($test, new ErrorLevelActivationStrategy('warning'));
+        $handler->handle($this->getRecord(Logger::DEBUG));
+        $this->assertFalse($test->hasDebugRecords());
+        $handler->activate();
+        $handler->handle($this->getRecord(Logger::INFO));
+        $this->assertTrue($test->hasDebugRecords());
+        $this->assertTrue($test->hasInfoRecords());
+    }
+
+    /**
      * @covers Monolog\Handler\FingersCrossed\ChannelLevelActivationStrategy::__construct
      * @covers Monolog\Handler\FingersCrossed\ChannelLevelActivationStrategy::isHandlerActivated
      */

--- a/tests/Monolog/Handler/FingersCrossedHandlerTest.php
+++ b/tests/Monolog/Handler/FingersCrossedHandlerTest.php
@@ -22,6 +22,7 @@ class FingersCrossedHandlerTest extends TestCase
     /**
      * @covers Monolog\Handler\FingersCrossedHandler::__construct
      * @covers Monolog\Handler\FingersCrossedHandler::handle
+     * @covers Monolog\Handler\FingersCrossedHandler::activate
      */
     public function testHandleBuffers()
     {
@@ -39,6 +40,7 @@ class FingersCrossedHandlerTest extends TestCase
 
     /**
      * @covers Monolog\Handler\FingersCrossedHandler::handle
+     * @covers Monolog\Handler\FingersCrossedHandler::activate
      */
     public function testHandleStopsBufferingAfterTrigger()
     {
@@ -53,6 +55,7 @@ class FingersCrossedHandlerTest extends TestCase
 
     /**
      * @covers Monolog\Handler\FingersCrossedHandler::handle
+     * @covers Monolog\Handler\FingersCrossedHandler::activate
      * @covers Monolog\Handler\FingersCrossedHandler::reset
      */
     public function testHandleRestartBufferingAfterReset()
@@ -71,6 +74,7 @@ class FingersCrossedHandlerTest extends TestCase
 
     /**
      * @covers Monolog\Handler\FingersCrossedHandler::handle
+     * @covers Monolog\Handler\FingersCrossedHandler::activate
      */
     public function testHandleRestartBufferingAfterBeingTriggeredWhenStopBufferingIsDisabled()
     {
@@ -87,6 +91,7 @@ class FingersCrossedHandlerTest extends TestCase
 
     /**
      * @covers Monolog\Handler\FingersCrossedHandler::handle
+     * @covers Monolog\Handler\FingersCrossedHandler::activate
      */
     public function testHandleBufferLimit()
     {
@@ -103,6 +108,7 @@ class FingersCrossedHandlerTest extends TestCase
 
     /**
      * @covers Monolog\Handler\FingersCrossedHandler::handle
+     * @covers Monolog\Handler\FingersCrossedHandler::activate
      */
     public function testHandleWithCallback()
     {
@@ -121,6 +127,7 @@ class FingersCrossedHandlerTest extends TestCase
 
     /**
      * @covers Monolog\Handler\FingersCrossedHandler::handle
+     * @covers Monolog\Handler\FingersCrossedHandler::activate
      * @expectedException RuntimeException
      */
     public function testHandleWithBadCallbackThrowsException()
@@ -184,8 +191,8 @@ class FingersCrossedHandlerTest extends TestCase
         $handler->handle($this->getRecord(Logger::DEBUG));
         $this->assertFalse($test->hasDebugRecords());
         $handler->activate();
-        $handler->handle($this->getRecord(Logger::INFO));
         $this->assertTrue($test->hasDebugRecords());
+        $handler->handle($this->getRecord(Logger::INFO));
         $this->assertTrue($test->hasInfoRecords());
     }
 
@@ -225,6 +232,7 @@ class FingersCrossedHandlerTest extends TestCase
 
     /**
      * @covers Monolog\Handler\FingersCrossedHandler::handle
+     * @covers Monolog\Handler\FingersCrossedHandler::activate
      */
     public function testHandleUsesProcessors()
     {


### PR DESCRIPTION
This is useful if you have a FingersCrossedHandler set up and some where in your application are interested in all output regardless of whether the threshold is actually reached. For example to temporarily debug some problem. One can replace the handler in that spot, but this is signifcantly easier to use.