### PR TITLE
Fixed $handler property visibility in the HandlerWrapper

### DIFF
--- a/src/Monolog/Handler/HandlerWrapper.php
+++ b/src/Monolog/Handler/HandlerWrapper.php
@@ -33,7 +33,7 @@ class HandlerWrapper implements HandlerInterface, ProcessableHandlerInterface, F
     /**
      * @var HandlerInterface
      */
-    private $handler;
+    protected $handler;
 
     /**
      * HandlerWrapper constructor.


### PR DESCRIPTION
According to the given example, $handler property should not be private.