### PR TITLE
Add deprecation errors on RotatingFileHandler

### DIFF
--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -11,7 +11,6 @@
 
 namespace Monolog\Handler;
 
-use InvalidArgumentException;
 use Monolog\Logger;
 
 /**

--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -11,6 +11,7 @@
 
 namespace Monolog\Handler;
 
+use InvalidArgumentException;
 use Monolog\Logger;
 
 /**
@@ -24,6 +25,10 @@ use Monolog\Logger;
  */
 class RotatingFileHandler extends StreamHandler
 {
+    const FILE_PER_DAY = 'Y-m-d';
+    const FILE_PER_MONTH = 'Y-m';
+    const FILE_PER_YEAR = 'Y';
+
     protected $filename;
     protected $maxFiles;
     protected $mustRotate;
@@ -64,6 +69,20 @@ class RotatingFileHandler extends StreamHandler
 
     public function setFilenameFormat($filenameFormat, $dateFormat)
     {
+        if (!in_array($dateFormat, array(self::FILE_PER_DAY, self::FILE_PER_MONTH, self::FILE_PER_YEAR))) {
+            trigger_error(
+                'Invalid date format - format should be one of '.
+                'RotatingFileHandler::FILE_PER_DAY, RotatingFileHandler::FILE_PER_MONTH '.
+                'or RotatingFileHandler::FILE_PER_YEAR.',
+                E_USER_DEPRECATED
+            );
+        }
+        if (substr_count($filenameFormat, '{date}') === 0) {
+            trigger_error(
+                'Invalid filename format - format should contain at least `{date}`, because otherwise rotating is impossible.',
+                E_USER_DEPRECATED
+            );
+        }
         $this->filenameFormat = $filenameFormat;
         $this->dateFormat = $dateFormat;
         $this->url = $this->getTimedFilename();

--- a/tests/Monolog/Handler/RotatingFileHandlerTest.php
+++ b/tests/Monolog/Handler/RotatingFileHandlerTest.php
@@ -29,7 +29,8 @@ class RotatingFileHandlerTest extends TestCase
             $this->markTestSkipped($dir.' must be writable to test the RotatingFileHandler.');
         }
         $this->lastError = null;
-        set_error_handler(function($code, $message) use ($this) {
+        $self = $this;
+        set_error_handler(function($code, $message) use (&$self) {
             $this->lastError = array(
                 'code' => $code,
                 'message' => $message,

--- a/tests/Monolog/Handler/RotatingFileHandlerTest.php
+++ b/tests/Monolog/Handler/RotatingFileHandlerTest.php
@@ -30,10 +30,10 @@ class RotatingFileHandlerTest extends TestCase
         }
         $this->lastError = null;
         set_error_handler(function($code, $message) {
-            $this->lastError = [
+            $this->lastError = array(
                 'code' => $code,
                 'message' => $message,
-            ];
+            );
         });
     }
 

--- a/tests/Monolog/Handler/RotatingFileHandlerTest.php
+++ b/tests/Monolog/Handler/RotatingFileHandlerTest.php
@@ -29,7 +29,7 @@ class RotatingFileHandlerTest extends TestCase
             $this->markTestSkipped($dir.' must be writable to test the RotatingFileHandler.');
         }
         $this->lastError = null;
-        set_error_handler(function($code, $message) {
+        set_error_handler(function($code, $message) use ($this) {
             $this->lastError = array(
                 'code' => $code,
                 'message' => $message,

--- a/tests/Monolog/Handler/RotatingFileHandlerTest.php
+++ b/tests/Monolog/Handler/RotatingFileHandlerTest.php
@@ -19,7 +19,13 @@ use PHPUnit_Framework_Error_Deprecated;
  */
 class RotatingFileHandlerTest extends TestCase
 {
-    private $lastError;
+    /**
+     * This var should be private but then the anonymous function
+     * in the `setUp` method won't be able to set it. `$this` cant't
+     * be used in the anonymous function in `setUp` because PHP 5.3
+     * does not support it.
+     */
+    public $lastError;
 
     public function setUp()
     {
@@ -30,6 +36,7 @@ class RotatingFileHandlerTest extends TestCase
         }
         $this->lastError = null;
         $self = $this;
+        // workaround with &$self used for PHP 5.3
         set_error_handler(function($code, $message) use (&$self) {
             $this->lastError = array(
                 'code' => $code,

--- a/tests/Monolog/Handler/RotatingFileHandlerTest.php
+++ b/tests/Monolog/Handler/RotatingFileHandlerTest.php
@@ -38,7 +38,7 @@ class RotatingFileHandlerTest extends TestCase
         $self = $this;
         // workaround with &$self used for PHP 5.3
         set_error_handler(function($code, $message) use (&$self) {
-            $this->lastError = array(
+            $self->lastError = array(
                 'code' => $code,
                 'message' => $message,
             );


### PR DESCRIPTION
Add deprecation errors on RotatingFileHandler when attempting to set dateFormats of fileFormats that break the possibility of rotating easily in RotatingFileHandler. Version 2.x
of Monolog will throw `\InvalidArgumentException`s in these cases.

- Require the dateFormat to be one of three presets ('Y-m-d', 'Y-m' or 'Y') to
  ensure that dates can be sorted lexographically
- Require the filenameFormat to contain the (sub)string `{date}` so we will
  actually create new files instead of the same file over and over again.

Related to https://github.com/Seldaek/monolog/pull/773