### PR TITLE
Fix NewRelicHandler error when using LineFormatter

### DIFF
--- a/src/Monolog/Handler/NewRelicHandler.php
+++ b/src/Monolog/Handler/NewRelicHandler.php
@@ -92,23 +92,27 @@ class NewRelicHandler extends AbstractProcessingHandler
             newrelic_notice_error($record['message']);
         }
 
-        foreach ($record['formatted']['context'] as $key => $parameter) {
-            if (is_array($parameter) && $this->explodeArrays) {
-                foreach ($parameter as $paramKey => $paramValue) {
-                    $this->setNewRelicParameter('context_' . $key . '_' . $paramKey, $paramValue);
+        if (isset($record['formatted']['context'])) {
+            foreach ($record['formatted']['context'] as $key => $parameter) {
+                if (is_array($parameter) && $this->explodeArrays) {
+                    foreach ($parameter as $paramKey => $paramValue) {
+                        $this->setNewRelicParameter('context_' . $key . '_' . $paramKey, $paramValue);
+                    }
+                } else {
+                    $this->setNewRelicParameter('context_' . $key, $parameter);
                 }
-            } else {
-                $this->setNewRelicParameter('context_' . $key, $parameter);
             }
         }
 
-        foreach ($record['formatted']['extra'] as $key => $parameter) {
-            if (is_array($parameter) && $this->explodeArrays) {
-                foreach ($parameter as $paramKey => $paramValue) {
-                    $this->setNewRelicParameter('extra_' . $key . '_' . $paramKey, $paramValue);
+        if (isset($record['formatted']['extra'])) {
+            foreach ($record['formatted']['extra'] as $key => $parameter) {
+                if (is_array($parameter) && $this->explodeArrays) {
+                    foreach ($parameter as $paramKey => $paramValue) {
+                        $this->setNewRelicParameter('extra_' . $key . '_' . $paramKey, $paramValue);
+                    }
+                } else {
+                    $this->setNewRelicParameter('extra_' . $key, $parameter);
                 }
-            } else {
-                $this->setNewRelicParameter('extra_' . $key, $parameter);
             }
         }
     }

--- a/tests/Monolog/Handler/NewRelicHandlerTest.php
+++ b/tests/Monolog/Handler/NewRelicHandlerTest.php
@@ -11,6 +11,7 @@
 
 namespace Monolog\Handler;
 
+use Monolog\Formatter\LineFormatter;
 use Monolog\TestCase;
 use Monolog\Logger;
 
@@ -102,6 +103,13 @@ class NewRelicHandlerTest extends TestCase
         );
 
         $this->assertEquals($expected, self::$customParameters);
+    }
+
+    public function testThehandlerCanHandleTheRecordsFormattedUsingTheLineFormatter()
+    {
+        $handler = new StubNewRelicHandler();
+        $handler->setFormatter(new LineFormatter());
+        $handler->handle($this->getRecord(Logger::ERROR));
     }
 
     public function testTheAppNameIsNullByDefault()


### PR DESCRIPTION
My application uses a customized `LineFormatter`, which sets the `formatted` key value to a string. This is a problem for the existing `NewRelicHandler`, which expects `formatted` to be an array with a `context` and `extra` key.

This change just does an `isset` check before looping over those elements.