### PR TITLE
Add parent logger to 1.x

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -120,6 +120,13 @@ class Logger implements LoggerInterface
     protected $handlers;
 
     /**
+     * The logger's parent logger
+     *
+     * @var Logger
+     */
+    protected $parent;
+
+    /**
      * Processors that will process all log records
      *
      * To process records of a single handler instead, add the processor on that specific handler
@@ -137,12 +144,18 @@ class Logger implements LoggerInterface
      * @param string             $name       The logging channel
      * @param HandlerInterface[] $handlers   Optional stack of handlers, the first one in the array is called first, etc.
      * @param callable[]         $processors Optional array of processors
+     * @param Logger             $parent     Optional logger parent
      */
-    public function __construct($name, array $handlers = array(), array $processors = array())
+    public function __construct(
+        $name,
+        array $handlers = array(),
+        array $processors = array(),
+        Logger $parent = null)
     {
         $this->name = $name;
         $this->handlers = $handlers;
         $this->processors = $processors;
+        $this->parent = $parent;
     }
 
     /**
@@ -217,6 +230,28 @@ class Logger implements LoggerInterface
     public function getHandlers()
     {
         return $this->handlers;
+    }
+
+    /**
+     * Set the parent logger. Will override any prior set parent logger.
+     *
+     * @param Logger $parent    Parent logger
+     * @return $this
+     */
+    public function setParent(Logger $parent)
+    {
+        $this->parent = $parent;
+        return $this;
+    }
+
+    /**
+     * Get the parent logger, if it exists.
+     *
+     * @return Logger
+     */
+    public function getParent()
+    {
+        return $this->parent;
     }
 
     /**
@@ -339,6 +374,12 @@ class Logger implements LoggerInterface
 
             next($this->handlers);
         }
+
+        // Lets also propagate this to the parent, if it exists.
+        if ($this->parent != null) {
+            $this->parent->addRecord($level, $message, $context);
+        }
+
 
         return true;
     }

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -339,6 +339,10 @@ class Logger implements LoggerInterface
         }
 
         if (null === $handlerKey) {
+            // Check if a parent logger should handle this message as well.
+            if ($this->parent !== null) {
+                return $this->parent->addRecord($level, $message, $context);
+            }
             return false;
         }
 
@@ -378,6 +382,8 @@ class Logger implements LoggerInterface
         // Lets also propagate this to the parent, if it exists.
         if ($this->parent != null) {
             $this->parent->addRecord($level, $message, $context);
+            // We return true here because at least one logger (this one) handled this record.
+            return true;
         }
 
 

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -570,12 +570,14 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     public function testParentIsCalledWhenHandlerNotBubble()
     {
         $parentLogger = new Logger('parent');
-        $parentHandler = new TestHandler();
-        $parentLogger->pushHandler($parentHandler);
+        $bubblingParentHandler = new TestHandler();
+        $nonBubblingParentHandler = new Testhandler(Logger::INFO, false);
+        $parentLogger->pushHandler($bubblingParentHandler);
+        $parentLogger->pushHandler($nonBubblingParentHandler);
 
         $childLogger = new Logger('child');
         $bubblingChildHandler = new TestHandler();
-        $nonBubblingChildHandler = new TestHandler(Logger::DEBUG, false);
+        $nonBubblingChildHandler = new TestHandler(Logger::INFO, false);
         $childLogger->pushHandler($bubblingChildHandler);
         $childLogger->pushHandler($nonBubblingChildHandler);
 
@@ -584,7 +586,8 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($childLogger->warn('foo'));
         $this->assertFalse($bubblingChildHandler->hasRecordThatMatches('/^foo$/', Logger::WARNING));
         $this->assertTrue($nonBubblingChildHandler->hasRecordThatMatches('/^foo$/', Logger::WARNING));
-        $this->assertTrue($parentHandler->hasRecordThatMatches('/^foo$/', Logger::WARNING));
+        $this->assertTrue($nonBubblingParentHandler->hasRecordThatMatches('/^foo$/', Logger::WARNING));
+        $this->assertFalse($bubblingParentHandler->hasRecordThatMatches('/^foo$/', Logger::WARNING));
     }
 
     /**


### PR DESCRIPTION
## Overview
This was my first pass as this feature. I have filed a feature Issue ticket to better describe the use case. #778 

In general,developers may find parent loggers useful when a service wants to have a defined logging behavior across all of its parts; however, a developer may also want individual parts of this service to have some additional behavior. For example:

```php
class Foo
{
    protected $logger;

    public function __construct(Logger $parent_logger = null){
        // We want our logger to always log to the injected logger
        // If we have a warning level log, lets do something special with it.
        $special_handler = new MySpecialHandler(Logger::WARN, false);
        // If we don't have a warning level log, lets do something boring.
        $boring_handler = new MyBoringHandler(Logger::DEBUG);

        $logger = new Logger(__CLASS__);
        $logger->setHandlers(array($special_handler, $boring_handler));

        // Lets always log to our parent logger
        $logger->setParent($parent_logger);
        $this->logger = $logger;
    }
}
```
```
$handler_1 = new StreamHandler('/var/log/my_log.log');
$handler_2 = new StreamHandler('/var/log/my_important_log.log', Logger::WARNING, false);
$logger = new Logger('routine_1');
$logger->pushHandler($handler_2);
$logger->pushHandler($handler_1);

// No matter how Foo logs, I always want it to log to my stream handlers from above.
$foo = new Foo($logger);
```

### Possible Additions
One may want to pass the record instead of the message to the parent so that any context or extras added by the processors gets passed to the parent. For example . . .

```php


    /**
     * Adds a log record.
     *
     * @param  int     $level   The logging level
     * @param  string  $message The log message
     * @param  array   $context The log context
     * @return Boolean Whether the record has been processed
     */
    public function addRecord($level, $message, array $context = array(), $message_as_record = false)
    {
        . . .    
        $record = $message_as_record ?
            $message :
            array(
                'message' => (string) $message,
                'context' => $context,
                'level' => $level,
                'level_name' => $levelName,
                'channel' => $this->name,
                'datetime' => $ts,
                'extra' => array(),
        );
        . . . 
        // Lets also propagate this to the parent, if it exists.
        if ($this->parent != null) {
            $this->parent->addRecord($level, $record, $context, true);
            // We return true here because at least one logger (this one) handled this record.
            return true;
        }
        . . . 
    }
``` 