### PR TITLE
Exclude development stuff from repository autogenerated ZIP archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
-.gitattributes export-ignore
-.gitignore export-ignore
-.travis.yml export-ignore
+/doc export-ignore
+/tests export-ignore
+/.* export-ignore
+/phpunit.xml.dist


### PR DESCRIPTION
People that install this library via composer don't need the test/sample/doc stuff, they just need the library itself.
This PR removes the development directories and files from the repository auto-generated ZIP archives.
Since these development files/directories will still be available via `git clone`, Travis is happy, developers are happy, and so are end-users (they won't have unneeded stuff in production machines).