### PR TITLE
Add fluent setters for parameters in the slack handler

### DIFF
--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -85,26 +85,31 @@ class SlackRecord
      */
     private $normalizerFormatter;
 
-    public function __construct($channel = null, $username = null, $useAttachment = true, $userIcon = null, $useShortAttachment = false, $includeContextAndExtra = false, array $excludeFields = array(), FormatterInterface $formatter = null)
-    {
-        $this->channel = $channel;
-        $this->username = $username;
-        $this->userIcon = $userIcon !== null ? trim($userIcon, ':') : null;
-        $this->useAttachment = $useAttachment;
-        $this->useShortAttachment = $useShortAttachment;
-        $this->includeContextAndExtra = $includeContextAndExtra;
-        $this->excludeFields = $excludeFields;
-        $this->formatter = $formatter;
-
-        if ($this->includeContextAndExtra) {
-            $this->normalizerFormatter = new NormalizerFormatter();
-        }
+    public function __construct(
+        $channel = null,
+        $username = null,
+        $useAttachment = true,
+        $userIcon = null,
+        $useShortAttachment = false,
+        $includeContextAndExtra = false,
+        array $excludeFields = array(),
+        FormatterInterface $formatter = null
+    ) {
+        $this
+            ->setChannel($channel)
+            ->setUsername($username)
+            ->useAttachment($useAttachment)
+            ->setUserIcon($userIcon)
+            ->useShortAttachment($useShortAttachment)
+            ->includeContextAndExtra($includeContextAndExtra)
+            ->excludeFields($excludeFields)
+            ->setFormatter($formatter);
     }
 
     public function getSlackData(array $record)
     {
         $dataArray = array();
-        $record = $this->excludeFields($record);
+        $record = $this->removeExcludedFields($record);
 
         if ($this->username) {
             $dataArray['username'] = $this->username;
@@ -216,13 +221,113 @@ class SlackRecord
     }
 
     /**
+     * Channel used by the bot when posting
+     *
+     * @param ?string $channel
+     *
+     * @return SlackHandler
+     */
+    public function setChannel(?string $channel = null): self
+    {
+        $this->channel = $channel;
+
+        return $this;
+    }
+
+    /**
+     * Username used by the bot when posting
+     *
+     * @param ?string $username
+     *
+     * @return SlackHandler
+     */
+    public function setUsername(?string $username = null): self
+    {
+        $this->username = $username;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $useAttachment
+     *
+     * @return SlackHandler
+     */
+    public function useAttachment(bool $useAttachment = true): self
+    {
+        $this->useAttachment = $useAttachment;
+
+        return $this;
+    }
+
+    /**
+     * @param string $userIcon
+     *
+     * @return SlackHandler
+     */
+    public function setUserIcon(?string $userIcon = null): self
+    {
+        $this->userIcon = $userIcon;
+
+        if (\is_string($userIcon)) {
+            $this->userIcon = trim($userIcon, ':');
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param bool $useShortAttachment
+     *
+     * @return SlackHandler
+     */
+    public function useShortAttachment(bool $useShortAttachment = false): self
+    {
+        $this->useShortAttachment = $useShortAttachment;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $includeContextAndExtra
+     *
+     * @return SlackHandler
+     */
+    public function includeContextAndExtra(bool $includeContextAndExtra = false): self
+    {
+        $this->includeContextAndExtra = $includeContextAndExtra;
+
+        if ($this->includeContextAndExtra) {
+            $this->normalizerFormatter = new NormalizerFormatter();
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param array $excludeFields
+     *
+     * @return SlackHandler
+     */
+    public function excludeFields(array $excludeFields = []): self
+    {
+        $this->excludeFields = $excludeFields;
+
+        return $this;
+    }
+
+    /**
      * Sets the formatter
      *
      * @param FormatterInterface $formatter
+     *
+     * @return  SlackHandler
      */
-    public function setFormatter(FormatterInterface $formatter)
+    public function setFormatter(?FormatterInterface $formatter = null): self
     {
         $this->formatter = $formatter;
+
+        return $this;
     }
 
     /**
@@ -270,7 +375,7 @@ class SlackRecord
      *
      * @return array
      */
-    private function excludeFields(array $record)
+    private function removeExcludedFields(array $record)
     {
         foreach ($this->excludeFields as $field) {
             $keys = explode('.', $field);

--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -216,4 +216,92 @@ class SlackHandler extends SocketHandler
 
         return $formatter;
     }
+
+    /**
+     * Channel used by the bot when posting
+     *
+     * @param string $channel
+     *
+     * @return SlackHandler
+     */
+    public function setChannel(string $channel): self
+    {
+        $this->slackRecord->setChannel($channel);
+
+        return $this;
+    }
+
+    /**
+     * Username used by the bot when posting
+     *
+     * @param string $username
+     *
+     * @return SlackHandler
+     */
+    public function setUsername(string $username): self
+    {
+        $this->slackRecord->setUsername($username);
+
+        return $this;
+    }
+
+    /**
+     * @param bool $useAttachment
+     *
+     * @return SlackHandler
+     */
+    public function useAttachment(bool $useAttachment): self
+    {
+        $this->slackRecord->useAttachment($useAttachment);
+
+        return $this;
+    }
+
+    /**
+     * @param string $iconEmoji
+     *
+     * @return SlackHandler
+     */
+    public function setIconEmoji(string $iconEmoji): self
+    {
+        $this->slackRecord->setUserIcon($iconEmoji);
+
+        return $this;
+    }
+
+    /**
+     * @param bool $useShortAttachment
+     *
+     * @return SlackHandler
+     */
+    public function useShortAttachment(bool $useShortAttachment): self
+    {
+        $this->slackRecord->useShortAttachment($useShortAttachment);
+
+        return $this;
+    }
+
+    /**
+     * @param bool $includeContextAndExtra
+     *
+     * @return SlackHandler
+     */
+    public function includeContextAndExtra(bool $includeContextAndExtra): self
+    {
+        $this->slackRecord->includeContextAndExtra($includeContextAndExtra);
+
+        return $this;
+    }
+
+    /**
+     * @param array $excludeFields
+     *
+     * @return SlackHandler
+     */
+    public function excludeFields(array $excludeFields): self
+    {
+        $this->slackRecord->excludeFields($excludeFields);
+
+        return $this;
+    }
 }


### PR DESCRIPTION
The current slack handler has way too many constructor parameters and no clear order as to their position. This makes it confusing to work out what is actually trying to be set when constructing a new class, e.g,

``` php
$slack = new SlackHandler(
    'xoxp-0000000000-1111111111-22222222222-3333333333',
    '#general',
    'Monolog',
    false,
    null,
    Logger::ERROR,
    true,
    false,
    true
);
```

This PR makes things a bit easier by adding some fluent setters into the class.

``` php
$slack = new SlackHandler(
        'xoxp-0000000000-1111111111-22222222222-3333333333',
        '#general',
        'Monolog'
    )
    ->setErrorLevel(Logger::ERROR)
    ->useAttachment(false)
    ->includeContextAndExtra(true);
```

It would be nice to cut back the number of constructor parameters and reorder them to make a bit more sense

``` php
// Current
public function __construct(
    $token,
    $channel,
    $username = 'Monolog',
    $useAttachment = true,
    $iconEmoji = null,
    $level = Logger::CRITICAL,
    $bubble = true,
    $useShortAttachment = false,
    $includeContextAndExtra = false
)

// Proposed
public function __construct(
    $token,
    $channel,
    $username = 'Monolog',
    $level = Logger::CRITICAL,
    $bubble = true
)
```

Since that would be a fairly major breaking change though I've not included it in this PR. If it would be okay to do in another PR I'll open one up for it.

I've included scalar type hints for the methods because the file include the `declare(strict_types=1);` which is only valid for PHP7 so I assume that is okay. If not then I can easily remove them.
