### PR TITLE
Fix for TypeError within SocketHandler

### DIFF
--- a/src/Monolog/Handler/SocketHandler.php
+++ b/src/Monolog/Handler/SocketHandler.php
@@ -216,7 +216,7 @@ class SocketHandler extends AbstractProcessingHandler
         $seconds = floor($this->timeout);
         $microseconds = round(($this->timeout - $seconds) * 1e6);
 
-        return stream_set_timeout($this->resource, $seconds, $microseconds);
+        return stream_set_timeout($this->resource, (int) $seconds, (int) $microseconds);
     }
 
     /**


### PR DESCRIPTION
Proposed change fixes `TypeError` thrown while calling [`stream_set_timeout()`](stream_set_timeout) which expects both 2nd and 3rd arguments to be integers while [`floor()`](https://secure.php.net/manual/en/function.floor.php) returns `float` / `bool` and [`round()`](https://secure.php.net/manual/en/function.round.php) returns `float` as well.

**Warning**: This may not be the best solution, I didn't go through internals of class in depth, but I've noticed this breaks Slack logging for us after updating to most recent commit so it may be useful for others too.