### PR TITLE
Normalization of arrays containing self references

### DIFF
--- a/src/Monolog/Formatter/JsonFormatter.php
+++ b/src/Monolog/Formatter/JsonFormatter.php
@@ -135,8 +135,12 @@ class JsonFormatter extends NormalizerFormatter
      *
      * @return mixed
      */
-    protected function normalize($data)
+    protected function normalize($data, $depth = 0)
     {
+        if ($depth > 9) {
+            return 'Over 9 levels deep, aborting normalization';
+        }
+
         if (is_array($data) || $data instanceof \Traversable) {
             $normalized = array();
 
@@ -146,7 +150,7 @@ class JsonFormatter extends NormalizerFormatter
                     $normalized['...'] = 'Over 1000 items, aborting normalization';
                     break;
                 }
-                $normalized[$key] = $this->normalize($value);
+                $normalized[$key] = $this->normalize($value, $depth+1);
             }
 
             return $normalized;

--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -55,8 +55,12 @@ class NormalizerFormatter implements FormatterInterface
         return $records;
     }
 
-    protected function normalize($data)
+    protected function normalize($data, $depth = 0)
     {
+        if ($depth > 9) {
+            return 'Over 9 levels deep, aborting normalization';
+        }
+
         if (null === $data || is_scalar($data)) {
             if (is_float($data)) {
                 if (is_infinite($data)) {
@@ -79,7 +83,7 @@ class NormalizerFormatter implements FormatterInterface
                     $normalized['...'] = 'Over 1000 items, aborting normalization';
                     break;
                 }
-                $normalized[$key] = $this->normalize($value);
+                $normalized[$key] = $this->normalize($value, $depth+1);
             }
 
             return $normalized;

--- a/src/Monolog/Formatter/WildfireFormatter.php
+++ b/src/Monolog/Formatter/WildfireFormatter.php
@@ -102,12 +102,12 @@ class WildfireFormatter extends NormalizerFormatter
         throw new \BadMethodCallException('Batch formatting does not make sense for the WildfireFormatter');
     }
 
-    protected function normalize($data)
+    protected function normalize($data, $depth = 0)
     {
         if (is_object($data) && !$data instanceof \DateTime) {
             return $data;
         }
 
-        return parent::normalize($data);
+        return parent::normalize($data, $depth);
     }
 }

--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -166,6 +166,15 @@ class NormalizerFormatterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(@json_encode(array($foo, $bar)), $res);
     }
 
+    public function testCanNormalizeReferences()
+    {
+        $formatter = new NormalizerFormatter();
+        $x = ['foo' => 'bar'];
+        $y = ['x' => &$x];
+        $x['y'] = &$y;
+        $formatter->format($y);
+    }
+
     public function testIgnoresInvalidTypes()
     {
         // set up the recursion


### PR DESCRIPTION
This is an issue in particular when $GLOBALS gets stuck into $context. This is something Symfony's ErrorHandler does when an error is thrown in global scope. The result is infinite recusion resulting in stack overflow on normalize().

Currently only adds a failing test.

Options are
- Limit nesting, by introducing depth counting to `normalize()`
- Reference detection (more complicated and uses more memory)