### PR TITLE
with graylog2/gelf-php wrong class in tests mock

### DIFF
--- a/tests/Monolog/Handler/GelfMockMessagePublisher.php
+++ b/tests/Monolog/Handler/GelfMockMessagePublisher.php
@@ -11,7 +11,7 @@
 
 namespace Monolog\Handler;
 
-use Gelf\MessagePublisher;
+use Gelf\Publisher;
 use Gelf\Message;
 
 class GelfMockMessagePublisher extends MessagePublisher


### PR DESCRIPTION
"graylog2/gelf-php": "~1.5.0"
Attempted to load class "MessagePublisher" from namespace "Gelf".
Did you forget a "use" statement for another namespace?