### PR TITLE
Allow alternative date separators for RotatingFileHandler

### DIFF
--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -69,11 +69,12 @@ class RotatingFileHandler extends StreamHandler
 
     public function setFilenameFormat($filenameFormat, $dateFormat)
     {
-        if (!in_array($dateFormat, [self::FILE_PER_DAY, self::FILE_PER_MONTH, self::FILE_PER_YEAR])) {
+        if (!preg_match('~^Y(([/_\.-]m)([/_\.-]d)?)?$~', $dateFormat)) {
             throw new InvalidArgumentException(
                 'Invalid date format - format must be one of '.
-                'RotatingFileHandler::FILE_PER_DAY, RotatingFileHandler::FILE_PER_MONTH '.
-                'or RotatingFileHandler::FILE_PER_YEAR.'
+                'RotatingFileHandler::FILE_PER_DAY ("Y-m-d"), RotatingFileHandler::FILE_PER_MONTH ("Y-m")'.
+                'or RotatingFileHandler::FILE_PER_YEAR ("Y"), or you can set one of the '.
+                'date formats where dashes are replaces with slashes, underscores and/or dots.'
             );
         }
         if (substr_count($filenameFormat, '{date}') === 0) {

--- a/tests/Monolog/Handler/RotatingFileHandlerTest.php
+++ b/tests/Monolog/Handler/RotatingFileHandlerTest.php
@@ -153,8 +153,20 @@ class RotatingFileHandlerTest extends TestCase
             [RotatingFileHandler::FILE_PER_DAY, true],
             [RotatingFileHandler::FILE_PER_MONTH, true],
             [RotatingFileHandler::FILE_PER_YEAR, true],
+            ['Y/m/d', true],
+            ['Y.m.d', true],
+            ['Y_m_d', true],
+            ['Y/m', true],
+            ['Y.m', true],
+            ['Y_m', true],
+            ['', false],
             ['m-d-Y', false],
             ['Y-m-d-h-i', false],
+            ['Y-', false],
+            ['Y-m-', false],
+            ['Y--', false],
+            ['m-d', false],
+            ['Y-d', false]
         ];
     }
 


### PR DESCRIPTION
Currently only dashes are allowed in date formats (i.e., "Y-m-d").
This commit also allows slashes, underscores and dots to be used instead
of only dashes for more flexibility.