### PR TITLE
Fixed incompatible interfaces with MailHandler

### DIFF
--- a/src/Monolog/Handler/MandrillHandler.php
+++ b/src/Monolog/Handler/MandrillHandler.php
@@ -46,7 +46,7 @@ class MandrillHandler extends MailHandler
     /**
      * {@inheritdoc}
      */
-    protected function send($content, array $records)
+    protected function send(string $content, array $records)
     {
         $mime = null;
         if ($this->isHtmlBody($content)) {

--- a/src/Monolog/Handler/SendGridHandler.php
+++ b/src/Monolog/Handler/SendGridHandler.php
@@ -72,7 +72,7 @@ class SendGridHandler extends MailHandler
     /**
      * {@inheritdoc}
      */
-    protected function send($content, array $records)
+    protected function send(string $content, array $records)
     {
         $message = [];
         $message['api_user'] = $this->apiUser;


### PR DESCRIPTION
These two classes crash when I try to include them on PHP 7.

BTW: I found this issue using my new static analysis tool [PHPStan](https://github.com/phpstan/phpstan). I can send you a PR with integrating the tool in the Monolog build script.