### PR TITLE
Throw RuntimeException if socket resource is missing

### DIFF
--- a/src/Monolog/Handler/SyslogUdp/UdpSocket.php
+++ b/src/Monolog/Handler/SyslogUdp/UdpSocket.php
@@ -42,7 +42,7 @@ class UdpSocket
     protected function send($chunk)
     {
         if (!is_resource($this->socket)) {
-            throw new \LogicException('The UdpSocket to '.$this->ip.':'.$this->port.' has been closed and can not be written to anymore');
+            throw new \RuntimeException('The UdpSocket to '.$this->ip.':'.$this->port.' has been closed and can not be written to anymore');
         }
         socket_sendto($this->socket, $chunk, strlen($chunk), $flags = 0, $this->ip, $this->port);
     }


### PR DESCRIPTION
The socket resource can be closed, purged or lost during the runtime of an application.
It is valid concern, because the resource is acquired and used at different times during request.

LogicException is more for static preconditions that have to be valid before function call.

I realize that it's BC break, but it still makes sense. Having that I can handle all RuntimeExceptions the same way, instead of using catch-all Exception handling.
