### PR TITLE
Throw exception in case the log file has been deleted

### DIFF
--- a/src/Monolog/Handler/StreamHandler.php
+++ b/src/Monolog/Handler/StreamHandler.php
@@ -108,6 +108,10 @@ class StreamHandler extends AbstractProcessingHandler
             }
         }
 
+        if (null !== $this->url && null !== $this->getDirFromStream($this->url) && !is_writable($this->url)) {
+            throw new \UnexpectedValueException(sprintf('Impossible to write in the stream. This may be caused by the deletion of "%s".', $this->url));
+        }
+
         if ($this->useLocking) {
             // ignoring errors here, there's not much we can do about them
             flock($this->stream, LOCK_EX);

--- a/tests/Monolog/Handler/StreamHandlerTest.php
+++ b/tests/Monolog/Handler/StreamHandlerTest.php
@@ -88,9 +88,18 @@ class StreamHandlerTest extends TestCase
     /**
      * @covers Monolog\Handler\StreamHandler::write
      */
-    public function testWriteCreatesTheStreamResource()
+    public function testWriteCreatesTheMemoryStreamResource()
     {
         $handler = new StreamHandler('php://memory');
+        $handler->handle($this->getRecord());
+    }
+
+    /**
+     * @covers Monolog\Handler\StreamHandler::write
+     */
+    public function testWriteCreatesTheFileStreamResource()
+    {
+        $handler = new StreamHandler('file://'.sys_get_temp_dir().DIRECTORY_SEPARATOR.'foo');
         $handler->handle($this->getRecord());
     }
 
@@ -204,6 +213,21 @@ class StreamHandlerTest extends TestCase
             $this->markTestSkipped('Permissions checks can not run on windows');
         }
         $handler = new StreamHandler('file:///foo/bar/'.rand(0, 10000).DIRECTORY_SEPARATOR.rand(0, 10000));
+        $handler->handle($this->getRecord());
+    }
+
+
+    /**
+     * @expectedException UnexpectedValueException
+     * @expectedExceptionMessageRegExp /Impossible to write in the stream. This may be caused by the deletion of/
+     * @covers Monolog\Handler\StreamHandler::write
+     */
+    public function testWriteProblemOnStream()
+    {
+        $path = sys_get_temp_dir().DIRECTORY_SEPARATOR.uniqid('monolog');
+        $handler = new StreamHandler($path);
+        $handler->handle($this->getRecord());
+        unlink($path);
         $handler->handle($this->getRecord());
     }
 }


### PR DESCRIPTION
When you create a StreamHandler based on a file, absolutely no errors is raised if the file has been deleted.

Which is a real problem, as you don't know that you are not able to log.

This PR aims to fix this bug.