### PR TITLE
Add support for PHP 7 errors in RavenHandler

### DIFF
--- a/src/Monolog/Handler/RavenHandler.php
+++ b/src/Monolog/Handler/RavenHandler.php
@@ -179,7 +179,7 @@ class RavenHandler extends AbstractProcessingHandler
             $options['release'] = $this->release;
         }
 
-        if (isset($record['context']['exception']) && $record['context']['exception'] instanceof \Exception) {
+        if (isset($record['context']['exception']) && ($record['context']['exception'] instanceof \Exception || (PHP_VERSION_ID >= 70000 && $record['context']['exception'] instanceof \Throwable))) {
             $options['extra']['message'] = $record['formatted'];
             $this->ravenClient->captureException($record['context']['exception'], $options);
         } else {


### PR DESCRIPTION
I think this is related to #759.