### PR TITLE
Add ConstStub awareness to NormalizerFormatter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "php-amqplib/php-amqplib": "~2.4",
         "swiftmailer/swiftmailer": "~5.3",
         "php-console/php-console": "^3.1.3",
+        "symfony/var-dumper": ">=2.7",
         "jakub-onderka/php-parallel-lint": "^0.9"
     },
     "suggest": {

--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -13,6 +13,7 @@ namespace Monolog\Formatter;
 
 use Throwable;
 use Monolog\DateTimeImmutable;
+use Symfony\Component\VarDumper\Caster\ConstStub;
 
 /**
  * Normalizes incoming records to remove objects/resources so it's easier to dump to various targets
@@ -60,6 +61,10 @@ class NormalizerFormatter implements FormatterInterface
     {
         if ($depth > 9) {
             return 'Over 9 levels deep, aborting normalization';
+        }
+
+        if ($data instanceof ConstStub) {
+            $data = $data->value;
         }
 
         if (null === $data || is_scalar($data)) {

--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -11,6 +11,8 @@
 
 namespace Monolog\Formatter;
 
+use Symfony\Component\VarDumper\Caster\ConstStub;
+
 /**
  * @covers Monolog\Formatter\NormalizerFormatter
  */
@@ -38,6 +40,7 @@ class NormalizerFormatterTest extends \PHPUnit_Framework_TestCase
                 'inf' => INF,
                 '-inf' => -INF,
                 'nan' => acos(4),
+                'const_stub' => new ConstStub('FOO', 123),
             ],
         ]);
 
@@ -58,6 +61,7 @@ class NormalizerFormatterTest extends \PHPUnit_Framework_TestCase
                 'inf' => 'INF',
                 '-inf' => '-INF',
                 'nan' => 'NaN',
+                'const_stub' => 123,
             ],
         ], $formatted);
     }


### PR DESCRIPTION
By wrapping context values into [`ConstStub`](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/VarDumper/Caster/ConstStub.php) objects, one can add precise type information to log contexts. Yet, this results in pure noise when the context is dumped into log files.
Since ConstStub is basically a value wrapper, NormalizerFormatter can remove it to get clean logs back.

This would be of paramount usefulness for the upcoming Symfony 3.2 profiler panel where we'd use this feature immediately to get a better log panel.