### PR TITLE
Preserved typing for float and integers values

### DIFF
--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -196,7 +196,7 @@ class NormalizerFormatter implements FormatterInterface
      */
     private function jsonEncode($data)
     {
-        return json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        return json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_NUMERIC_CHECK | JSON_PRESERVE_ZERO_FRACTION);
     }
 
     /**


### PR DESCRIPTION
Related #831
Logs stored in a ELK-based solution need to keep the value typing, especially with float vs integer types.
Adding `JSON_NUMERIC_CHECK` and `JSON_PRESERVE_ZERO_FRACTION` allow to avoid issue.