### PR TITLE
Add new Slack handlers using Slackbot and webhooks

### DIFF
--- a/doc/02-handlers-formatters-processors.md
+++ b/doc/02-handlers-formatters-processors.md
@@ -32,7 +32,9 @@
 - _PushoverHandler_: Sends mobile notifications via the [Pushover](https://www.pushover.net/) API.
 - _HipChatHandler_: Logs records to a [HipChat](http://hipchat.com) chat room using its API.
 - _FlowdockHandler_: Logs records to a [Flowdock](https://www.flowdock.com/) account.
-- _SlackHandler_: Logs records to a [Slack](https://www.slack.com/) account.
+- _SlackHandler_: Logs records to a [Slack](https://www.slack.com/) account using the Slack API.
+- _SlackbotHandler_: Logs records to a [Slack](https://www.slack.com/) account using the Slackbot incoming hook.
+- _SlackWebhookHandler_: Logs records to a [Slack](https://www.slack.com/) account using Slack Webhooks.
 - _MandrillHandler_: Sends emails via the Mandrill API using a [`Swift_Message`](http://swiftmailer.org/) instance.
 - _FleepHookHandler_: Logs records to a [Fleep](https://fleep.io/) conversation using Webhooks.
 - _IFTTTHandler_: Notifies an [IFTTT](https://ifttt.com/maker) trigger with the log channel, level name and message.

--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -99,7 +99,6 @@ class SlackRecord
         $dataArray = array(
             'username'    => $this->username,
             'text'        => '',
-            'attachments' => array(),
         );
 
         if ($this->channel) {

--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -179,7 +179,7 @@ class SlackRecord
                 }
             }
 
-            $dataArray['attachments'] = json_encode(array($attachment));
+            $dataArray['attachments'] = array($attachment);
         } else {
             $dataArray['text'] = $message;
         }

--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -96,11 +96,14 @@ class SlackRecord
     public function getSlackData(array $record)
     {
         $dataArray = array(
-            'channel'     => $this->channel,
             'username'    => $this->username,
             'text'        => '',
             'attachments' => array(),
         );
+
+        if ($this->channel) {
+            $dataArray['channel'] = $this->channel;
+        }
 
         if ($this->formatter) {
             $message = $this->formatter->format($record);

--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -216,10 +216,14 @@ class SlackRecord
      * Stringifies an array of key/value pairs to be used in attachment fields
      *
      * @param  array  $fields
-     * @return string
+     * @return string|null
      */
     public function stringify($fields)
     {
+        if (!$this->lineFormatter) {
+            return null;
+        }
+
         $string = '';
         foreach ($fields as $var => $val) {
             $string .= $var.': '.$this->lineFormatter->stringify($val)." | ";

--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -217,9 +217,9 @@ class SlackRecord
     /**
      * Generates attachment field
      *
-     * @param $title
-     * @param $value
-     * @param $short
+     * @param string $title
+     * @param string|array $value
+     * @param bool $short
      * @return array
      */
     private function generateAttachmentField($title, $value, $short)

--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -226,4 +226,14 @@ class SlackRecord
 
         return $string;
     }
+
+    /**
+     * Sets the formatter
+     *
+     * @param FormatterInterface $formatter
+     */
+    public function setFormatter(FormatterInterface $formatter)
+    {
+        $this->formatter = $formatter;
+    }
 }

--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -96,7 +96,7 @@ class SlackRecord
         $this->includeContextAndExtra = $includeContextAndExtra;
         $this->formatter = $formatter;
 
-        if ($this->includeContextAndExtra && $this->useShortAttachment) {
+        if ($this->includeContextAndExtra) {
             $this->lineFormatter = new LineFormatter();
         }
     }
@@ -152,7 +152,7 @@ class SlackRecord
                         foreach ($record['extra'] as $var => $val) {
                             $attachment['fields'][] = array(
                                 'title' => $var,
-                                'value' => $val,
+                                'value' => is_array($val) ? $this->lineFormatter->stringify($val) : $val,
                                 'short' => $this->useShortAttachment,
                             );
                         }
@@ -171,7 +171,7 @@ class SlackRecord
                         foreach ($record['context'] as $var => $val) {
                             $attachment['fields'][] = array(
                                 'title' => $var,
-                                'value' => $val,
+                                'value' => is_array($val) ? $this->lineFormatter->stringify($val) : $val,
                                 'short' => $this->useShortAttachment,
                             );
                         }

--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -25,6 +25,14 @@ use Monolog\Formatter\FormatterInterface;
  */
 class SlackRecord
 {
+    const COLOR_DANGER = 'danger';
+
+    const COLOR_WARNING = 'warning';
+
+    const COLOR_GOOD = 'good';
+
+    const COLOR_DEFAULT = '#e3e4e6';
+
     /**
      * Slack channel (encoded ID or name)
      * @var string
@@ -194,13 +202,13 @@ class SlackRecord
     {
         switch (true) {
             case $level >= Logger::ERROR:
-                return 'danger';
+                return self::COLOR_DANGER;
             case $level >= Logger::WARNING:
-                return 'warning';
+                return self::COLOR_WARNING;
             case $level >= Logger::INFO:
-                return 'good';
+                return self::COLOR_GOOD;
             default:
-                return '#e3e4e6';
+                return self::COLOR_DEFAULT;
         }
     }
 

--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -1,0 +1,221 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler\Slack;
+
+use Monolog\Logger;
+use Monolog\Formatter\LineFormatter;
+use Monolog\Formatter\FormatterInterface;
+
+/**
+ * Slack record utility helping to log to Slack webhooks or API.
+ *
+ * @author Greg Kedzierski <greg@gregkedzierski.com>
+ * @author Haralan Dobrev <hkdobrev@gmail.com>
+ * @see    https://api.slack.com/incoming-webhooks
+ * @see    https://api.slack.com/docs/message-attachments
+ */
+class SlackRecord
+{
+    /**
+     * Slack channel (encoded ID or name)
+     * @var string
+     */
+    private $channel;
+
+    /**
+     * Name of a bot
+     * @var string
+     */
+    private $username;
+
+    /**
+     * Emoji icon name
+     * @var string
+     */
+    private $iconEmoji;
+
+    /**
+     * Whether the message should be added to Slack as attachment (plain text otherwise)
+     * @var bool
+     */
+    private $useAttachment;
+
+    /**
+     * Whether the the context/extra messages added to Slack as attachments are in a short style
+     * @var bool
+     */
+    private $useShortAttachment;
+
+    /**
+     * Whether the attachment should include context and extra data
+     * @var bool
+     */
+    private $includeContextAndExtra;
+
+    /**
+     * @var FormatterInterface
+     */
+    private $formatter;
+
+    /**
+     * @var LineFormatter
+     */
+    private $lineFormatter;
+
+    public function __construct(
+        $channel,
+        $username = 'Monolog',
+        $useAttachment = true,
+        $iconEmoji = null,
+        $useShortAttachment = false,
+        $includeContextAndExtra = false,
+        FormatterInterface $formatter = null
+    ) {
+        $this->channel = $channel;
+        $this->username = $username;
+        $this->iconEmoji = trim($iconEmoji, ':');
+        $this->useAttachment = $useAttachment;
+        $this->useShortAttachment = $useShortAttachment;
+        $this->includeContextAndExtra = $includeContextAndExtra;
+        $this->formatter = $formatter;
+
+        if ($this->includeContextAndExtra && $this->useShortAttachment) {
+            $this->lineFormatter = new LineFormatter();
+        }
+    }
+
+    public function getSlackData(array $record)
+    {
+        $dataArray = array(
+            'channel'     => $this->channel,
+            'username'    => $this->username,
+            'text'        => '',
+            'attachments' => array(),
+        );
+
+        if ($this->formatter) {
+            $message = $this->formatter->format($record);
+        } else {
+            $message = $record['message'];
+        }
+
+        if ($this->useAttachment) {
+            $attachment = array(
+                'fallback' => $message,
+                'color'    => $this->getAttachmentColor($record['level']),
+                'fields'   => array(),
+            );
+
+            if ($this->useShortAttachment) {
+                $attachment['title'] = $record['level_name'];
+                $attachment['text'] = $message;
+            } else {
+                $attachment['title'] = 'Message';
+                $attachment['text'] = $message;
+                $attachment['fields'][] = array(
+                    'title' => 'Level',
+                    'value' => $record['level_name'],
+                    'short' => true,
+                );
+            }
+
+            if ($this->includeContextAndExtra) {
+                if (!empty($record['extra'])) {
+                    if ($this->useShortAttachment) {
+                        $attachment['fields'][] = array(
+                            'title' => "Extra",
+                            'value' => $this->stringify($record['extra']),
+                            'short' => $this->useShortAttachment,
+                        );
+                    } else {
+                        // Add all extra fields as individual fields in attachment
+                        foreach ($record['extra'] as $var => $val) {
+                            $attachment['fields'][] = array(
+                                'title' => $var,
+                                'value' => $val,
+                                'short' => $this->useShortAttachment,
+                            );
+                        }
+                    }
+                }
+
+                if (!empty($record['context'])) {
+                    if ($this->useShortAttachment) {
+                        $attachment['fields'][] = array(
+                            'title' => "Context",
+                            'value' => $this->stringify($record['context']),
+                            'short' => $this->useShortAttachment,
+                        );
+                    } else {
+                        // Add all context fields as individual fields in attachment
+                        foreach ($record['context'] as $var => $val) {
+                            $attachment['fields'][] = array(
+                                'title' => $var,
+                                'value' => $val,
+                                'short' => $this->useShortAttachment,
+                            );
+                        }
+                    }
+                }
+            }
+
+            $dataArray['attachments'] = json_encode(array($attachment));
+        } else {
+            $dataArray['text'] = $message;
+        }
+
+        if ($this->iconEmoji) {
+            $dataArray['icon_emoji'] = ":{$this->iconEmoji}:";
+        }
+
+        return $dataArray;
+    }
+
+    /**
+     * Returned a Slack message attachment color associated with
+     * provided level.
+     *
+     * @param  int    $level
+     * @return string
+     */
+    public function getAttachmentColor($level)
+    {
+        switch (true) {
+            case $level >= Logger::ERROR:
+                return 'danger';
+            case $level >= Logger::WARNING:
+                return 'warning';
+            case $level >= Logger::INFO:
+                return 'good';
+            default:
+                return '#e3e4e6';
+        }
+    }
+
+    /**
+     * Stringifies an array of key/value pairs to be used in attachment fields
+     *
+     * @param  array  $fields
+     * @return string
+     */
+    public function stringify($fields)
+    {
+        $string = '';
+        foreach ($fields as $var => $val) {
+            $string .= $var.': '.$this->lineFormatter->stringify($val)." | ";
+        }
+
+        $string = rtrim($string, " |");
+
+        return $string;
+    }
+}

--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -35,7 +35,7 @@ class SlackRecord
 
     /**
      * Slack channel (encoded ID or name)
-     * @var string
+     * @var string|null
      */
     private $channel;
 
@@ -79,15 +79,8 @@ class SlackRecord
      */
     private $lineFormatter;
 
-    public function __construct(
-        $channel,
-        $username = 'Monolog',
-        $useAttachment = true,
-        $iconEmoji = null,
-        $useShortAttachment = false,
-        $includeContextAndExtra = false,
-        FormatterInterface $formatter = null
-    ) {
+    public function __construct($channel = null, $username = 'Monolog', $useAttachment = true, $iconEmoji = null, $useShortAttachment = false, $includeContextAndExtra = false, FormatterInterface $formatter = null)
+    {
         $this->channel = $channel;
         $this->username = $username;
         $this->iconEmoji = trim($iconEmoji, ':');
@@ -145,7 +138,7 @@ class SlackRecord
                         $attachment['fields'][] = array(
                             'title' => "Extra",
                             'value' => $this->stringify($record['extra']),
-                            'short' => $this->useShortAttachment,
+                            'short' => true,
                         );
                     } else {
                         // Add all extra fields as individual fields in attachment
@@ -153,7 +146,7 @@ class SlackRecord
                             $attachment['fields'][] = array(
                                 'title' => $var,
                                 'value' => is_array($val) ? $this->lineFormatter->stringify($val) : $val,
-                                'short' => $this->useShortAttachment,
+                                'short' => false,
                             );
                         }
                     }
@@ -164,7 +157,7 @@ class SlackRecord
                         $attachment['fields'][] = array(
                             'title' => "Context",
                             'value' => $this->stringify($record['context']),
-                            'short' => $this->useShortAttachment,
+                            'short' => true,
                         );
                     } else {
                         // Add all context fields as individual fields in attachment
@@ -172,7 +165,7 @@ class SlackRecord
                             $attachment['fields'][] = array(
                                 'title' => $var,
                                 'value' => is_array($val) ? $this->lineFormatter->stringify($val) : $val,
-                                'short' => $this->useShortAttachment,
+                                'short' => false,
                             );
                         }
                     }

--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -46,21 +46,10 @@ class SlackHandler extends SocketHandler
      * @param  bool                      $includeContextAndExtra Whether the attachment should include context and extra data
      * @throws MissingExtensionException If no OpenSSL PHP extension configured
      */
-    public function __construct(
-        $token,
-        $channel,
-        $username = 'Monolog',
-        $useAttachment = true,
-        $iconEmoji = null,
-        $level = Logger::CRITICAL,
-        $bubble = true,
-        $useShortAttachment = false,
-        $includeContextAndExtra = false
-    ) {
+    public function __construct($token, $channel, $username = 'Monolog', $useAttachment = true, $iconEmoji = null, $level = Logger::CRITICAL, $bubble = true, $useShortAttachment = false, $includeContextAndExtra = false)
+    {
         if (!extension_loaded('openssl')) {
-            throw new MissingExtensionException(
-                'The OpenSSL PHP extension is required to use the SlackHandler'
-            );
+            throw new MissingExtensionException('The OpenSSL PHP extension is required to use the SlackHandler');
         }
 
         parent::__construct('ssl://slack.com:443', $level, $bubble);

--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -191,4 +191,12 @@ class SlackHandler extends SocketHandler
 
         return $this;
     }
+
+    public function getFormatter()
+    {
+        $formatter = parent::getFormatter();
+        $this->slackRecord->setFormatter($formatter);
+
+        return $formatter;
+    }
 }

--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -156,9 +156,15 @@ class SlackHandler extends SocketHandler
      *
      * @param  int    $level
      * @return string
+     * @deprecated Use underlying SlackRecord instead
      */
     protected function getAttachmentColor($level)
     {
+        trigger_error(
+            'SlackHandler::getAttachmentColor() is deprecated. Use underlying SlackRecord instead.',
+            E_USER_DEPRECATED
+        );
+
         return $this->slackRecord->getAttachmentColor($level);
     }
 
@@ -167,9 +173,15 @@ class SlackHandler extends SocketHandler
      *
      * @param  array  $fields
      * @return string
+     * @deprecated Use underlying SlackRecord instead
      */
     protected function stringify($fields)
     {
+        trigger_error(
+            'SlackHandler::stringify() is deprecated. Use underlying SlackRecord instead.',
+            E_USER_DEPRECATED
+        );
+
         return $this->slackRecord->stringify($fields);
     }
 }

--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -11,6 +11,7 @@
 
 namespace Monolog\Handler;
 
+use Monolog\Formatter\FormatterInterface;
 use Monolog\Logger;
 use Monolog\Handler\Slack\SlackRecord;
 
@@ -177,5 +178,13 @@ class SlackHandler extends SocketHandler
         );
 
         return $this->slackRecord->stringify($fields);
+    }
+
+    public function setFormatter(FormatterInterface $formatter)
+    {
+        parent::setFormatter($formatter);
+        $this->slackRecord->setFormatter($formatter);
+
+        return $this;
     }
 }

--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -110,6 +110,10 @@ class SlackHandler extends SocketHandler
         $dataArray = $this->slackRecord->getSlackData($record);
         $dataArray['token'] = $this->token;
 
+        if (!empty($dataArray['attachments'])) {
+            $dataArray['attachments'] = json_encode($dataArray['attachments']);
+        }
+
         return $dataArray;
     }
 

--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -78,6 +78,11 @@ class SlackHandler extends SocketHandler
         $this->token = $token;
     }
 
+    public function getSlackRecord()
+    {
+        return $this->slackRecord;
+    }
+
     /**
      * {@inheritdoc}
      *

--- a/src/Monolog/Handler/SlackWebhookHandler.php
+++ b/src/Monolog/Handler/SlackWebhookHandler.php
@@ -11,8 +11,8 @@
 
 namespace Monolog\Handler;
 
+use Monolog\Formatter\FormatterInterface;
 use Monolog\Logger;
-use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\Slack\SlackRecord;
 
 /**
@@ -97,5 +97,21 @@ class SlackWebhookHandler extends AbstractProcessingHandler
         curl_setopt($ch, CURLOPT_POSTFIELDS, array('payload' => $postString));
 
         Curl\Util::execute($ch);
+    }
+
+    public function setFormatter(FormatterInterface $formatter)
+    {
+        parent::setFormatter($formatter);
+        $this->slackRecord->setFormatter($formatter);
+
+        return $this;
+    }
+
+    public function getFormatter()
+    {
+        $formatter = parent::getFormatter();
+        $this->slackRecord->setFormatter($formatter);
+
+        return $formatter;
     }
 }

--- a/src/Monolog/Handler/SlackWebhookHandler.php
+++ b/src/Monolog/Handler/SlackWebhookHandler.php
@@ -46,17 +46,8 @@ class SlackWebhookHandler extends AbstractProcessingHandler
      * @param  int         $level                  The minimum logging level at which this handler will be triggered
      * @param  bool        $bubble                 Whether the messages that are handled can bubble up the stack or not
      */
-    public function __construct(
-        $webhookUrl,
-        $channel = null,
-        $username = 'Monolog',
-        $useAttachment = true,
-        $iconEmoji = null,
-        $useShortAttachment = false,
-        $includeContextAndExtra = false,
-        $level = Logger::CRITICAL,
-        $bubble = true
-    ) {
+    public function __construct($webhookUrl, $channel = null, $username = 'Monolog', $useAttachment = true, $iconEmoji = null, $useShortAttachment = false, $includeContextAndExtra = false, $level = Logger::CRITICAL, $bubble = true)
+    {
         parent::__construct($level, $bubble);
 
         $this->webhookUrl = $webhookUrl;

--- a/src/Monolog/Handler/SlackWebhookHandler.php
+++ b/src/Monolog/Handler/SlackWebhookHandler.php
@@ -72,6 +72,11 @@ class SlackWebhookHandler extends AbstractProcessingHandler
         );
     }
 
+    public function getSlackRecord()
+    {
+        return $this->slackRecord;
+    }
+
     /**
      * {@inheritdoc}
      *

--- a/src/Monolog/Handler/SlackWebhookHandler.php
+++ b/src/Monolog/Handler/SlackWebhookHandler.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Logger;
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\Slack\SlackRecord;
+
+/**
+ * Sends notifications through Slack Webhooks
+ *
+ * @author Haralan Dobrev <hkdobrev@gmail.com>
+ * @see    https://api.slack.com/incoming-webhooks
+ */
+class SlackWebhookHandler extends AbstractProcessingHandler
+{
+    /**
+     * Slack Webhook token
+     * @var string
+     */
+    private $webhookUrl;
+
+    /**
+     * Instance of the SlackRecord util class preparing data for Slack API.
+     * @var SlackRecord
+     */
+    private $slackRecord;
+
+    /**
+     * @param  string      $webhookUrl             Slack Webhook URL
+     * @param  string|null $channel                Slack channel (encoded ID or name)
+     * @param  string      $username               Name of a bot
+     * @param  bool        $useAttachment          Whether the message should be added to Slack as attachment (plain text otherwise)
+     * @param  string|null $iconEmoji              The emoji name to use (or null)
+     * @param  bool        $useShortAttachment     Whether the the context/extra messages added to Slack as attachments are in a short style
+     * @param  bool        $includeContextAndExtra Whether the attachment should include context and extra data
+     * @param  int         $level                  The minimum logging level at which this handler will be triggered
+     * @param  bool        $bubble                 Whether the messages that are handled can bubble up the stack or not
+     */
+    public function __construct(
+        $webhookUrl,
+        $channel = null,
+        $username = 'Monolog',
+        $useAttachment = true,
+        $iconEmoji = null,
+        $useShortAttachment = false,
+        $includeContextAndExtra = false,
+        $level = Logger::CRITICAL,
+        $bubble = true
+    ) {
+        parent::__construct($level, $bubble);
+
+        $this->webhookUrl = $webhookUrl;
+
+        $this->slackRecord = new SlackRecord(
+            $channel,
+            $username,
+            $useAttachment,
+            $iconEmoji,
+            $useShortAttachment,
+            $includeContextAndExtra,
+            $this->formatter
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param array $record
+     */
+    protected function write(array $record)
+    {
+        $postData = $this->slackRecord->getSlackData($record);
+        $postString = json_encode($postData);
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $this->webhookUrl);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        if (defined('CURLOPT_SAFE_UPLOAD')) {
+            curl_setopt($ch, CURLOPT_SAFE_UPLOAD, true);
+        }
+        curl_setopt($ch, CURLOPT_POSTFIELDS, array('payload' => $postString));
+
+        Curl\Util::execute($ch);
+    }
+}

--- a/src/Monolog/Handler/SlackbotHandler.php
+++ b/src/Monolog/Handler/SlackbotHandler.php
@@ -46,13 +46,8 @@ class SlackbotHandler extends AbstractProcessingHandler
      * @param  int    $level     The minimum logging level at which this handler will be triggered
      * @param  bool   $bubble    Whether the messages that are handled can bubble up the stack or not
      */
-    public function __construct(
-        $slackTeam,
-        $token,
-        $channel,
-        $level = Logger::CRITICAL,
-        $bubble = true
-    ) {
+    public function __construct($slackTeam, $token, $channel, $level = Logger::CRITICAL, $bubble = true)
+    {
         parent::__construct($level, $bubble);
 
         $this->slackTeam = $slackTeam;

--- a/src/Monolog/Handler/SlackbotHandler.php
+++ b/src/Monolog/Handler/SlackbotHandler.php
@@ -40,10 +40,11 @@ class SlackbotHandler extends AbstractProcessingHandler
     private $channel;
 
     /**
-     * @param  string $token   Slackbot token
-     * @param  string $channel Slack channel (encoded ID or name)
-     * @param  int    $level   The minimum logging level at which this handler will be triggered
-     * @param  bool   $bubble  Whether the messages that are handled can bubble up the stack or not
+     * @param  string $slackTeam Slack team slug
+     * @param  string $token     Slackbot token
+     * @param  string $channel   Slack channel (encoded ID or name)
+     * @param  int    $level     The minimum logging level at which this handler will be triggered
+     * @param  bool   $bubble    Whether the messages that are handled can bubble up the stack or not
      */
     public function __construct(
         $slackTeam,

--- a/src/Monolog/Handler/SlackbotHandler.php
+++ b/src/Monolog/Handler/SlackbotHandler.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Logger;
+
+/**
+ * Sends notifications through Slack's Slackbot
+ *
+ * @author Haralan Dobrev <hkdobrev@gmail.com>
+ * @see    https://slack.com/apps/A0F81R8ET-slackbot
+ */
+class SlackbotHandler extends AbstractProcessingHandler
+{
+    /**
+     * The slug of the Slack team
+     * @var string
+     */
+    private $slackTeam;
+
+    /**
+     * Slackbot token
+     * @var string
+     */
+    private $token;
+
+    /**
+     * Slack channel name
+     * @var string
+     */
+    private $channel;
+
+    /**
+     * @param  string $token   Slackbot token
+     * @param  string $channel Slack channel (encoded ID or name)
+     * @param  int    $level   The minimum logging level at which this handler will be triggered
+     * @param  bool   $bubble  Whether the messages that are handled can bubble up the stack or not
+     */
+    public function __construct(
+        $slackTeam,
+        $token,
+        $channel,
+        $level = Logger::CRITICAL,
+        $bubble = true
+    ) {
+        parent::__construct($level, $bubble);
+
+        $this->slackTeam = $slackTeam;
+        $this->token = $token;
+        $this->channel = $channel;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param array $record
+     */
+    protected function write(array $record)
+    {
+        $slackbotUrl = sprintf(
+            'https://%s.slack.com/services/hooks/slackbot?token=%s&channel=%s',
+            $this->slackTeam,
+            $this->token,
+            $this->channel
+        );
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $slackbotUrl);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $record['message']);
+
+        Curl\Util::execute($ch);
+    }
+}

--- a/tests/Monolog/Handler/Slack/SlackRecordTest.php
+++ b/tests/Monolog/Handler/Slack/SlackRecordTest.php
@@ -308,7 +308,7 @@ class SlackRecordTest extends TestCase
             ),
             array(
                 'title' => 'tags',
-                'value' => array('web'),
+                'value' => '["web"]',
                 'short' => false
             ),
             array(

--- a/tests/Monolog/Handler/Slack/SlackRecordTest.php
+++ b/tests/Monolog/Handler/Slack/SlackRecordTest.php
@@ -181,12 +181,24 @@ class SlackRecordTest extends TestCase
             ->method('format')
             ->will($this->returnCallback(function ($record) { return $record['message'] . 'test'; }));
 
+        $formatter2 = $this->createMock(FormatterInterface::class);
+        $formatter2
+            ->expects($this->any())
+            ->method('format')
+            ->will($this->returnCallback(function ($record) { return $record['message'] . 'test1'; }));
+
         $message = 'Test message';
         $record = new SlackRecord($this->channel, 'Monolog', false, null, false, false, $formatter);
         $data = $record->getSlackData($this->getRecord(Logger::WARNING, $message));
 
         $this->assertArrayHasKey('text', $data);
         $this->assertSame($message . 'test', $data['text']);
+
+        $record->setFormatter($formatter2);
+        $data = $record->getSlackData($this->getRecord(Logger::WARNING, $message));
+
+        $this->assertArrayHasKey('text', $data);
+        $this->assertSame($message . 'test1', $data['text']);
     }
 
     public function testAddsFallbackAndTextToAttachment()

--- a/tests/Monolog/Handler/Slack/SlackRecordTest.php
+++ b/tests/Monolog/Handler/Slack/SlackRecordTest.php
@@ -11,6 +11,7 @@
 
 namespace Monolog\Handler\Slack;
 
+use Monolog\Formatter\FormatterInterface;
 use Monolog\Logger;
 use Monolog\TestCase;
 
@@ -19,6 +20,13 @@ use Monolog\TestCase;
  */
 class SlackRecordTest extends TestCase
 {
+    private $channel;
+
+    protected function setUp()
+    {
+        $this->channel = 'monolog_alerts';
+    }
+
     public function dataGetAttachmentColor()
     {
         return array(
@@ -47,10 +55,28 @@ class SlackRecordTest extends TestCase
         );
     }
 
+    public function testAddsChannel()
+    {
+        $record = new SlackRecord($this->channel);
+        $data = $record->getSlackData($this->getRecord());
+
+        $this->assertArrayHasKey('channel', $data);
+        $this->assertSame($this->channel, $data['channel']);
+    }
+
     public function testStringifyReturnsNullWithNoLineFormatter()
     {
         $slackRecord = new SlackRecord('#test');
         $this->assertNull($slackRecord->stringify(array('foo' => 'bar')));
+    }
+
+    public function testAddsDefaultUsername()
+    {
+        $record = new SlackRecord($this->channel);
+        $data = $record->getSlackData($this->getRecord());
+
+        $this->assertArrayHasKey('username', $data);
+        $this->assertSame('Monolog', $data['username']);
     }
 
     /**
@@ -80,5 +106,226 @@ class SlackRecordTest extends TestCase
         );
 
         $this->assertSame($expectedResult, $slackRecord->stringify($fields));
+    }
+
+    public function testAddsCustomUsername()
+    {
+        $username = 'Monolog bot';
+        $record = new SlackRecord($this->channel, $username);
+        $data = $record->getSlackData($this->getRecord());
+
+        $this->assertArrayHasKey('username', $data);
+        $this->assertSame($username, $data['username']);
+    }
+
+    public function testNoIcon()
+    {
+        $record = new SlackRecord($this->channel);
+        $data = $record->getSlackData($this->getRecord());
+
+        $this->assertArrayNotHasKey('icon_emoji', $data);
+    }
+
+    public function testAddsIcon()
+    {
+        $record = new SlackRecord($this->channel, 'Monolog', true, 'ghost');
+        $data = $record->getSlackData($this->getRecord());
+
+        $this->assertArrayHasKey('icon_emoji', $data);
+        $this->assertSame(':ghost:', $data['icon_emoji']);
+    }
+
+    public function testAddsEmptyTextIfUseAttachment()
+    {
+        $record = new SlackRecord($this->channel);
+        $data = $record->getSlackData($this->getRecord());
+
+        $this->assertArrayHasKey('text', $data);
+        $this->assertSame('', $data['text']);
+    }
+
+    public function testAttachmentsEmptyIfNoAttachment()
+    {
+        $record = new SlackRecord($this->channel, 'Monolog', false);
+        $data = $record->getSlackData($this->getRecord());
+
+        $this->assertArrayHasKey('attachments', $data);
+        $this->assertSame(array(), $data['attachments']);
+    }
+
+    public function testAddsOneAttachment()
+    {
+        $record = new SlackRecord($this->channel);
+        $data = $record->getSlackData($this->getRecord());
+
+        $this->assertArrayHasKey('attachments', $data);
+        $this->assertArrayHasKey(0, $data['attachments']);
+        $this->assertInternalType('array', $data['attachments'][0]);
+    }
+
+    public function testTextEqualsMessageIfNoFormatter()
+    {
+        $message = 'Test message';
+        $record = new SlackRecord($this->channel, 'Monolog', false);
+        $data = $record->getSlackData($this->getRecord(Logger::WARNING, $message));
+
+        $this->assertArrayHasKey('text', $data);
+        $this->assertSame($message, $data['text']);
+    }
+
+    public function testTextEqualsFormatterOutput()
+    {
+        $formatter = $this->createMock(FormatterInterface::class);
+        $formatter
+            ->expects($this->any())
+            ->method('format')
+            ->will($this->returnCallback(function ($record) { return $record['message'] . 'test'; }));
+
+        $message = 'Test message';
+        $record = new SlackRecord($this->channel, 'Monolog', false, null, false, false, $formatter);
+        $data = $record->getSlackData($this->getRecord(Logger::WARNING, $message));
+
+        $this->assertArrayHasKey('text', $data);
+        $this->assertSame($message . 'test', $data['text']);
+    }
+
+    public function testAddsFallbackAndTextToAttachment()
+    {
+        $message = 'Test message';
+        $record = new SlackRecord($this->channel);
+        $data = $record->getSlackData($this->getRecord(Logger::WARNING, $message));
+
+        $this->assertSame($message, $data['attachments'][0]['text']);
+        $this->assertSame($message, $data['attachments'][0]['fallback']);
+    }
+
+    public function testMapsLevelToColorAttachmentColor()
+    {
+        $record = new SlackRecord($this->channel);
+        $errorLoggerRecord = $this->getRecord(Logger::ERROR);
+        $emergencyLoggerRecord = $this->getRecord(Logger::EMERGENCY);
+        $warningLoggerRecord = $this->getRecord(Logger::WARNING);
+        $infoLoggerRecord = $this->getRecord(Logger::INFO);
+        $debugLoggerRecord = $this->getRecord(Logger::DEBUG);
+
+        $data = $record->getSlackData($errorLoggerRecord);
+        $this->assertSame(SlackRecord::COLOR_DANGER, $data['attachments'][0]['color']);
+
+        $data = $record->getSlackData($emergencyLoggerRecord);
+        $this->assertSame(SlackRecord::COLOR_DANGER, $data['attachments'][0]['color']);
+
+        $data = $record->getSlackData($warningLoggerRecord);
+        $this->assertSame(SlackRecord::COLOR_WARNING, $data['attachments'][0]['color']);
+
+        $data = $record->getSlackData($infoLoggerRecord);
+        $this->assertSame(SlackRecord::COLOR_GOOD, $data['attachments'][0]['color']);
+
+        $data = $record->getSlackData($debugLoggerRecord);
+        $this->assertSame(SlackRecord::COLOR_DEFAULT, $data['attachments'][0]['color']);
+    }
+
+    public function testAddsShortAttachmentWithoutContextAndExtra()
+    {
+        $level = Logger::ERROR;
+        $levelName = Logger::getLevelName($level);
+        $record = new SlackRecord($this->channel, 'Monolog', true, null, true);
+        $data = $record->getSlackData($this->getRecord($level, 'test', array('test' => 1)));
+
+        $attachment = $data['attachments'][0];
+        $this->assertArrayHasKey('title', $attachment);
+        $this->assertArrayHasKey('fields', $attachment);
+        $this->assertSame($levelName, $attachment['title']);
+        $this->assertSame(array(), $attachment['fields']);
+    }
+
+    public function testAddsShortAttachmentWithContextAndExtra()
+    {
+        $level = Logger::ERROR;
+        $levelName = Logger::getLevelName($level);
+        $record = new SlackRecord($this->channel, 'Monolog', true, null, true, true);
+        $loggerRecord = $this->getRecord($level, 'test', array('test' => 1));
+        $loggerRecord['extra'] = array('tags' => array('web'));
+        $data = $record->getSlackData($loggerRecord);
+
+        $attachment = $data['attachments'][0];
+        $this->assertArrayHasKey('title', $attachment);
+        $this->assertArrayHasKey('fields', $attachment);
+        $this->assertCount(2, $attachment['fields']);
+        $this->assertSame($levelName, $attachment['title']);
+        $this->assertSame(
+            array(
+                array(
+                    'title' => 'Extra',
+                    'value' => 'tags: ["web"]',
+                    'short' => true
+                ),
+                array(
+                    'title' => 'Context',
+                    'value' => 'test: 1',
+                    'short' => true
+                )
+            ),
+            $attachment['fields']
+        );
+    }
+
+    public function testAddsLongAttachmentWithoutContextAndExtra()
+    {
+        $level = Logger::ERROR;
+        $levelName = Logger::getLevelName($level);
+        $record = new SlackRecord($this->channel, 'Monolog', true, null);
+        $data = $record->getSlackData($this->getRecord($level, 'test', array('test' => 1)));
+
+        $attachment = $data['attachments'][0];
+        $this->assertArrayHasKey('title', $attachment);
+        $this->assertArrayHasKey('fields', $attachment);
+        $this->assertCount(1, $attachment['fields']);
+        $this->assertSame('Message', $attachment['title']);
+        $this->assertSame(
+            array(array(
+                'title' => 'Level',
+                'value' => $levelName,
+                'short' => true
+            )),
+            $attachment['fields']
+        );
+    }
+
+    public function testAddsLongAttachmentWithContextAndExtra()
+    {
+        $level = Logger::ERROR;
+        $levelName = Logger::getLevelName($level);
+        $record = new SlackRecord($this->channel, 'Monolog', true, null, false, true);
+        $loggerRecord = $this->getRecord($level, 'test', array('test' => 1));
+        $loggerRecord['extra'] = array('tags' => array('web'));
+        $data = $record->getSlackData($loggerRecord);
+
+        $expectedFields = array(
+            array(
+                'title' => 'Level',
+                'value' => $levelName,
+                'short' => true,
+            ),
+            array(
+                'title' => 'tags',
+                'value' => array('web'),
+                'short' => false
+            ),
+            array(
+                'title' => 'test',
+                'value' => 1,
+                'short' => false
+            )
+        );
+
+        $attachment = $data['attachments'][0];
+        $this->assertArrayHasKey('title', $attachment);
+        $this->assertArrayHasKey('fields', $attachment);
+        $this->assertCount(3, $attachment['fields']);
+        $this->assertSame('Message', $attachment['title']);
+        $this->assertSame(
+            $expectedFields,
+            $attachment['fields']
+        );
     }
 }

--- a/tests/Monolog/Handler/Slack/SlackRecordTest.php
+++ b/tests/Monolog/Handler/Slack/SlackRecordTest.php
@@ -11,7 +11,6 @@
 
 namespace Monolog\Handler\Slack;
 
-use Monolog\Formatter\FormatterInterface;
 use Monolog\Logger;
 use Monolog\TestCase;
 
@@ -175,13 +174,13 @@ class SlackRecordTest extends TestCase
 
     public function testTextEqualsFormatterOutput()
     {
-        $formatter = $this->createMock(FormatterInterface::class);
+        $formatter = $this->getMock('Monolog\\Formatter\\FormatterInterface');
         $formatter
             ->expects($this->any())
             ->method('format')
             ->will($this->returnCallback(function ($record) { return $record['message'] . 'test'; }));
 
-        $formatter2 = $this->createMock(FormatterInterface::class);
+        $formatter2 = $this->getMock('Monolog\\Formatter\\FormatterInterface');
         $formatter2
             ->expects($this->any())
             ->method('format')

--- a/tests/Monolog/Handler/Slack/SlackRecordTest.php
+++ b/tests/Monolog/Handler/Slack/SlackRecordTest.php
@@ -143,13 +143,12 @@ class SlackRecordTest extends TestCase
         $this->assertSame('', $data['text']);
     }
 
-    public function testAttachmentsEmptyIfNoAttachment()
+    public function testAttachmentsNotPresentIfNoAttachment()
     {
         $record = new SlackRecord($this->channel, 'Monolog', false);
         $data = $record->getSlackData($this->getRecord());
 
-        $this->assertArrayHasKey('attachments', $data);
-        $this->assertSame(array(), $data['attachments']);
+        $this->assertArrayNotHasKey('attachments', $data);
     }
 
     public function testAddsOneAttachment()

--- a/tests/Monolog/Handler/Slack/SlackRecordTest.php
+++ b/tests/Monolog/Handler/Slack/SlackRecordTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler\Slack;
+
+use Monolog\Logger;
+use Monolog\TestCase;
+
+/**
+ * @coversDefaultClass Monolog\Handler\Slack\SlackRecord
+ */
+class SlackRecordTest extends TestCase
+{
+    public function dataGetAttachmentColor()
+    {
+        return array(
+            array(Logger::DEBUG, SlackRecord::COLOR_DEFAULT),
+            array(Logger::INFO, SlackRecord::COLOR_GOOD),
+            array(Logger::NOTICE, SlackRecord::COLOR_GOOD),
+            array(Logger::WARNING, SlackRecord::COLOR_WARNING),
+            array(Logger::ERROR, SlackRecord::COLOR_DANGER),
+            array(Logger::CRITICAL, SlackRecord::COLOR_DANGER),
+            array(Logger::ALERT, SlackRecord::COLOR_DANGER),
+            array(Logger::EMERGENCY, SlackRecord::COLOR_DANGER),
+        );
+    }
+    /**
+     * @dataProvider dataGetAttachmentColor
+     * @param  int $logLevel
+     * @param  string $expectedColour RGB hex color or name of Slack color
+     * @covers ::getAttachmentColor
+     */
+    public function testGetAttachmentColor($logLevel, $expectedColour)
+    {
+        $slackRecord = new SlackRecord('#test');
+        $this->assertSame(
+            $expectedColour,
+            $slackRecord->getAttachmentColor($logLevel)
+        );
+    }
+
+    public function testStringifyReturnsNullWithNoLineFormatter()
+    {
+        $slackRecord = new SlackRecord('#test');
+        $this->assertNull($slackRecord->stringify(array('foo' => 'bar')));
+    }
+
+    /**
+     * @return array
+     */
+    public function dataStringify()
+    {
+        return array(
+            array(array(), ''),
+            array(array('foo' => 'bar'), 'foo: bar'),
+            array(array('Foo' => 'bAr'), 'Foo: bAr'),
+        );
+    }
+
+    /**
+     * @dataProvider dataStringify
+     */
+    public function testStringifyWithLineFormatter($fields, $expectedResult)
+    {
+        $slackRecord = new SlackRecord(
+            '#test',
+            'test',
+            true,
+            null,
+            true,
+            true
+        );
+
+        $this->assertSame($expectedResult, $slackRecord->stringify($fields));
+    }
+}

--- a/tests/Monolog/Handler/SlackHandlerTest.php
+++ b/tests/Monolog/Handler/SlackHandlerTest.php
@@ -99,7 +99,7 @@ class SlackHandlerTest extends TestCase
         fseek($this->res, 0);
         $content = fread($this->res, 1024);
 
-        $this->assertRegexp('/%5Bcolor%5D='.$expectedColor.'/', $content);
+        $this->assertRegexp('/%22color%22%3A%22'.$expectedColor.'/', $content);
     }
 
     public function testWriteContentWithPlainTextMessage()

--- a/tests/Monolog/Handler/SlackHandlerTest.php
+++ b/tests/Monolog/Handler/SlackHandlerTest.php
@@ -56,7 +56,10 @@ class SlackHandlerTest extends TestCase
         fseek($this->res, 0);
         $content = fread($this->res, 1024);
 
-        $this->assertRegexp('/token=myToken&channel=channel1&username=Monolog&text=&attachments=.*$/', $content);
+        $this->assertRegExp('/username=Monolog/', $content);
+        $this->assertRegExp('/channel=channel1/', $content);
+        $this->assertRegExp('/token=myToken/', $content);
+        $this->assertRegExp('/attachments/', $content);
     }
 
     public function testWriteContentUsesFormatterIfProvided()
@@ -72,8 +75,8 @@ class SlackHandlerTest extends TestCase
         fseek($this->res, 0);
         $content2 = fread($this->res, 1024);
 
-        $this->assertRegexp('/token=myToken&channel=channel1&username=Monolog&text=test1.*$/', $content);
-        $this->assertRegexp('/token=myToken&channel=channel1&username=Monolog&text=foo--test2.*$/', $content2);
+        $this->assertRegexp('/text=test1/', $content);
+        $this->assertRegexp('/text=foo--test2/', $content2);
     }
 
     public function testWriteContentWithEmoji()
@@ -83,7 +86,7 @@ class SlackHandlerTest extends TestCase
         fseek($this->res, 0);
         $content = fread($this->res, 1024);
 
-        $this->assertRegexp('/icon_emoji=%3Aalien%3A$/', $content);
+        $this->assertRegexp('/icon_emoji=%3Aalien%3A/', $content);
     }
 
     /**
@@ -96,7 +99,7 @@ class SlackHandlerTest extends TestCase
         fseek($this->res, 0);
         $content = fread($this->res, 1024);
 
-        $this->assertRegexp('/color%22%3A%22'.$expectedColor.'/', $content);
+        $this->assertRegexp('/%5Bcolor%5D='.$expectedColor.'/', $content);
     }
 
     public function testWriteContentWithPlainTextMessage()

--- a/tests/Monolog/Handler/SlackHandlerTest.php
+++ b/tests/Monolog/Handler/SlackHandlerTest.php
@@ -14,6 +14,7 @@ namespace Monolog\Handler;
 use Monolog\TestCase;
 use Monolog\Logger;
 use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\Slack\SlackRecord;
 
 /**
  * @author Greg Kedzierski <greg@gregkedzierski.com>
@@ -111,14 +112,14 @@ class SlackHandlerTest extends TestCase
     public function provideLevelColors()
     {
         return array(
-            array(Logger::DEBUG,    '%23e3e4e6'),   // escaped #e3e4e6
-            array(Logger::INFO,     'good'),
-            array(Logger::NOTICE,   'good'),
-            array(Logger::WARNING,  'warning'),
-            array(Logger::ERROR,    'danger'),
-            array(Logger::CRITICAL, 'danger'),
-            array(Logger::ALERT,    'danger'),
-            array(Logger::EMERGENCY,'danger'),
+            array(Logger::DEBUG,    urlencode(SlackRecord::COLOR_DEFAULT)),
+            array(Logger::INFO,     SlackRecord::COLOR_GOOD),
+            array(Logger::NOTICE,   SlackRecord::COLOR_GOOD),
+            array(Logger::WARNING,  SlackRecord::COLOR_WARNING),
+            array(Logger::ERROR,    SlackRecord::COLOR_DANGER),
+            array(Logger::CRITICAL, SlackRecord::COLOR_DANGER),
+            array(Logger::ALERT,    SlackRecord::COLOR_DANGER),
+            array(Logger::EMERGENCY,SlackRecord::COLOR_DANGER),
         );
     }
 

--- a/tests/Monolog/Handler/SlackWebhookHandlerTest.php
+++ b/tests/Monolog/Handler/SlackWebhookHandlerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\TestCase;
+use Monolog\Logger;
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\Slack\SlackRecord;
+
+/**
+ * @author Haralan Dobrev <hkdobrev@gmail.com>
+ * @see    https://api.slack.com/incoming-webhooks
+ * @coversDefaultClass Monolog\Handler\SlackWebhookHandler
+ */
+class SlackWebhookHandlerTest extends TestCase
+{
+    const WEBHOOK_URL = 'https://hooks.slack.com/services/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E';
+
+    /**
+     * @covers ::__construct
+     * @covers ::getSlackRecord
+     */
+    public function testConstructorMinimal()
+    {
+        $handler = new SlackWebhookHandler(self::WEBHOOK_URL);
+        $slackRecord = $handler->getSlackRecord();
+        $this->assertInstanceOf('Monolog\Handler\Slack\SlackRecord', $slackRecord);
+        $this->assertEquals(array(
+            'username' => 'Monolog',
+            'text' => '',
+            'attachments' => array(
+                array(
+                    'fallback' => 'test',
+                    'text' => 'test',
+                    'color' => SlackRecord::COLOR_WARNING,
+                    'fields' => array(
+                        array(
+                            'title' => 'Level',
+                            'value' => 'WARNING',
+                            'short' => true,
+                        ),
+                    ),
+                    'title' => 'Message',
+                ),
+            ),
+        ), $slackRecord->getSlackData($this->getRecord()));
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getSlackRecord
+     */
+    public function testConstructorFull()
+    {
+        $handler = new SlackWebhookHandler(
+            self::WEBHOOK_URL,
+            'test-channel',
+            'test-username',
+            false,
+            ':ghost:',
+            false,
+            false,
+            Logger::DEBUG,
+            false
+        );
+
+        $slackRecord = $handler->getSlackRecord();
+        $this->assertInstanceOf('Monolog\Handler\Slack\SlackRecord', $slackRecord);
+        $this->assertEquals(array(
+            'username' => 'test-username',
+            'text' => 'test',
+            'channel' => 'test-channel',
+            'icon_emoji' => ':ghost:',
+        ), $slackRecord->getSlackData($this->getRecord()));
+    }
+
+    /**
+     * @covers ::getFormatter
+     */
+    public function testGetFormatter()
+    {
+        $handler = new SlackWebhookHandler(self::WEBHOOK_URL);
+        $formatter = $handler->getFormatter();
+        $this->assertInstanceOf('Monolog\Formatter\FormatterInterface', $formatter);
+    }
+
+    /**
+     * @covers ::setFormatter
+     */
+    public function testSetFormatter()
+    {
+        $handler = new SlackWebhookHandler(self::WEBHOOK_URL);
+        $formatter = new LineFormatter();
+        $handler->setFormatter($formatter);
+        $this->assertSame($formatter, $handler->getFormatter());
+    }
+}

--- a/tests/Monolog/Handler/SlackbotHandlerTest.php
+++ b/tests/Monolog/Handler/SlackbotHandlerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\TestCase;
+use Monolog\Logger;
+
+/**
+ * @author Haralan Dobrev <hkdobrev@gmail.com>
+ * @see    https://slack.com/apps/A0F81R8ET-slackbot
+ * @coversDefaultClass Monolog\Handler\SlackbotHandler
+ */
+class SlackbotHandlerTest extends TestCase
+{
+    /**
+     * @covers ::__construct
+     */
+    public function testConstructorMinimal()
+    {
+        $handler = new SlackbotHandler('test-team', 'test-token', 'test-channel');
+        $this->assertInstanceOf('Monolog\Handler\AbstractProcessingHandler', $handler);
+    }
+
+    /**
+     * @covers ::__construct
+     */
+    public function testConstructorFull()
+    {
+        $handler = new SlackbotHandler(
+            'test-team',
+            'test-token',
+            'test-channel',
+            Logger::DEBUG,
+            false
+        );
+        $this->assertInstanceOf('Monolog\Handler\AbstractProcessingHandler', $handler);
+    }
+}


### PR DESCRIPTION
See https://github.com/Seldaek/monolog/issues/743#issuecomment-242994019

This is keeping the previous `SlackHandler`, but extracts the message formatting logic and introduces two new Slack handlers:
- `SlackbotHandler` - this is the simplest way to log to Slack and most people could use that. It doesn't allow fancy formatting, but has autolinking and the simplest configuration with two clicks in the Slack settings and getting a token.
- `SlackWebhookHandler` - This is a bit more advanced as it allows for the same formatting and adding attachements as the `SlackHandler`, but it uses the Slack Webhooks which are quite easier to set up than the OAuth API. The minimum it requires is a webhook URL which is a retrievable with about two clicks in the Slack settings. Even the channel is optional as it could be configured in the integration.

This is probably not the leanest way to implement what we've discussed in https://github.com/Seldaek/monolog/issues/743, but after working at this I believe this is the simplest and the right approach.

While we could implement everything in one handler the API would become horrible and it would be harder to understand from users. Providing choice with simple to use separate classes is better IMHO. Apart from this the `SlackHandler` extends the `SocketHandler` and the webhooks and the Slackbot wouldn't work nicely with that.

What do you think?

@Seldaek @gkedzierski @Gummibeer @nisbeti

---
- [x] Extracting Slack formatting logic in `SlackRecord`
- [x] `SlackbotHandler`
- [x] `SlackWebhookHandler`
- [x] Refactor `SlackHandler` using the new `SlackRecord`
- [x] Add new handlers to the docs
- [x] Unit tests of `SlackRecord`
- [x] Unit tests for `SlackbotHandler`
- [x] Unit tests for `SlackWebhookHandler`
- [x] Update unit tests for `SlackHandler`
