### PR TITLE
Attempt at fixing microsecond timezone support, fixes #832

### DIFF
--- a/src/Monolog/DateTimeImmutable.php
+++ b/src/Monolog/DateTimeImmutable.php
@@ -28,9 +28,17 @@ class DateTimeImmutable extends \DateTimeImmutable implements \JsonSerializable
             // Circumvent DateTimeImmutable::createFromFormat() which always returns \DateTimeImmutable instead of `static`
             // @link https://bugs.php.net/bug.php?id=60302
             $timestamp = microtime(true);
+
+            // apply offset of the timezone as microtime() is always UTC
+            if ($timezone && $timezone->getName() !== 'UTC') {
+                $timestamp += (new \DateTime('now', $timezone))->getOffset();
+                // $timestamp -= (new \DateTime('now', new \DateTimeZone(date_default_timezone_get() ?: 'UTC')))->getOffset();
+            }
+
             $microseconds = sprintf("%06d", ($timestamp - floor($timestamp)) * 1000000);
             $date = date('Y-m-d H:i:s.' . $microseconds, (int) $timestamp);
         }
+
         parent::__construct($date, $timezone);
 
         $this->useMicroseconds = $useMicroseconds;


### PR DESCRIPTION
Refs #832

This fixes the TimeZone support when the default timezone is UTC, but fails when it isn't, as `date()` returns the time using the current timezone, and as far as I understand the offset is not calculated correctly then.. Not sure what to do at this point.