### PR TITLE
Added Yii2 component on README.mdown

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -81,6 +81,7 @@ Bugs and feature request are tracked on [GitHub](https://github.com/Seldaek/mono
 - [Proton Micro Framework](https://github.com/alexbilbie/Proton) comes out of the box with Monolog.
 - [FuelPHP](http://fuelphp.com/) come out of the box with Monolog.
 - [Equip Framework](https://github.com/equip/framework) comes out of the box with Monolog.
+- [Yii 2](http://www.yiiframework.com/) is usable with Monolog via the [yii2-monolog](https://github.com/merorafael/yii2-monolog) plugin.
 
 ### Author
 


### PR DESCRIPTION
Hello everyone,

I'm working on a Yii 2 component to port Monolog. I edited the README file by adding the project, the first developed for this framework.