### PR TITLE
Remove substitution for not defined variables

### DIFF
--- a/src/Monolog/Formatter/LineFormatter.php
+++ b/src/Monolog/Formatter/LineFormatter.php
@@ -76,12 +76,16 @@ class LineFormatter extends NormalizerFormatter
             }
         }
 
+	    $output = preg_replace('/%extra\..+?%/', '', $output);
+
         foreach ($vars['context'] as $var => $val) {
             if (false !== strpos($output, '%context.'.$var.'%')) {
                 $output = str_replace('%context.'.$var.'%', $this->stringify($val), $output);
                 unset($vars['context'][$var]);
             }
         }
+
+	    $output = preg_replace('/%context\..+?%/', '', $output);
 
         if ($this->ignoreEmptyContextAndExtra) {
             if (empty($vars['context'])) {

--- a/src/Monolog/Formatter/LineFormatter.php
+++ b/src/Monolog/Formatter/LineFormatter.php
@@ -76,7 +76,7 @@ class LineFormatter extends NormalizerFormatter
             }
         }
 
-	    $output = preg_replace('/%extra\..+?%/', '', $output);
+        $output = preg_replace('/%extra\..+?%/', '', $output);
 
         foreach ($vars['context'] as $var => $val) {
             if (false !== strpos($output, '%context.'.$var.'%')) {
@@ -85,7 +85,7 @@ class LineFormatter extends NormalizerFormatter
             }
         }
 
-	    $output = preg_replace('/%context\..+?%/', '', $output);
+        $output = preg_replace('/%context\..+?%/', '', $output);
 
         if ($this->ignoreEmptyContextAndExtra) {
             if (empty($vars['context'])) {


### PR DESCRIPTION
If variable in extra or context isn't defined, than placeholder will not not be replaced in format string. This patch remove all not replaced placeholders
