### PR TITLE
Added the NoopHandler.

### DIFF
--- a/doc/02-handlers-formatters-processors.md
+++ b/doc/02-handlers-formatters-processors.md
@@ -113,6 +113,8 @@
    to the wrapped handler.
 - [_SamplingHandler_](../src/Monolog/Handler/SamplingHandler.php): Wraps around another handler and lets you sample records
    if you only want to store some of them.
+- [_NoopHandler_](../src/Monolog/Handler/NoopHandler.php): This handler handles anything by doing nothing. It does not stop
+  processing the rest of the stack. This can be used for testing, or to disable a handler when overriding a configuration.
 - [_NullHandler_](../src/Monolog/Handler/NullHandler.php): Any record it can handle will be thrown away. This can be used
   to put on top of an existing handler stack to disable it temporarily.
 - [_PsrHandler_](../src/Monolog/Handler/PsrHandler.php): Can be used to forward log records to an existing PSR-3 logger

--- a/src/Monolog/Handler/NoopHandler.php
+++ b/src/Monolog/Handler/NoopHandler.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Roel Harbers <roelharbers@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Logger;
+
+/**
+ * No-op
+ *
+ * This handler handles anything, but does nothing, and does not stop bubbling to the rest of the stack.
+ * This can be used for testing, or to disable a handler when overriding a configuration without
+ * influencing the rest of the stack.
+ *
+ * @author Roel Harbers <roelharbers@gmail.com>
+ */
+class NoopHandler extends Handler
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isHandling(array $record): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(array $record): bool
+    {
+        return false;
+    }
+}

--- a/tests/Monolog/Handler/NoopHandlerTest.php
+++ b/tests/Monolog/Handler/NoopHandlerTest.php
@@ -28,16 +28,6 @@ class NoopHandlerTest extends TestCase
         $this->assertTrue($handler->isHandling($this->getRecord($level)));
     }
 
-    public function isHandleProvider()
-    {
-        return array_map(
-            function ($level) {
-                return [$level];
-            },
-            array_values(Logger::getLevels())
-        );
-    }
-
     /**
      * @dataProvider logLevelsProvider
      */

--- a/tests/Monolog/Handler/NoopHandlerTest.php
+++ b/tests/Monolog/Handler/NoopHandlerTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Roel Harbers <roelharbers@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Test\TestCase;
+use Monolog\Logger;
+
+/**
+ * @covers Monolog\Handler\NoopHandler::handle
+ */
+class NoopHandlerTest extends TestCase
+{
+    /**
+     * @dataProvider logLevelsProvider
+     */
+    public function testIsHandling($level)
+    {
+        $handler = new NoopHandler();
+        $this->assertTrue($handler->isHandling($this->getRecord($level)));
+    }
+
+    public function isHandleProvider()
+    {
+        return array_map(
+            function ($level) {
+                return [$level];
+            },
+            array_values(Logger::getLevels())
+        );
+    }
+
+    /**
+     * @dataProvider logLevelsProvider
+     */
+    public function testHandle($level)
+    {
+        $handler = new NoopHandler();
+        $this->assertFalse($handler->handle($this->getRecord($level)));
+    }
+
+    public function logLevelsProvider()
+    {
+        return array_map(
+            function ($level) {
+                return [$level];
+            },
+            array_values(Logger::getLevels())
+        );
+    }
+}


### PR DESCRIPTION
This handler handles anything, but does nothing, and does not stop bubbling to the rest of the stack, unlike the NullHandler.

This can be used for testing, or to disable a handler when overriding a configuration without influencing the rest of the stack.

The specific use-case I need this for is in symfony, where `config_test.yml` imports `config_dev.yml`, but needs to disable some handlers and add some others:

`config_dev.yml`:

```
monolog:
    handlers:
        stderr:
            type:   stream
            path:   "php://stderr"
            level:  debug
```

`config_test.yml`:

```
imports:
    - { resource: config_dev.yml }
monolog:
    handlers:
        test:
            type:   test
            level:  debug
        stderr:
            type:   'null'
```

This fails, because the `stderr` handler is first in the stack, even after overriding it. Because the NullHandler doesn't bubble, the `test` handler is never called. This would be solved with `type: 'noop'`
