### PR TITLE
Make the RavenHandler picks the first highest record as main

### DIFF
--- a/src/Monolog/Handler/RavenHandler.php
+++ b/src/Monolog/Handler/RavenHandler.php
@@ -84,7 +84,7 @@ class RavenHandler extends AbstractProcessingHandler
 
         // the record with the highest severity is the "main" one
         $record = array_reduce($records, function ($highest, $record) {
-            if ($record['level'] >= $highest['level']) {
+            if ($record['level'] > $highest['level']) {
                 return $record;
             }
 

--- a/tests/Monolog/Handler/RavenHandlerTest.php
+++ b/tests/Monolog/Handler/RavenHandlerTest.php
@@ -195,6 +195,32 @@ class RavenHandlerTest extends TestCase
         $handler->handleBatch($records);
     }
 
+    public function testHandleBatchPicksProperMessage()
+    {
+        $records = array(
+            $this->getRecord(Logger::DEBUG, 'debug message 1'),
+            $this->getRecord(Logger::DEBUG, 'debug message 2'),
+            $this->getRecord(Logger::INFO, 'information 1'),
+            $this->getRecord(Logger::ERROR, 'error 1'),
+            $this->getRecord(Logger::WARNING, 'warning'),
+            $this->getRecord(Logger::ERROR, 'error 2'),
+            $this->getRecord(Logger::INFO, 'information 2'),
+        );
+
+        $logFormatter = $this->getMock('Monolog\\Formatter\\FormatterInterface');
+        $logFormatter->expects($this->once())->method('formatBatch');
+
+        $formatter = $this->getMock('Monolog\\Formatter\\FormatterInterface');
+        $formatter->expects($this->once())->method('format')->with($this->callback(function ($record) use ($records) {
+            return $record['message'] == 'error 1';
+        }));
+
+        $handler = $this->getHandler($this->getRavenClient());
+        $handler->setBatchFormatter($logFormatter);
+        $handler->setFormatter($formatter);
+        $handler->handleBatch($records);
+    }
+
     public function testGetSetBatchFormatter()
     {
         $ravenClient = $this->getRavenClient();


### PR DESCRIPTION
Recently in production, I received a lot of sentry notifications for `NotFoundHttpException`, which surprised me because we explicitly ignore 404 with a custom activation strategy.
After digging a little bit, I found out that the `NotFoundHttpException` was not the real reason to send the error to Sentry, but a previous error was, only the RavenHandler was not picking this one.

That lead me to believe that the `RavenHandler` should pick the first highest log message as the main one, which is the more likely to be the one who "triggered" things in the first place, rest becoming only a resultant of it.
Moreover, this is more consistent with how the `MailHandler` is behaving (https://github.com/Seldaek/monolog/blob/58544af7ff9d0c54ef36bc0e4e79330cda751b0e/src/Monolog/Handler/MailHandler.php#L59-L69).
