### PR TITLE
Minimum required PHP version in README

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -58,7 +58,7 @@ can also add your own there if you publish one.
 
 ### Requirements
 
-- Monolog works with PHP 5.3 or above, and is also tested to work with HHVM.
+- Monolog works with PHP 7.0 or above, and is also tested to work with HHVM.
 
 ### Submitting bugs and feature requests
 

--- a/README.mdown
+++ b/README.mdown
@@ -58,7 +58,7 @@ can also add your own there if you publish one.
 
 ### Requirements
 
-- Monolog works with PHP 7.0 or above, and is also tested to work with HHVM.
+- Monolog works with PHP 7.0 or above, use Monolog `^1.0` for PHP 5.3+ support.
 
 ### Submitting bugs and feature requests
 


### PR DESCRIPTION
Updated the minimum required PHP version in README from 5.3 to 7.0 as detailed in `composer.json`.

Fixes #873