### PR TITLE
Fix tests for sentry/sentry >= 0.16.0 (and < 1.0)

### DIFF
--- a/tests/Monolog/Handler/MockRavenClient-gte-0-16-0.php
+++ b/tests/Monolog/Handler/MockRavenClient-gte-0-16-0.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Raven_Client;
+
+class MockRavenClient extends Raven_Client
+{
+    public function capture($data, $stack = null, $vars = null)
+    {
+        $data = array_merge($this->get_user_data(), $data);
+        $this->lastData = $data;
+        $this->lastStack = $stack;
+    }
+
+    public $lastData;
+    public $lastStack;
+}

--- a/tests/Monolog/Handler/RavenHandlerTest.php
+++ b/tests/Monolog/Handler/RavenHandlerTest.php
@@ -14,16 +14,21 @@ namespace Monolog\Handler;
 use Monolog\Test\TestCase;
 use Monolog\Logger;
 use Monolog\Formatter\LineFormatter;
+use Raven_Client;
 
 class RavenHandlerTest extends TestCase
 {
     public function setUp()
     {
         if (!class_exists('Raven_Client')) {
-            $this->markTestSkipped('raven/raven not installed');
+            $this->markTestSkipped('sentry/sentry not installed');
         }
 
-        require_once __DIR__ . '/MockRavenClient.php';
+        if (version_compare(Raven_Client::VERSION, '0.16.0', '>=')) {
+            require_once __DIR__ . '/MockRavenClient-gte-0-16-0.php';
+        } else {
+            require_once __DIR__ . '/MockRavenClient.php';
+        }
     }
 
     /**


### PR DESCRIPTION
From composer.json: `"sentry/sentry": "^0.13"`
Latest 0.x `sentry/sentry`: 0.22.0

sentry/sentry 0.16.0 changed the function signature of Raven_Client::capture():
0.16.0: `public function capture($data, $stack = null, $vars = null)`
0.15.0: `public function capture($data, $stack, $vars = null)`

While the test suite silently passes with PHP < 7.1, running the test suite with
PHP 7.1 fails with the following error:
`Declaration of Monolog\Handler\MockRavenClient::capture($data, $stack, $vars = NULL)
should be compatible with Raven_Client::capture($data, $stack = NULL, $vars = NULL)`