### PR TITLE
Public generic methods in TestHandler

### DIFF
--- a/src/Monolog/Handler/TestHandler.php
+++ b/src/Monolog/Handler/TestHandler.php
@@ -79,12 +79,12 @@ class TestHandler extends AbstractProcessingHandler
         $this->recordsByLevel = [];
     }
 
-    protected function hasRecordRecords($level)
+    public function hasRecords($level)
     {
         return isset($this->recordsByLevel[$level]);
     }
 
-    protected function hasRecord($record, $level)
+    public function hasRecord($record, $level)
     {
         if (is_array($record)) {
             $record = $record['message'];
@@ -140,7 +140,7 @@ class TestHandler extends AbstractProcessingHandler
     public function __call($method, $args)
     {
         if (preg_match('/(.*)(Debug|Info|Notice|Warning|Error|Critical|Alert|Emergency)(.*)/', $method, $matches) > 0) {
-            $genericMethod = $matches[1] . 'Record' . $matches[3];
+            $genericMethod = $matches[1] . ('Records' !== $matches[3] ? 'Record' : '') . $matches[3];
             $level = constant('Monolog\Logger::' . strtoupper($matches[2]));
             if (method_exists($this, $genericMethod)) {
                 $args[] = $level;

--- a/tests/Monolog/Handler/TestHandlerTest.php
+++ b/tests/Monolog/Handler/TestHandlerTest.php
@@ -26,6 +26,8 @@ class TestHandlerTest extends TestCase
     {
         $handler = new TestHandler;
         $record = $this->getRecord($level, 'test'.$method);
+        $this->assertFalse($handler->hasRecords($level));
+        $this->assertFalse($handler->hasRecord($record, $level));
         $this->assertFalse($handler->{'has'.$method}($record), 'has'.$method);
         $this->assertFalse($handler->{'has'.$method.'ThatContains'}('test'), 'has'.$method.'ThatContains');
         $this->assertFalse($handler->{'has'.$method.'ThatPasses'}(function ($rec) {
@@ -36,6 +38,8 @@ class TestHandlerTest extends TestCase
         $handler->handle($record);
 
         $this->assertFalse($handler->{'has'.$method}('bar'), 'has'.$method);
+        $this->assertTrue($handler->hasRecords($level));
+        $this->assertTrue($handler->hasRecord($record, $level));
         $this->assertTrue($handler->{'has'.$method}($record), 'has'.$method);
         $this->assertTrue($handler->{'has'.$method}('test'.$method), 'has'.$method);
         $this->assertTrue($handler->{'has'.$method.'ThatContains'}('test'), 'has'.$method.'ThatContains');


### PR DESCRIPTION
Makes `TestHandler::hasRecordRecords()` and `TestHandler::hasRecord()` public so they can be used in tests directly just like the other generic methods. Also renames `hasRecordRecords` to `hasRecords` because _hasRecordRecords_ is kinda weird.
Not sure the `protected` to `public` change would be a BC break for 1.x. If not, I can set the `hasRecordRecords` method back with a deprecation message. WDYT?