### PR TITLE
Do not iterate non-array Traversables

### DIFF
--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -70,17 +70,13 @@ class NormalizerFormatter implements FormatterInterface
             return $data;
         }
 
-        if (is_array($data) || $data instanceof \Traversable) {
+        if (is_array($data)) {
             $normalized = array();
 
             $count = 1;
-            if ($data instanceof \Generator && !$data->valid()) {
-                return array('...' => 'Generator is already consumed, aborting');
-            }
-
             foreach ($data as $key => $value) {
                 if ($count++ >= 1000) {
-                    $normalized['...'] = 'Over 1000 items ('.($data instanceof \Generator ? 'generator function' : count($data).' total').'), aborting normalization';
+                    $normalized['...'] = 'Over 1000 items ('.count($data).' total), aborting normalization';
                     break;
                 }
                 $normalized[$key] = $this->normalize($value);


### PR DESCRIPTION
Iterators and Generators may not be rewindable, so foreach is not safe to use on them.

Iterators and especially Generators may trigger irreversible actions on calling next(), so iterating over all values can potentially cause harm, e.g. imagine an iterator over a set of HTTP POST requests that are sent when the next value is requested . The only sufficiently safe thing to iterate and include here are primitive arrays.