### PR TITLE
Slack improvements

### DIFF
--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -46,10 +46,10 @@ class SlackRecord
     private $username;
 
     /**
-     * Emoji icon name
+     * User icon e.g. 'ghost', 'http://example.com/user.png'
      * @var string
      */
-    private $iconEmoji;
+    private $userIcon;
 
     /**
      * Whether the message should be added to Slack as attachment (plain text otherwise)
@@ -79,11 +79,11 @@ class SlackRecord
      */
     private $lineFormatter;
 
-    public function __construct($channel = null, $username = 'Monolog', $useAttachment = true, $iconEmoji = null, $useShortAttachment = false, $includeContextAndExtra = false, FormatterInterface $formatter = null)
+    public function __construct($channel = null, $username = 'Monolog', $useAttachment = true, $icon = null, $useShortAttachment = false, $includeContextAndExtra = false, FormatterInterface $formatter = null)
     {
         $this->channel = $channel;
         $this->username = $username;
-        $this->iconEmoji = trim($iconEmoji, ':');
+        $this->userIcon = trim($icon, ':');
         $this->useAttachment = $useAttachment;
         $this->useShortAttachment = $useShortAttachment;
         $this->includeContextAndExtra = $includeContextAndExtra;
@@ -154,8 +154,12 @@ class SlackRecord
             $dataArray['text'] = $message;
         }
 
-        if ($this->iconEmoji) {
-            $dataArray['icon_emoji'] = ":{$this->iconEmoji}:";
+        if ($this->userIcon) {
+            if (filter_var($this->userIcon, FILTER_VALIDATE_URL)) {
+                $dataArray['icon_url'] = $this->userIcon;
+            } else {
+                $dataArray['icon_emoji'] = ":{$this->userIcon}:";
+            }
         }
 
         return $dataArray;

--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -41,7 +41,7 @@ class SlackRecord
 
     /**
      * Name of a bot
-     * @var string
+     * @var string|null
      */
     private $username;
 
@@ -79,7 +79,7 @@ class SlackRecord
      */
     private $normalizerFormatter;
 
-    public function __construct($channel = null, $username = 'Monolog', $useAttachment = true, $userIcon = null, $useShortAttachment = false, $includeContextAndExtra = false, FormatterInterface $formatter = null)
+    public function __construct($channel = null, $username = null, $useAttachment = true, $userIcon = null, $useShortAttachment = false, $includeContextAndExtra = false, FormatterInterface $formatter = null)
     {
         $this->channel = $channel;
         $this->username = $username;
@@ -96,10 +96,11 @@ class SlackRecord
 
     public function getSlackData(array $record)
     {
-        $dataArray = array(
-            'username'    => $this->username,
-            'text'        => '',
-        );
+        $dataArray = array();
+
+        if ($this->username) {
+            $dataArray['username'] = $this->username;
+        }
 
         if ($this->channel) {
             $dataArray['channel'] = $this->channel;

--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -105,7 +105,7 @@ class SlackRecord
             $dataArray['channel'] = $this->channel;
         }
 
-        if ($this->formatter) {
+        if ($this->formatter && !$this->useAttachment) {
             $message = $this->formatter->format($record);
         } else {
             $message = $record['message'];

--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -206,12 +206,13 @@ class SlackRecord
     public function stringify($fields)
     {
         $normalized = $this->normalizerFormatter->format($fields);
+        $prettyPrintFlag = defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 128;
 
         $hasSecondDimension = count(array_filter($normalized, 'is_array'));
         $hasNonNumericKeys = !count(array_filter(array_keys($normalized), 'is_numeric'));
 
         return $hasSecondDimension || $hasNonNumericKeys
-            ? json_encode($normalized, JSON_PRETTY_PRINT)
+            ? json_encode($normalized, $prettyPrintFlag)
             : json_encode($normalized);
     }
 

--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -117,6 +117,7 @@ class SlackRecord
                 'text'     => $message,
                 'color'    => $this->getAttachmentColor($record['level']),
                 'fields'   => array(),
+                'ts'       => $record['datetime']->getTimestamp()
             );
 
             if ($this->useShortAttachment) {

--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -45,9 +45,10 @@ class SlackHandler extends SocketHandler
      * @param  bool                      $bubble                 Whether the messages that are handled can bubble up the stack or not
      * @param  bool                      $useShortAttachment     Whether the the context/extra messages added to Slack as attachments are in a short style
      * @param  bool                      $includeContextAndExtra Whether the attachment should include context and extra data
+     * @param  array                     $excludeFields          Dot separated list of fields to exclude from slack message. E.g. ['context.field1', 'extra.field2']
      * @throws MissingExtensionException If no OpenSSL PHP extension configured
      */
-    public function __construct($token, $channel, $username = null, $useAttachment = true, $iconEmoji = null, $level = Logger::CRITICAL, $bubble = true, $useShortAttachment = false, $includeContextAndExtra = false)
+    public function __construct($token, $channel, $username = null, $useAttachment = true, $iconEmoji = null, $level = Logger::CRITICAL, $bubble = true, $useShortAttachment = false, $includeContextAndExtra = false, array $excludeFields = array())
     {
         if (!extension_loaded('openssl')) {
             throw new MissingExtensionException('The OpenSSL PHP extension is required to use the SlackHandler');
@@ -62,6 +63,7 @@ class SlackHandler extends SocketHandler
             $iconEmoji,
             $useShortAttachment,
             $includeContextAndExtra,
+            $excludeFields,
             $this->formatter
         );
 

--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -38,7 +38,7 @@ class SlackHandler extends SocketHandler
     /**
      * @param  string                    $token                  Slack API token
      * @param  string                    $channel                Slack channel (encoded ID or name)
-     * @param  string                    $username               Name of a bot
+     * @param  string|null               $username               Name of a bot
      * @param  bool                      $useAttachment          Whether the message should be added to Slack as attachment (plain text otherwise)
      * @param  string|null               $iconEmoji              The emoji name to use (or null)
      * @param  int                       $level                  The minimum logging level at which this handler will be triggered
@@ -47,7 +47,7 @@ class SlackHandler extends SocketHandler
      * @param  bool                      $includeContextAndExtra Whether the attachment should include context and extra data
      * @throws MissingExtensionException If no OpenSSL PHP extension configured
      */
-    public function __construct($token, $channel, $username = 'Monolog', $useAttachment = true, $iconEmoji = null, $level = Logger::CRITICAL, $bubble = true, $useShortAttachment = false, $includeContextAndExtra = false)
+    public function __construct($token, $channel, $username = null, $useAttachment = true, $iconEmoji = null, $level = Logger::CRITICAL, $bubble = true, $useShortAttachment = false, $includeContextAndExtra = false)
     {
         if (!extension_loaded('openssl')) {
             throw new MissingExtensionException('The OpenSSL PHP extension is required to use the SlackHandler');

--- a/src/Monolog/Handler/SlackWebhookHandler.php
+++ b/src/Monolog/Handler/SlackWebhookHandler.php
@@ -38,7 +38,7 @@ class SlackWebhookHandler extends AbstractProcessingHandler
     /**
      * @param  string      $webhookUrl             Slack Webhook URL
      * @param  string|null $channel                Slack channel (encoded ID or name)
-     * @param  string      $username               Name of a bot
+     * @param  string|null $username               Name of a bot
      * @param  bool        $useAttachment          Whether the message should be added to Slack as attachment (plain text otherwise)
      * @param  string|null $iconEmoji              The emoji name to use (or null)
      * @param  bool        $useShortAttachment     Whether the the context/extra messages added to Slack as attachments are in a short style
@@ -46,7 +46,7 @@ class SlackWebhookHandler extends AbstractProcessingHandler
      * @param  int         $level                  The minimum logging level at which this handler will be triggered
      * @param  bool        $bubble                 Whether the messages that are handled can bubble up the stack or not
      */
-    public function __construct($webhookUrl, $channel = null, $username = 'Monolog', $useAttachment = true, $iconEmoji = null, $useShortAttachment = false, $includeContextAndExtra = false, $level = Logger::CRITICAL, $bubble = true)
+    public function __construct($webhookUrl, $channel = null, $username = null, $useAttachment = true, $iconEmoji = null, $useShortAttachment = false, $includeContextAndExtra = false, $level = Logger::CRITICAL, $bubble = true)
     {
         parent::__construct($level, $bubble);
 

--- a/src/Monolog/Handler/SlackWebhookHandler.php
+++ b/src/Monolog/Handler/SlackWebhookHandler.php
@@ -45,8 +45,9 @@ class SlackWebhookHandler extends AbstractProcessingHandler
      * @param  bool        $includeContextAndExtra Whether the attachment should include context and extra data
      * @param  int         $level                  The minimum logging level at which this handler will be triggered
      * @param  bool        $bubble                 Whether the messages that are handled can bubble up the stack or not
+     * @param  array       $excludeFields          Dot separated list of fields to exclude from slack message. E.g. ['context.field1', 'extra.field2']
      */
-    public function __construct($webhookUrl, $channel = null, $username = null, $useAttachment = true, $iconEmoji = null, $useShortAttachment = false, $includeContextAndExtra = false, $level = Logger::CRITICAL, $bubble = true)
+    public function __construct($webhookUrl, $channel = null, $username = null, $useAttachment = true, $iconEmoji = null, $useShortAttachment = false, $includeContextAndExtra = false, $level = Logger::CRITICAL, $bubble = true, array $excludeFields = array())
     {
         parent::__construct($level, $bubble);
 
@@ -59,6 +60,7 @@ class SlackWebhookHandler extends AbstractProcessingHandler
             $iconEmoji,
             $useShortAttachment,
             $includeContextAndExtra,
+            $excludeFields,
             $this->formatter
         );
     }

--- a/tests/Monolog/Handler/Slack/SlackRecordTest.php
+++ b/tests/Monolog/Handler/Slack/SlackRecordTest.php
@@ -19,13 +19,6 @@ use Monolog\TestCase;
  */
 class SlackRecordTest extends TestCase
 {
-    private $channel;
-
-    protected function setUp()
-    {
-        $this->channel = 'monolog_alerts';
-    }
-
     public function dataGetAttachmentColor()
     {
         return array(
@@ -39,6 +32,7 @@ class SlackRecordTest extends TestCase
             array(Logger::EMERGENCY, SlackRecord::COLOR_DANGER),
         );
     }
+
     /**
      * @dataProvider dataGetAttachmentColor
      * @param  int $logLevel
@@ -47,7 +41,7 @@ class SlackRecordTest extends TestCase
      */
     public function testGetAttachmentColor($logLevel, $expectedColour)
     {
-        $slackRecord = new SlackRecord('#test');
+        $slackRecord = new SlackRecord();
         $this->assertSame(
             $expectedColour,
             $slackRecord->getAttachmentColor($logLevel)
@@ -56,26 +50,20 @@ class SlackRecordTest extends TestCase
 
     public function testAddsChannel()
     {
-        $record = new SlackRecord($this->channel);
+        $channel = '#test';
+        $record = new SlackRecord($channel);
         $data = $record->getSlackData($this->getRecord());
 
         $this->assertArrayHasKey('channel', $data);
-        $this->assertSame($this->channel, $data['channel']);
+        $this->assertSame($channel, $data['channel']);
     }
 
-    public function testStringifyReturnsNullWithNoLineFormatter()
+    public function testNoUsernameByDefault()
     {
-        $slackRecord = new SlackRecord('#test');
-        $this->assertNull($slackRecord->stringify(array('foo' => 'bar')));
-    }
-
-    public function testAddsDefaultUsername()
-    {
-        $record = new SlackRecord($this->channel);
+        $record = new SlackRecord();
         $data = $record->getSlackData($this->getRecord());
 
-        $this->assertArrayHasKey('username', $data);
-        $this->assertSame('Monolog', $data['username']);
+        $this->assertArrayNotHasKey('username', $data);
     }
 
     /**
@@ -83,17 +71,22 @@ class SlackRecordTest extends TestCase
      */
     public function dataStringify()
     {
+        $multipleDimensions = array(array(1, 2));
+        $numericKeys = array('library' => 'monolog');
+        $singleDimension = array(1, 'Hello', 'Jordi');
+
         return array(
-            array(array(), ''),
-            array(array('foo' => 'bar'), 'foo: bar'),
-            array(array('Foo' => 'bAr'), 'Foo: bAr'),
+            array(array(), '[]'),
+            array($multipleDimensions, json_encode($multipleDimensions, JSON_PRETTY_PRINT)),
+            array($numericKeys, json_encode($numericKeys, JSON_PRETTY_PRINT)),
+            array($singleDimension, json_encode($singleDimension))
         );
     }
 
     /**
      * @dataProvider dataStringify
      */
-    public function testStringifyWithLineFormatter($fields, $expectedResult)
+    public function testStringify($fields, $expectedResult)
     {
         $slackRecord = new SlackRecord(
             '#test',
@@ -110,7 +103,7 @@ class SlackRecordTest extends TestCase
     public function testAddsCustomUsername()
     {
         $username = 'Monolog bot';
-        $record = new SlackRecord($this->channel, $username);
+        $record = new SlackRecord(null, $username);
         $data = $record->getSlackData($this->getRecord());
 
         $this->assertArrayHasKey('username', $data);
@@ -119,7 +112,7 @@ class SlackRecordTest extends TestCase
 
     public function testNoIcon()
     {
-        $record = new SlackRecord($this->channel);
+        $record = new SlackRecord();
         $data = $record->getSlackData($this->getRecord());
 
         $this->assertArrayNotHasKey('icon_emoji', $data);
@@ -127,25 +120,22 @@ class SlackRecordTest extends TestCase
 
     public function testAddsIcon()
     {
-        $record = new SlackRecord($this->channel, 'Monolog', true, 'ghost');
-        $data = $record->getSlackData($this->getRecord());
+        $record = $this->getRecord();
+        $slackRecord = new SlackRecord(null, null, false, 'ghost');
+        $data = $slackRecord->getSlackData($record);
+
+        $slackRecord2 = new SlackRecord(null, null, false, 'http://github.com/Seldaek/monolog');
+        $data2 = $slackRecord2->getSlackData($record);
 
         $this->assertArrayHasKey('icon_emoji', $data);
         $this->assertSame(':ghost:', $data['icon_emoji']);
-    }
-
-    public function testAddsEmptyTextIfUseAttachment()
-    {
-        $record = new SlackRecord($this->channel);
-        $data = $record->getSlackData($this->getRecord());
-
-        $this->assertArrayHasKey('text', $data);
-        $this->assertSame('', $data['text']);
+        $this->assertArrayHasKey('icon_url', $data2);
+        $this->assertSame('http://github.com/Seldaek/monolog', $data2['icon_url']);
     }
 
     public function testAttachmentsNotPresentIfNoAttachment()
     {
-        $record = new SlackRecord($this->channel, 'Monolog', false);
+        $record = new SlackRecord(null, null, false);
         $data = $record->getSlackData($this->getRecord());
 
         $this->assertArrayNotHasKey('attachments', $data);
@@ -153,7 +143,7 @@ class SlackRecordTest extends TestCase
 
     public function testAddsOneAttachment()
     {
-        $record = new SlackRecord($this->channel);
+        $record = new SlackRecord();
         $data = $record->getSlackData($this->getRecord());
 
         $this->assertArrayHasKey('attachments', $data);
@@ -161,10 +151,10 @@ class SlackRecordTest extends TestCase
         $this->assertInternalType('array', $data['attachments'][0]);
     }
 
-    public function testTextEqualsMessageIfNoFormatter()
+    public function testTextEqualsMessageIfNoAttachment()
     {
         $message = 'Test message';
-        $record = new SlackRecord($this->channel, 'Monolog', false);
+        $record = new SlackRecord(null, null, false);
         $data = $record->getSlackData($this->getRecord(Logger::WARNING, $message));
 
         $this->assertArrayHasKey('text', $data);
@@ -186,7 +176,7 @@ class SlackRecordTest extends TestCase
             ->will($this->returnCallback(function ($record) { return $record['message'] . 'test1'; }));
 
         $message = 'Test message';
-        $record = new SlackRecord($this->channel, 'Monolog', false, null, false, false, $formatter);
+        $record = new SlackRecord(null, null, false, null, false, false, array(), $formatter);
         $data = $record->getSlackData($this->getRecord(Logger::WARNING, $message));
 
         $this->assertArrayHasKey('text', $data);
@@ -202,7 +192,7 @@ class SlackRecordTest extends TestCase
     public function testAddsFallbackAndTextToAttachment()
     {
         $message = 'Test message';
-        $record = new SlackRecord($this->channel);
+        $record = new SlackRecord(null);
         $data = $record->getSlackData($this->getRecord(Logger::WARNING, $message));
 
         $this->assertSame($message, $data['attachments'][0]['text']);
@@ -211,7 +201,7 @@ class SlackRecordTest extends TestCase
 
     public function testMapsLevelToColorAttachmentColor()
     {
-        $record = new SlackRecord($this->channel);
+        $record = new SlackRecord(null);
         $errorLoggerRecord = $this->getRecord(Logger::ERROR);
         $emergencyLoggerRecord = $this->getRecord(Logger::EMERGENCY);
         $warningLoggerRecord = $this->getRecord(Logger::WARNING);
@@ -238,7 +228,7 @@ class SlackRecordTest extends TestCase
     {
         $level = Logger::ERROR;
         $levelName = Logger::getLevelName($level);
-        $record = new SlackRecord($this->channel, 'Monolog', true, null, true);
+        $record = new SlackRecord(null, null, true, null, true);
         $data = $record->getSlackData($this->getRecord($level, 'test', array('test' => 1)));
 
         $attachment = $data['attachments'][0];
@@ -252,9 +242,11 @@ class SlackRecordTest extends TestCase
     {
         $level = Logger::ERROR;
         $levelName = Logger::getLevelName($level);
-        $record = new SlackRecord($this->channel, 'Monolog', true, null, true, true);
-        $loggerRecord = $this->getRecord($level, 'test', array('test' => 1));
-        $loggerRecord['extra'] = array('tags' => array('web'));
+        $context = array('test' => 1);
+        $extra = array('tags' => array('web'));
+        $record = new SlackRecord(null, null, true, null, true, true);
+        $loggerRecord = $this->getRecord($level, 'test', $context);
+        $loggerRecord['extra'] = $extra;
         $data = $record->getSlackData($loggerRecord);
 
         $attachment = $data['attachments'][0];
@@ -266,13 +258,13 @@ class SlackRecordTest extends TestCase
             array(
                 array(
                     'title' => 'Extra',
-                    'value' => 'tags: ["web"]',
-                    'short' => true
+                    'value' => sprintf('```%s```', json_encode($extra, JSON_PRETTY_PRINT)),
+                    'short' => false
                 ),
                 array(
                     'title' => 'Context',
-                    'value' => 'test: 1',
-                    'short' => true
+                    'value' => sprintf('```%s```', json_encode($context, JSON_PRETTY_PRINT)),
+                    'short' => false
                 )
             ),
             $attachment['fields']
@@ -283,7 +275,7 @@ class SlackRecordTest extends TestCase
     {
         $level = Logger::ERROR;
         $levelName = Logger::getLevelName($level);
-        $record = new SlackRecord($this->channel, 'Monolog', true, null);
+        $record = new SlackRecord(null, null, true, null);
         $data = $record->getSlackData($this->getRecord($level, 'test', array('test' => 1)));
 
         $attachment = $data['attachments'][0];
@@ -295,7 +287,7 @@ class SlackRecordTest extends TestCase
             array(array(
                 'title' => 'Level',
                 'value' => $levelName,
-                'short' => true
+                'short' => false
             )),
             $attachment['fields']
         );
@@ -305,25 +297,27 @@ class SlackRecordTest extends TestCase
     {
         $level = Logger::ERROR;
         $levelName = Logger::getLevelName($level);
-        $record = new SlackRecord($this->channel, 'Monolog', true, null, false, true);
-        $loggerRecord = $this->getRecord($level, 'test', array('test' => 1));
-        $loggerRecord['extra'] = array('tags' => array('web'));
+        $context = array('test' => 1);
+        $extra = array('tags' => array('web'));
+        $record = new SlackRecord(null, null, true, null, false, true);
+        $loggerRecord = $this->getRecord($level, 'test', $context);
+        $loggerRecord['extra'] = $extra;
         $data = $record->getSlackData($loggerRecord);
 
         $expectedFields = array(
             array(
                 'title' => 'Level',
                 'value' => $levelName,
-                'short' => true,
+                'short' => false,
             ),
             array(
                 'title' => 'tags',
-                'value' => '["web"]',
+                'value' => sprintf('```%s```', json_encode($extra['tags'])),
                 'short' => false
             ),
             array(
                 'title' => 'test',
-                'value' => 1,
+                'value' => $context['test'],
                 'short' => false
             )
         );
@@ -337,5 +331,48 @@ class SlackRecordTest extends TestCase
             $expectedFields,
             $attachment['fields']
         );
+    }
+
+    public function testAddsTimestampToAttachment()
+    {
+        $record = $this->getRecord();
+        $slackRecord = new SlackRecord();
+        $data = $slackRecord->getSlackData($this->getRecord());
+
+        $attachment = $data['attachments'][0];
+        $this->assertArrayHasKey('ts', $attachment);
+        $this->assertSame($record['datetime']->getTimestamp(), $attachment['ts']);
+    }
+
+    public function testExcludeExtraAndContextFields()
+    {
+        $record = $this->getRecord(
+            Logger::WARNING,
+            'test',
+            array('info' => array('library' => 'monolog', 'author' => 'Jordi'))
+        );
+        $record['extra'] = array('tags' => array('web', 'cli'));
+
+        $slackRecord = new SlackRecord(null, null, true, null, false, true, array('context.info.library', 'extra.tags.1'));
+        $data = $slackRecord->getSlackData($record);
+        $attachment = $data['attachments'][0];
+
+        $expected = array(
+            array(
+                'title' => 'info',
+                'value' => sprintf('```%s```', json_encode(array('author' => 'Jordi'), JSON_PRETTY_PRINT)),
+                'short' => false
+            ),
+            array(
+                'title' => 'tags',
+                'value' => sprintf('```%s```', json_encode(array('web'))),
+                'short' => false
+            ),
+        );
+
+        foreach ($expected as $field) {
+            $this->assertNotFalse(array_search($field, $attachment['fields']));
+            break;
+        }
     }
 }

--- a/tests/Monolog/Handler/Slack/SlackRecordTest.php
+++ b/tests/Monolog/Handler/Slack/SlackRecordTest.php
@@ -19,6 +19,13 @@ use Monolog\TestCase;
  */
 class SlackRecordTest extends TestCase
 {
+    private $jsonPrettyPrintFlag;
+
+    protected function setUp()
+    {
+        $this->jsonPrettyPrintFlag = defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 128;
+    }
+
     public function dataGetAttachmentColor()
     {
         return array(
@@ -71,14 +78,16 @@ class SlackRecordTest extends TestCase
      */
     public function dataStringify()
     {
+        $jsonPrettyPrintFlag = defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 128;
+
         $multipleDimensions = array(array(1, 2));
         $numericKeys = array('library' => 'monolog');
         $singleDimension = array(1, 'Hello', 'Jordi');
 
         return array(
             array(array(), '[]'),
-            array($multipleDimensions, json_encode($multipleDimensions, JSON_PRETTY_PRINT)),
-            array($numericKeys, json_encode($numericKeys, JSON_PRETTY_PRINT)),
+            array($multipleDimensions, json_encode($multipleDimensions, $jsonPrettyPrintFlag)),
+            array($numericKeys, json_encode($numericKeys, $jsonPrettyPrintFlag)),
             array($singleDimension, json_encode($singleDimension))
         );
     }
@@ -258,12 +267,12 @@ class SlackRecordTest extends TestCase
             array(
                 array(
                     'title' => 'Extra',
-                    'value' => sprintf('```%s```', json_encode($extra, JSON_PRETTY_PRINT)),
+                    'value' => sprintf('```%s```', json_encode($extra, $this->jsonPrettyPrintFlag)),
                     'short' => false
                 ),
                 array(
                     'title' => 'Context',
-                    'value' => sprintf('```%s```', json_encode($context, JSON_PRETTY_PRINT)),
+                    'value' => sprintf('```%s```', json_encode($context, $this->jsonPrettyPrintFlag)),
                     'short' => false
                 )
             ),
@@ -360,7 +369,7 @@ class SlackRecordTest extends TestCase
         $expected = array(
             array(
                 'title' => 'info',
-                'value' => sprintf('```%s```', json_encode(array('author' => 'Jordi'), JSON_PRETTY_PRINT)),
+                'value' => sprintf('```%s```', json_encode(array('author' => 'Jordi'), $this->jsonPrettyPrintFlag)),
                 'short' => false
             ),
             array(

--- a/tests/Monolog/Handler/SlackWebhookHandlerTest.php
+++ b/tests/Monolog/Handler/SlackWebhookHandlerTest.php
@@ -32,11 +32,10 @@ class SlackWebhookHandlerTest extends TestCase
     public function testConstructorMinimal()
     {
         $handler = new SlackWebhookHandler(self::WEBHOOK_URL);
+        $record = $this->getRecord();
         $slackRecord = $handler->getSlackRecord();
         $this->assertInstanceOf('Monolog\Handler\Slack\SlackRecord', $slackRecord);
         $this->assertEquals(array(
-            'username' => 'Monolog',
-            'text' => '',
             'attachments' => array(
                 array(
                     'fallback' => 'test',
@@ -46,13 +45,15 @@ class SlackWebhookHandlerTest extends TestCase
                         array(
                             'title' => 'Level',
                             'value' => 'WARNING',
-                            'short' => true,
+                            'short' => false,
                         ),
                     ),
                     'title' => 'Message',
+                    'mrkdwn_in' => array('fields'),
+                    'ts' => $record['datetime']->getTimestamp(),
                 ),
             ),
-        ), $slackRecord->getSlackData($this->getRecord()));
+        ), $slackRecord->getSlackData($record));
     }
 
     /**


### PR DESCRIPTION
While #846 was focused on providing the ability to communicate with Slack via webhooks/bot, there's a bunch of improvements that can be done before 2.x. Thanks to @greeny, @websirnik, @jewome62 and @mirfilip for ideas.

- [x] Exclude `extra`/`context`, `datetime`, `level` from message when attachment is used
- [x] Use `ts` attachment key to display `datetime` considering user timezone
- [x] [Support](https://github.com/Seldaek/monolog/pull/846#issuecomment-249528719) custom user images
- [x] [Allow](https://github.com/Seldaek/monolog/pull/894#issuecomment-263532399) to setup username from slack
- [x] [Improve](https://github.com/Seldaek/monolog/pull/846#issuecomment-261529198) array formatting within `context`/`extra`
- [x] [Support](https://github.com/Seldaek/monolog/issues/745) `include_stacktraces` option when attachment is not used and always include stacktraces when attachment is used
- [x] Support `extra`/`context` field exclusion
- [x] Update tests