### PR TITLE
Replacing the add* methods in the docs and comments with the PSR-3 compliant methods

### DIFF
--- a/doc/01-usage.md
+++ b/doc/01-usage.md
@@ -97,7 +97,7 @@ $logger->pushHandler(new StreamHandler(__DIR__.'/my_app.log', Logger::DEBUG));
 $logger->pushHandler(new FirePHPHandler());
 
 // You can now use your logger
-$logger->addInfo('My logger is now ready');
+$logger->info('My logger is now ready');
 ```
 
 Let's explain it. The first step is to create the logger instance which will
@@ -129,7 +129,7 @@ record:
 ```php
 <?php
 
-$logger->addInfo('Adding a new user', array('username' => 'Seldaek'));
+$logger->info('Adding a new user', array('username' => 'Seldaek'));
 ```
 
 Simple handlers (like the StreamHandler for instance) will simply format

--- a/doc/04-extending.md
+++ b/doc/04-extending.md
@@ -66,7 +66,7 @@ You can now use this handler in your logger:
 $logger->pushHandler(new PDOHandler(new PDO('sqlite:logs.sqlite')));
 
 // You can now use your logger
-$logger->addInfo('My logger is now ready');
+$logger->info('My logger is now ready');
 ```
 
 The `Monolog\Handler\AbstractProcessingHandler` class provides most of the

--- a/doc/sockets.md
+++ b/doc/sockets.md
@@ -29,7 +29,7 @@ $handler->setPersistent(true);
 $logger->pushHandler($handler, Logger::DEBUG);
 
 // You can now use your logger
-$logger->addInfo('My logger is now ready');
+$logger->info('My logger is now ready');
 
 ```
 

--- a/src/Monolog/Handler/PHPConsoleHandler.php
+++ b/src/Monolog/Handler/PHPConsoleHandler.php
@@ -33,7 +33,7 @@ use PhpConsole\Helper;
  *      $logger = new \Monolog\Logger('all', array(new \Monolog\Handler\PHPConsoleHandler()));
  *      \Monolog\ErrorHandler::register($logger);
  *      echo $undefinedVar;
- *      $logger->addDebug('SELECT * FROM users', array('db', 'time' => 0.012));
+ *      $logger->debug('SELECT * FROM users', array('db', 'time' => 0.012));
  *      PC::debug($_SERVER); // PHP Console debugger for any type of vars
  *
  * @author Sergey Barbushin https://www.linkedin.com/in/barbushin

--- a/src/Monolog/Registry.php
+++ b/src/Monolog/Registry.php
@@ -28,8 +28,8 @@ use InvalidArgumentException;
  *
  * function testLogger()
  * {
- *     Monolog\Registry::api()->addError('Sent to $api Logger instance');
- *     Monolog\Registry::application()->addError('Sent to $application Logger instance');
+ *     Monolog\Registry::api()->error('Sent to $api Logger instance');
+ *     Monolog\Registry::application()->error('Sent to $application Logger instance');
  * }
  * </code>
  *


### PR DESCRIPTION
Noticed some of the docs had code using `addInfo` which I had also noticed was removed in the recent upgrade, so I did some grepping and replaced mentions of it with `info` in some comments and documentation. I did this with the other add* methods as well.