### PR TITLE
Splunk Formatter

### DIFF
--- a/src/Monolog/Formatter/SplunkFormatter.php
+++ b/src/Monolog/Formatter/SplunkFormatter.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use DateTimeInterface;
+
+/**
+ * Encodes message information into JSON in a format compatible with Splunk.
+ *
+ * @author Daniel Sposito <daniel.g.sposito@gmail.com>
+ */
+class SplunkFormatter extends JsonFormatter
+{
+    /**
+     * Prepends the timestamp parameter for indexing by Splunk.
+     *
+     * @see http://dev.splunk.com/view/logging-best-practices/SP-CAAADP6
+     * @see \Monolog\Formatter\JsonFormatter::format()
+     */
+    public function format(array $record): string
+    {
+        if (isset($record["datetime"]) && ($record["datetime"] instanceof DateTimeInterface)) {
+            $record = array_merge(
+                array("timestamp" => $record["datetime"]->format("Y-m-d H:i:s.u T")),
+                $record
+            );
+
+            unset($record["datetime"]);
+        }
+
+        return parent::format($record);
+    }
+}

--- a/tests/Monolog/Formatter/SplunkFormatterTest.php
+++ b/tests/Monolog/Formatter/SplunkFormatterTest.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Monolog\Test\TestCase;
+
+class SplunkFormatterTest extends TestCase
+{
+    /**
+     * @covers Monolog\Formatter\SplunkFormatter::format
+     */
+    public function testFormat()
+    {
+        $formatter = new SplunkFormatter();
+        $record = $this->getRecord();
+        $formatted_decoded = json_decode($formatter->format($record), true);
+
+        $this->assertArrayNotHasKey("datetime", $formatted_decoded);
+        $this->assertEquals("timestamp", key($formatted_decoded));
+        $this->assertEquals($record["datetime"]->format("Y-m-d H:i:s.u T"), $formatted_decoded["timestamp"]);
+    }
+}


### PR DESCRIPTION
This adds a new formatter that is compatible with Splunk's parser. It ensures that a "timestamp" key exists at the beginning of the logged JSON.