### PR TITLE
Update PHPConsoleHandler

### DIFF
--- a/src/Monolog/Handler/PHPConsoleHandler.php
+++ b/src/Monolog/Handler/PHPConsoleHandler.php
@@ -187,11 +187,14 @@ class PHPConsoleHandler extends AbstractProcessingHandler
     private function handleDebugRecord(array $record)
     {
         $tags = $this->getRecordTags($record);
-        $message = $record['message'];
-        if ($record['context']) {
-            $message .= ' ' . json_encode($this->connector->getDumper()->dump(array_filter($record['context'])));
+        $result = array(
+            'message' => $record['message']
+        );
+        if ($record['context'])	{
+            $result['context'] = $this->connector->getDumper()->dump(array_filter($record['context']));
         }
-        $this->connector->getDebugDispatcher()->dispatchDebug($message, $tags, $this->options['classesPartialsTraceIgnore']);
+        
+        $this->connector->getDebugDispatcher()->dispatchDebug($result, $tags, $this->options['classesPartialsTraceIgnore']);
     }
 
     private function handleExceptionRecord(array $record)


### PR DESCRIPTION
I have noticed that PHPConsoleHandler pushes not intractable logs to chrome browser so i have made small patch. Why are you guys using private methods that makes people have to copy whole class code to make small patch in those methods?