### PR TITLE
Improves code coverage

### DIFF
--- a/tests/Monolog/ErrorHandlerTest.php
+++ b/tests/Monolog/ErrorHandlerTest.php
@@ -15,18 +15,67 @@ use Monolog\Handler\TestHandler;
 
 class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
 {
+
+    public function testRegister()
+    {
+        $logger = new Logger('test', [$handler = new TestHandler]);
+
+        $this->assertInstanceOf(ErrorHandler::class, ErrorHandler::register($logger, false, false, false));
+    }
+
     public function testHandleError()
     {
         $logger = new Logger('test', [$handler = new TestHandler]);
         $errHandler = new ErrorHandler($logger);
 
-        $errHandler->registerErrorHandler([E_USER_NOTICE => Logger::EMERGENCY], false);
+        $resHandler = $errHandler->registerErrorHandler([E_USER_NOTICE => Logger::EMERGENCY], false);
+        $this->assertSame($errHandler, $resHandler);
         trigger_error('Foo', E_USER_ERROR);
         $this->assertCount(1, $handler->getRecords());
         $this->assertTrue($handler->hasErrorRecords());
         trigger_error('Foo', E_USER_NOTICE);
         $this->assertCount(2, $handler->getRecords());
         $this->assertTrue($handler->hasEmergencyRecords());
+
+        $errHandler->registerErrorHandler([], true);
+        $prop = $this->getPrivatePropertyValue($errHandler, 'previousErrorHandler');
+        $this->assertTrue(is_callable($prop));
+    }
+
+    public function fatalHandlerProvider()
+    {
+        return [
+            [null, 10, str_repeat(' ', 1024 * 10), null],
+            [E_ALL, 15, str_repeat(' ', 1024 * 15), E_ALL]
+        ];
+    }
+
+    protected function getPrivatePropertyValue($instance, $property)
+    {
+        $ref = new \ReflectionClass(get_class($instance));
+        $prop = $ref->getProperty($property);
+        $prop->setAccessible(true);
+
+        return $prop->getValue($instance);
+    }
+
+    /**
+     * @dataProvider fatalHandlerProvider
+     */
+    public function testFatalHandler(
+        $level,
+        $reservedMemorySize,
+        $expectedReservedMemory,
+        $expectedFatalLevel
+    ) {
+        $logger = new Logger('test', [$handler = new TestHandler]);
+        $errHandler = new ErrorHandler($logger);
+        $res = $errHandler->registerFatalHandler($level, $reservedMemorySize);
+
+        $this->assertSame($res, $errHandler);
+        $this->assertTrue($this->getPrivatePropertyValue($errHandler, 'hasFatalErrorHandler'));
+        $this->assertEquals($expectedReservedMemory, $this->getPrivatePropertyValue($errHandler, 'reservedMemory'));
+        $this->assertEquals($expectedFatalLevel, $this->getPrivatePropertyValue($errHandler, 'fatalLevel'));
     }
 
     public function testHandleException()
@@ -34,7 +83,8 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
         $logger = new Logger('test', [$handler = new TestHandler]);
         $errHandler = new ErrorHandler($logger);
 
-        $errHandler->registerExceptionHandler(['Monolog\CustomTestException' => Logger::ALERT, 'Throwable' => Logger::WARNING], false);
+        $resHandler = $errHandler->registerExceptionHandler(['Monolog\CustomTestException' => Logger::ALERT, 'Throwable' => Logger::WARNING], false);
+        $this->assertSame($errHandler, $resHandler);
 
         try {
             throw new CustomCustomException();
@@ -54,6 +104,35 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue($handler->hasWarningRecords());
         } catch (\Throwable $e) {
         }
+
+        $errHandler->registerExceptionHandler([], true);
+        $prop = $this->getPrivatePropertyValue($errHandler, 'previousExceptionHandler');
+        $this->assertTrue(is_callable($prop));
+    }
+
+    public function testCodeToString()
+    {
+        $method = new \ReflectionMethod(ErrorHandler::class, 'codeToString');
+        $method->setAccessible(true);
+
+        $this->assertEquals('E_ERROR', $method->invokeArgs(null, [E_ERROR]));
+        $this->assertEquals('E_WARNING', $method->invokeArgs(null, [E_WARNING]));
+        $this->assertEquals('E_PARSE', $method->invokeArgs(null, [E_PARSE]));
+        $this->assertEquals('E_NOTICE', $method->invokeArgs(null, [E_NOTICE]));
+        $this->assertEquals('E_CORE_ERROR', $method->invokeArgs(null, [E_CORE_ERROR]));
+        $this->assertEquals('E_CORE_WARNING', $method->invokeArgs(null, [E_CORE_WARNING]));
+        $this->assertEquals('E_COMPILE_ERROR', $method->invokeArgs(null, [E_COMPILE_ERROR]));
+        $this->assertEquals('E_COMPILE_WARNING', $method->invokeArgs(null, [E_COMPILE_WARNING]));
+        $this->assertEquals('E_USER_ERROR', $method->invokeArgs(null, [E_USER_ERROR]));
+        $this->assertEquals('E_USER_WARNING', $method->invokeArgs(null, [E_USER_WARNING]));
+        $this->assertEquals('E_USER_NOTICE', $method->invokeArgs(null, [E_USER_NOTICE]));
+        $this->assertEquals('E_STRICT', $method->invokeArgs(null, [E_STRICT]));
+        $this->assertEquals('E_RECOVERABLE_ERROR', $method->invokeArgs(null, [E_RECOVERABLE_ERROR]));
+        $this->assertEquals('E_DEPRECATED', $method->invokeArgs(null, [E_DEPRECATED]));
+        $this->assertEquals('E_USER_DEPRECATED', $method->invokeArgs(null, [E_USER_DEPRECATED]));
+
+        $this->assertEquals('Unknown PHP error', $method->invokeArgs(null, ['RANDOM_TEXT']));
+        $this->assertEquals('Unknown PHP error', $method->invokeArgs(null, [E_ALL]));
     }
 }
 


### PR DESCRIPTION
This will improve code coverage on `Monolog\ErrorHandler` class.

I left `ErrorHandler::register` not fully covered on purpose, since I got no easy way to test handlers methods.

Hope this helps. :)