### PR TITLE
Php5.3 autoload errors

### DIFF
--- a/src/Monolog/ErrorHandler.php
+++ b/src/Monolog/ErrorHandler.php
@@ -58,6 +58,9 @@ class ErrorHandler
      */
     public static function register(LoggerInterface $logger, $errorLevelMap = array(), $exceptionLevel = null, $fatalLevel = null)
     {
+        //Forces the autoloader to run for LogLevel. Fixes an autoload issue at compile-time on PHP5.3. See https://github.com/Seldaek/monolog/pull/929
+        class_exists('\\Psr\\Log\\LogLevel', true);
+
         $handler = new static($logger);
         if ($errorLevelMap !== false) {
             $handler->registerErrorHandler($errorLevelMap);

--- a/src/Monolog/ErrorHandler.php
+++ b/src/Monolog/ErrorHandler.php
@@ -24,7 +24,7 @@ use Monolog\Handler\AbstractHandler;
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-class ErrorHandler extends LogLevel
+class ErrorHandler
 {
     private $logger;
 
@@ -104,21 +104,21 @@ class ErrorHandler extends LogLevel
     protected function defaultErrorLevelMap()
     {
         return array(
-            E_ERROR             => self::CRITICAL,
-            E_WARNING           => self::WARNING,
-            E_PARSE             => self::ALERT,
-            E_NOTICE            => self::NOTICE,
-            E_CORE_ERROR        => self::CRITICAL,
-            E_CORE_WARNING      => self::WARNING,
-            E_COMPILE_ERROR     => self::ALERT,
-            E_COMPILE_WARNING   => self::WARNING,
-            E_USER_ERROR        => self::ERROR,
-            E_USER_WARNING      => self::WARNING,
-            E_USER_NOTICE       => self::NOTICE,
-            E_STRICT            => self::NOTICE,
-            E_RECOVERABLE_ERROR => self::ERROR,
-            E_DEPRECATED        => self::NOTICE,
-            E_USER_DEPRECATED   => self::NOTICE,
+            E_ERROR             => LogLevel::CRITICAL,
+            E_WARNING           => LogLevel::WARNING,
+            E_PARSE             => LogLevel::ALERT,
+            E_NOTICE            => LogLevel::NOTICE,
+            E_CORE_ERROR        => LogLevel::CRITICAL,
+            E_CORE_WARNING      => LogLevel::WARNING,
+            E_COMPILE_ERROR     => LogLevel::ALERT,
+            E_COMPILE_WARNING   => LogLevel::WARNING,
+            E_USER_ERROR        => LogLevel::ERROR,
+            E_USER_WARNING      => LogLevel::WARNING,
+            E_USER_NOTICE       => LogLevel::NOTICE,
+            E_STRICT            => LogLevel::NOTICE,
+            E_RECOVERABLE_ERROR => LogLevel::ERROR,
+            E_DEPRECATED        => LogLevel::NOTICE,
+            E_USER_DEPRECATED   => LogLevel::NOTICE,
         );
     }
 
@@ -128,7 +128,7 @@ class ErrorHandler extends LogLevel
     public function handleException($e)
     {
         $this->logger->log(
-            $this->uncaughtExceptionLevel === null ? self::ERROR : $this->uncaughtExceptionLevel,
+            $this->uncaughtExceptionLevel === null ? LogLevel::ERROR : $this->uncaughtExceptionLevel,
             sprintf('Uncaught Exception %s: "%s" at %s line %s', get_class($e), $e->getMessage(), $e->getFile(), $e->getLine()),
             array('exception' => $e)
         );
@@ -151,7 +151,7 @@ class ErrorHandler extends LogLevel
 
         // fatal error codes are ignored if a fatal error handler is present as well to avoid duplicate log entries
         if (!$this->hasFatalErrorHandler || !in_array($code, self::$fatalErrors, true)) {
-            $level = isset($this->errorLevelMap[$code]) ? $this->errorLevelMap[$code] : self::CRITICAL;
+            $level = isset($this->errorLevelMap[$code]) ? $this->errorLevelMap[$code] : LogLevel::CRITICAL;
             $this->logger->log($level, self::codeToString($code).': '.$message, array('code' => $code, 'message' => $message, 'file' => $file, 'line' => $line));
         }
 
@@ -172,7 +172,7 @@ class ErrorHandler extends LogLevel
         $lastError = error_get_last();
         if ($lastError && in_array($lastError['type'], self::$fatalErrors, true)) {
             $this->logger->log(
-                $this->fatalLevel === null ? self::ALERT : $this->fatalLevel,
+                $this->fatalLevel === null ? LogLevel::ALERT : $this->fatalLevel,
                 'Fatal Error ('.self::codeToString($lastError['type']).'): '.$lastError['message'],
                 array('code' => $lastError['type'], 'message' => $lastError['message'], 'file' => $lastError['file'], 'line' => $lastError['line'])
             );

--- a/src/Monolog/ErrorHandler.php
+++ b/src/Monolog/ErrorHandler.php
@@ -24,7 +24,7 @@ use Monolog\Handler\AbstractHandler;
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-class ErrorHandler
+class ErrorHandler extends LogLevel
 {
     private $logger;
 
@@ -104,21 +104,21 @@ class ErrorHandler
     protected function defaultErrorLevelMap()
     {
         return array(
-            E_ERROR             => LogLevel::CRITICAL,
-            E_WARNING           => LogLevel::WARNING,
-            E_PARSE             => LogLevel::ALERT,
-            E_NOTICE            => LogLevel::NOTICE,
-            E_CORE_ERROR        => LogLevel::CRITICAL,
-            E_CORE_WARNING      => LogLevel::WARNING,
-            E_COMPILE_ERROR     => LogLevel::ALERT,
-            E_COMPILE_WARNING   => LogLevel::WARNING,
-            E_USER_ERROR        => LogLevel::ERROR,
-            E_USER_WARNING      => LogLevel::WARNING,
-            E_USER_NOTICE       => LogLevel::NOTICE,
-            E_STRICT            => LogLevel::NOTICE,
-            E_RECOVERABLE_ERROR => LogLevel::ERROR,
-            E_DEPRECATED        => LogLevel::NOTICE,
-            E_USER_DEPRECATED   => LogLevel::NOTICE,
+            E_ERROR             => self::CRITICAL,
+            E_WARNING           => self::WARNING,
+            E_PARSE             => self::ALERT,
+            E_NOTICE            => self::NOTICE,
+            E_CORE_ERROR        => self::CRITICAL,
+            E_CORE_WARNING      => self::WARNING,
+            E_COMPILE_ERROR     => self::ALERT,
+            E_COMPILE_WARNING   => self::WARNING,
+            E_USER_ERROR        => self::ERROR,
+            E_USER_WARNING      => self::WARNING,
+            E_USER_NOTICE       => self::NOTICE,
+            E_STRICT            => self::NOTICE,
+            E_RECOVERABLE_ERROR => self::ERROR,
+            E_DEPRECATED        => self::NOTICE,
+            E_USER_DEPRECATED   => self::NOTICE,
         );
     }
 
@@ -128,7 +128,7 @@ class ErrorHandler
     public function handleException($e)
     {
         $this->logger->log(
-            $this->uncaughtExceptionLevel === null ? LogLevel::ERROR : $this->uncaughtExceptionLevel,
+            $this->uncaughtExceptionLevel === null ? self::ERROR : $this->uncaughtExceptionLevel,
             sprintf('Uncaught Exception %s: "%s" at %s line %s', get_class($e), $e->getMessage(), $e->getFile(), $e->getLine()),
             array('exception' => $e)
         );
@@ -151,7 +151,7 @@ class ErrorHandler
 
         // fatal error codes are ignored if a fatal error handler is present as well to avoid duplicate log entries
         if (!$this->hasFatalErrorHandler || !in_array($code, self::$fatalErrors, true)) {
-            $level = isset($this->errorLevelMap[$code]) ? $this->errorLevelMap[$code] : LogLevel::CRITICAL;
+            $level = isset($this->errorLevelMap[$code]) ? $this->errorLevelMap[$code] : self::CRITICAL;
             $this->logger->log($level, self::codeToString($code).': '.$message, array('code' => $code, 'message' => $message, 'file' => $file, 'line' => $line));
         }
 
@@ -172,7 +172,7 @@ class ErrorHandler
         $lastError = error_get_last();
         if ($lastError && in_array($lastError['type'], self::$fatalErrors, true)) {
             $this->logger->log(
-                $this->fatalLevel === null ? LogLevel::ALERT : $this->fatalLevel,
+                $this->fatalLevel === null ? self::ALERT : $this->fatalLevel,
                 'Fatal Error ('.self::codeToString($lastError['type']).'): '.$lastError['message'],
                 array('code' => $lastError['type'], 'message' => $lastError['message'], 'file' => $lastError['file'], 'line' => $lastError['line'])
             );


### PR DESCRIPTION
See this [PHP5.3 bug](https://bugs.php.net/bug.php?id=47987)

When an error is triggered on compile-time the autoloader is not called which create a "`LogLevel` class not found" error.

I make the ErrorHandler extend LogLevel so ErrorHandler will already have all the log level it's looking for, and the autoloader won't be called. 
