### PR TITLE
Allow to set custom event_id [PHP7]

### DIFF
--- a/src/Monolog/Handler/RavenHandler.php
+++ b/src/Monolog/Handler/RavenHandler.php
@@ -218,7 +218,7 @@ class RavenHandler extends AbstractProcessingHandler
      */
     protected function getExtraParameters()
     {
-        return ['checksum', 'release'];
+        return ['checksum', 'release', 'event_id'];
     }
 
     /**

--- a/tests/Monolog/Handler/RavenHandlerTest.php
+++ b/tests/Monolog/Handler/RavenHandlerTest.php
@@ -97,11 +97,13 @@ class RavenHandlerTest extends TestCase
 
         $checksum = '098f6bcd4621d373cade4e832627b4f6';
         $release = '05a671c66aefea124cc08b76ea6d30bb';
-        $record = $this->getRecord(Logger::INFO, 'test', ['checksum' => $checksum, 'release' => $release]);
+        $eventId = '31423';
+        $record = $this->getRecord(Logger::INFO, 'test', ['checksum' => $checksum, 'release' => $release, 'event_id' => $eventId]);
         $handler->handle($record);
 
         $this->assertEquals($checksum, $ravenClient->lastData['checksum']);
         $this->assertEquals($release, $ravenClient->lastData['release']);
+        $this->assertEquals($eventId, $ravenClient->lastData['event_id']);
     }
 
     public function testFingerprint()


### PR DESCRIPTION
Raven_Client allows for the event_id to be custom if it's in the data. So I made a PR that adds this to the extra parameters.

For the 1.x legacy version see: https://github.com/Seldaek/monolog/pull/930

This is the code that allows it:
https://github.com/getsentry/sentry-php/blob/master/lib/Raven/Client.php#L785-L787