### PR TITLE
Micro-optimisation: delayed unnecessary `static::getLevelName`

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -279,8 +279,6 @@ class Logger implements LoggerInterface
      */
     public function addRecord(int $level, string $message, array $context = []): bool
     {
-        $levelName = static::getLevelName($level);
-
         // check if any handler will handle this message so we can return early and save cycles
         $handlerKey = null;
         reset($this->handlers);
@@ -296,6 +294,8 @@ class Logger implements LoggerInterface
         if (null === $handlerKey) {
             return false;
         }
+
+        $levelName = static::getLevelName($level);
 
         $record = [
             'message' => $message,


### PR DESCRIPTION
I am micro-optimising one local project and have noticed that the

```php
$levelName = static::getLevelName($level);
```

inside the `Logger::addRecord()` can be moved slightly later so that it was not invoked when we don't need it (when there are no handlers for a given error level).