### PR TITLE
Replaced current/next-style loop with foreach

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -283,14 +283,11 @@ class Logger implements LoggerInterface
 
         // check if any handler will handle this message so we can return early and save cycles
         $handlerKey = null;
-        reset($this->handlers);
-        while ($handler = current($this->handlers)) {
+        foreach ($this->handlers as $key => $handler) {
             if ($handler->isHandling(['level' => $level])) {
-                $handlerKey = key($this->handlers);
+                $handlerKey = $key;
                 break;
             }
-
-            next($this->handlers);
         }
 
         if (null === $handlerKey) {


### PR DESCRIPTION
At least in my enviroment it gives 2x performance boost for the `Logger::addRecord` for the messages that are not to be handled (due to level).

My use case: it's **a lot** of calls for the method and all but couple are not to be logged (due to level), so in this scenario it is really important to return quickly. And calling functions (`current` or `next`) does not help with that.