### PR TITLE
Replaced current/next-style loop with foreach

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -283,14 +283,11 @@ class Logger implements LoggerInterface
 
         // check if any handler will handle this message so we can return early and save cycles
         $handlerKey = null;
-        reset($this->handlers);
-        while ($handler = current($this->handlers)) {
+        foreach ($this->handlers as $key => $handler) {
             if ($handler->isHandling(['level' => $level])) {
-                $handlerKey = key($this->handlers);
+                $handlerKey = $key;
                 break;
             }
-
-            next($this->handlers);
         }
 
         if (null === $handlerKey) {
@@ -311,7 +308,17 @@ class Logger implements LoggerInterface
             $record = call_user_func($processor, $record);
         }
 
+        reset($this->handlers);
+        $skip = true;
         while ($handler = current($this->handlers)) {
+            if ($skip) {
+                if ($key !== key($this->handlers)) {
+                    next($this->handlers);
+                    continue;
+                }
+                $skip = false;
+            }
+
             if (true === $handler->handle($record)) {
                 break;
             }

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -308,6 +308,7 @@ class Logger implements LoggerInterface
             $record = call_user_func($processor, $record);
         }
 
+        // advance the array pointer to the first handler that will handle this record
         reset($this->handlers);
         while ($handlerKey !== key($this->handlers)) {
             next($this->handlers);

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -309,16 +309,11 @@ class Logger implements LoggerInterface
         }
 
         reset($this->handlers);
-        $skip = true;
-        while ($handler = current($this->handlers)) {
-            if ($skip) {
-                if ($key !== key($this->handlers)) {
-                    next($this->handlers);
-                    continue;
-                }
-                $skip = false;
-            }
+        while ($key !== key($this->handlers)) {
+            next($this->handlers);
+        }
 
+        while ($handler = current($this->handlers)) {
             if (true === $handler->handle($record)) {
                 break;
             }

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -309,7 +309,7 @@ class Logger implements LoggerInterface
         }
 
         reset($this->handlers);
-        while ($key !== key($this->handlers)) {
+        while ($handlerKey !== key($this->handlers)) {
             next($this->handlers);
         }
 


### PR DESCRIPTION
In this PR I optimised the hot path for the cases when there are no handlers to handle a message (due to a level).

In my environment the performance gain is about x2-3.

The cost of this change is slightly more complicated message handling code: it is more tangled now (so I'm open for suggestions on how to improve it). And it is likely to be slightly less performant, but in case when a message is handled - the handlers would be the slowest part, so the penalty for the lines I added should be negligible (it is my speculations, it needs a proof).

If necessary and if the dev team agrees this optimisation worth it, I may provide a small set of performance tests (but I'm not a performance engineer and don't do it professionally, so they likely to be not ideal).

So, what would be your thoughts?