### PR TITLE
spelling fixes (comments, text)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
   * Added SlackbotHandler and SlackWebhookHandler to set up Slack integration more easily
   * Added MercurialProcessor to add mercurial revision and branch names to log records
   * Added support for AWS SDK v3 in DynamoDbHandler
-  * Fixed fatal errors occuring when normalizing generators that have been fully consumed
+  * Fixed fatal errors occurring when normalizing generators that have been fully consumed
   * Fixed RollbarHandler to include a level (rollbar level), monolog_level (original name), channel and datetime (unix)
   * Fixed RollbarHandler not flushing records automatically, calling close() explicitly is not necessary anymore
   * Fixed SyslogUdpHandler to avoid sending empty frames
@@ -13,7 +13,7 @@
 
   * Break: Reverted the addition of $context when the ErrorHandler handles regular php errors from 1.20.0 as it was causing issues
   * Added support for more formats in RotatingFileHandler::setFilenameFormat as long as they have Y, m and d in order
-  * Added ability to format the main line of text the SlackHandler sends by explictly setting a formatter on the handler
+  * Added ability to format the main line of text the SlackHandler sends by explicitly setting a formatter on the handler
   * Added information about SoapFault instances in NormalizerFormatter
   * Added $handleOnlyReportedErrors option on ErrorHandler::registerErrorHandler (default true) to allow logging of all errors no matter the error_reporting level
 
@@ -135,7 +135,7 @@
   * Added $useShortAttachment to SlackHandler to minify attachment size and $includeExtra to append extra data
   * Added $host to HipChatHandler for users of private instances
   * Added $transactionName to NewRelicHandler and support for a transaction_name context value
-  * Fixed MandrillHandler to avoid outputing API call responses
+  * Fixed MandrillHandler to avoid outputting API call responses
   * Fixed some non-standard behaviors in SyslogUdpHandler
 
 ### 1.11.0 (2014-09-30)

--- a/doc/01-usage.md
+++ b/doc/01-usage.md
@@ -118,7 +118,7 @@ you want to override other configured loggers.
 
 ## Adding extra data in the records
 
-Monolog provides two different ways to add extra informations along the simple
+Monolog provides two different ways to add extra information along the simple
 textual message.
 
 ### Using the logging context

--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -210,7 +210,7 @@ class NormalizerFormatter implements FormatterInterface
      *
      * If the failure is due to invalid string encoding, try to clean the
      * input and encode again. If the second encoding attempt fails, the
-     * inital error is not encoding related or the input can't be cleaned then
+     * initial error is not encoding related or the input can't be cleaned then
      * raise a descriptive exception.
      *
      * @param  int               $code return code of json_last_error function


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.