### PR TITLE
Correcting a small spelling mistake in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Bugs and feature request are tracked on [GitHub](https://github.com/Seldaek/mono
 - [Aura.Web_Project](https://github.com/auraphp/Aura.Web_Project) comes out of the box with Monolog.
 - [Nette Framework](http://nette.org/en/) can be used with Monolog via [Kdyby/Monolog](https://github.com/Kdyby/Monolog) extension.
 - [Proton Micro Framework](https://github.com/alexbilbie/Proton) comes out of the box with Monolog.
-- [FuelPHP](http://fuelphp.com/) come out of the box with Monolog.
+- [FuelPHP](http://fuelphp.com/) comes out of the box with Monolog.
 - [Equip Framework](https://github.com/equip/framework) comes out of the box with Monolog.
 - [Yii 2](http://www.yiiframework.com/) is usable with Monolog via the [yii2-monolog](https://github.com/merorafael/yii2-monolog) plugin.
 


### PR DESCRIPTION
"come out of the box" => "comes out of the box"