### PR TITLE
re-throws exception thrown by execute function 

### DIFF
--- a/src/Monolog/Handler/LogglyHandler.php
+++ b/src/Monolog/Handler/LogglyHandler.php
@@ -93,7 +93,11 @@ class LogglyHandler extends AbstractProcessingHandler
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
-        Curl\Util::execute($ch);
+        try{
+            Curl\Util::execute($ch);    
+        }catch(Exception $e){
+            throw new \RuntimeException(sprintf('unable to connect to host, error message: %s', $e->getMessage()));
+        }
     }
 
     protected function getDefaultFormatter(): FormatterInterface


### PR DESCRIPTION
We've observed that the runtime exception thrown by the function execute() in util.php does not propagate to created instances of logger or pushHandler. 

Because of this php threads break when curl requests to loggly hosts fail after max retries.
This issue is similar to #933 
