### PR TITLE
Handle DateTime objects in formatted messages

### DIFF
--- a/src/Monolog/Processor/PsrLogMessageProcessor.php
+++ b/src/Monolog/Processor/PsrLogMessageProcessor.php
@@ -22,7 +22,7 @@ class PsrLogMessageProcessor
 {
     const SIMPLE_DATE = "Y-m-d\TH:i:sP";
 
-    protected $dateFormat;
+    private $dateFormat;
 
     /**
      * @param string $dateFormat The format of the timestamp: one supported by DateTime::format

--- a/src/Monolog/Processor/PsrLogMessageProcessor.php
+++ b/src/Monolog/Processor/PsrLogMessageProcessor.php
@@ -20,6 +20,18 @@ namespace Monolog\Processor;
  */
 class PsrLogMessageProcessor
 {
+    const SIMPLE_DATE = "Y-m-d\TH:i:sP";
+
+    protected $dateFormat;
+
+    /**
+     * @param string $dateFormat The format of the timestamp: one supported by DateTime::format
+     */
+    public function __construct(string $dateFormat = null)
+    {
+        $this->dateFormat = null === $dateFormat ? static::SIMPLE_DATE : $dateFormat;
+    }
+
     /**
      * @param  array $record
      * @return array
@@ -33,7 +45,9 @@ class PsrLogMessageProcessor
         $replacements = [];
         foreach ($record['context'] as $key => $val) {
             if (is_null($val) || is_scalar($val) || (is_object($val) && method_exists($val, "__toString"))) {
-                $replacements['{'.$key.'}'] = $val;
+                $replacements['{' . $key . '}'] = $val;
+            } elseif ($val instanceof \DateTime) {
+                $replacements['{'.$key.'}'] = $val->format($this->dateFormat);
             } elseif (is_object($val)) {
                 $replacements['{'.$key.'}'] = '[object '.get_class($val).']';
             } else {

--- a/src/Monolog/Processor/PsrLogMessageProcessor.php
+++ b/src/Monolog/Processor/PsrLogMessageProcessor.php
@@ -45,7 +45,7 @@ class PsrLogMessageProcessor
         $replacements = [];
         foreach ($record['context'] as $key => $val) {
             if (is_null($val) || is_scalar($val) || (is_object($val) && method_exists($val, "__toString"))) {
-                $replacements['{' . $key . '}'] = $val;
+                $replacements['{'.$key.'}'] = $val;
             } elseif ($val instanceof \DateTimeInterface) {
                 $replacements['{'.$key.'}'] = $val->format($this->dateFormat);
             } elseif (is_object($val)) {

--- a/src/Monolog/Processor/PsrLogMessageProcessor.php
+++ b/src/Monolog/Processor/PsrLogMessageProcessor.php
@@ -46,7 +46,7 @@ class PsrLogMessageProcessor
         foreach ($record['context'] as $key => $val) {
             if (is_null($val) || is_scalar($val) || (is_object($val) && method_exists($val, "__toString"))) {
                 $replacements['{' . $key . '}'] = $val;
-            } elseif ($val instanceof \DateTime) {
+            } elseif ($val instanceof \DateTimeInterface) {
                 $replacements['{'.$key.'}'] = $val->format($this->dateFormat);
             } elseif (is_object($val)) {
                 $replacements['{'.$key.'}'] = '[object '.get_class($val).']';

--- a/tests/Monolog/Processor/PsrLogMessageProcessorTest.php
+++ b/tests/Monolog/Processor/PsrLogMessageProcessorTest.php
@@ -27,8 +27,24 @@ class PsrLogMessageProcessorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $message['message']);
     }
 
+    public function testCustomDateFormat()
+    {
+        $format = "Y-m-d";
+        $date = new \DateTime();
+
+        $proc = new PsrLogMessageProcessor($format);
+
+        $message = $proc([
+            'message' => '{foo}',
+            'context' => ['foo' => $date],
+        ]);
+        $this->assertEquals($date->format($format), $message['message']);
+    }
+
     public function getPairs()
     {
+        $date = new \DateTime();
+
         return [
             ['foo',    'foo'],
             ['3',      '3'],
@@ -36,6 +52,7 @@ class PsrLogMessageProcessorTest extends \PHPUnit_Framework_TestCase
             [null,     ''],
             [true,     '1'],
             [false,    ''],
+            [$date, $date->format(PsrLogMessageProcessor::SIMPLE_DATE)],
             [new \stdClass, '[object stdClass]'],
             [[], '[array]'],
         ];


### PR DESCRIPTION
Adds support for DateTime objects being passed and formatted in PSRLogMessages.

Seems like it might be a good addition. Totally understand if this change pushes this processor beyond it's intended scope.

Cheers.