### PR TITLE
Complete rfc5424 header for SyslogUdpHandler

### DIFF
--- a/src/Monolog/Handler/SyslogUdpHandler.php
+++ b/src/Monolog/Handler/SyslogUdpHandler.php
@@ -27,12 +27,12 @@ class SyslogUdpHandler extends AbstractSyslogHandler
     /**
      * @param string  $host
      * @param int     $port
-     * @param string  $ident    Program name or tag for each log message.
      * @param mixed   $facility
      * @param int     $level    The minimum logging level at which this handler will be triggered
      * @param Boolean $bubble   Whether the messages that are handled can bubble up the stack or not
+     * @param string  $ident    Program name or tag for each log message.
      */
-    public function __construct($host, $port = 514, $ident = 'php', $facility = LOG_USER, $level = Logger::DEBUG, $bubble = true)
+    public function __construct($host, $port = 514, $facility = LOG_USER, $level = Logger::DEBUG, $bubble = true, $ident = 'php')
     {
         parent::__construct($facility, $level, $bubble);
 
@@ -73,17 +73,19 @@ class SyslogUdpHandler extends AbstractSyslogHandler
     {
         $priority = $severity + $this->facility;
 
-        if(!$pid = getmypid())
+        if (!$pid = getmypid()) {
             $pid = '-';
+        }
 
-        if(!$hostname = gethostname())
+        if (!$hostname = gethostname()) {
             $hostname = '-';
+        }
 
-        return "<$priority>1 ".
-            $this->getDateTime()." ".
-            $hostname." ".
-            $this->ident." ".
-            $pid." - - ";
+        return "<$priority>1 " .
+            $this->getDateTime() . " " .
+            $hostname . " " .
+            $this->ident . " " .
+            $pid . " - - ";
     }
 
     protected function getDateTime()

--- a/src/Monolog/Handler/SyslogUdpHandler.php
+++ b/src/Monolog/Handler/SyslogUdpHandler.php
@@ -22,17 +22,21 @@ use Monolog\Handler\SyslogUdp\UdpSocket;
 class SyslogUdpHandler extends AbstractSyslogHandler
 {
     protected $socket;
+    protected $ident;
 
     /**
      * @param string  $host
      * @param int     $port
+     * @param string  $ident    Program name or tag for each log message.
      * @param mixed   $facility
      * @param int     $level    The minimum logging level at which this handler will be triggered
      * @param Boolean $bubble   Whether the messages that are handled can bubble up the stack or not
      */
-    public function __construct($host, $port = 514, $facility = LOG_USER, $level = Logger::DEBUG, $bubble = true)
+    public function __construct($host, $port = 514, $ident = 'php', $facility = LOG_USER, $level = Logger::DEBUG, $bubble = true)
     {
         parent::__construct($facility, $level, $bubble);
+
+        $this->ident = $ident;
 
         $this->socket = new UdpSocket($host, $port ?: 514);
     }
@@ -69,7 +73,22 @@ class SyslogUdpHandler extends AbstractSyslogHandler
     {
         $priority = $severity + $this->facility;
 
-        return "<$priority>1 ";
+        if(!$pid = getmypid())
+            $pid = '-';
+
+        if(!$hostname = gethostname())
+            $hostname = '-';
+
+        return "<$priority>1 ".
+            $this->getDateTime()." ".
+            $hostname." ".
+            $this->ident." ".
+            $pid." - - ";
+    }
+
+    protected function getDateTime()
+    {
+        return date(\DateTime::RFC3339);
     }
 
     /**

--- a/tests/Monolog/Handler/SyslogUdpHandlerTest.php
+++ b/tests/Monolog/Handler/SyslogUdpHandlerTest.php
@@ -23,7 +23,7 @@ class SyslogUdpHandlerTest extends TestCase
      */
     public function testWeValidateFacilities()
     {
-        $handler = new SyslogUdpHandler("ip", null, "php", "invalidFacility");
+        $handler = new SyslogUdpHandler("ip", null, "invalidFacility");
     }
 
     public function testWeSplitIntoLines()
@@ -33,7 +33,7 @@ class SyslogUdpHandlerTest extends TestCase
         $host = gethostname();
 
         $handler = $this->getMockBuilder('\Monolog\Handler\SyslogUdpHandler')
-            ->setConstructorArgs(array("127.0.0.1", 514, "php", "authpriv"))
+            ->setConstructorArgs(array("127.0.0.1", 514, "authpriv"))
             ->setMethods(array('getDateTime'))
             ->getMock();
 

--- a/tests/Monolog/Handler/SyslogUdpHandlerTest.php
+++ b/tests/Monolog/Handler/SyslogUdpHandlerTest.php
@@ -23,21 +23,32 @@ class SyslogUdpHandlerTest extends TestCase
      */
     public function testWeValidateFacilities()
     {
-        $handler = new SyslogUdpHandler("ip", null, "invalidFacility");
+        $handler = new SyslogUdpHandler("ip", null, "php", "invalidFacility");
     }
 
     public function testWeSplitIntoLines()
     {
-        $handler = new SyslogUdpHandler("127.0.0.1", 514, "authpriv");
+        $time = '2014-01-07T12:34';
+        $pid = getmypid();
+        $host = gethostname();
+
+        $handler = $this->getMockBuilder('\Monolog\Handler\SyslogUdpHandler')
+            ->setConstructorArgs(["127.0.0.1", 514, "php", "authpriv"])
+            ->setMethods(['getDateTime'])
+            ->getMock();
+
+        $handler->method('getDateTime')
+            ->willReturn($time);
+
         $handler->setFormatter(new \Monolog\Formatter\ChromePHPFormatter());
 
         $socket = $this->getMock('\Monolog\Handler\SyslogUdp\UdpSocket', array('write'), array('lol', 'lol'));
         $socket->expects($this->at(0))
             ->method('write')
-            ->with("lol", "<".(LOG_AUTHPRIV + LOG_WARNING).">1 ");
+            ->with("lol", "<".(LOG_AUTHPRIV + LOG_WARNING).">1 $time $host php $pid - - ");
         $socket->expects($this->at(1))
             ->method('write')
-            ->with("hej", "<".(LOG_AUTHPRIV + LOG_WARNING).">1 ");
+            ->with("hej", "<".(LOG_AUTHPRIV + LOG_WARNING).">1 $time $host php $pid - - ");
 
         $handler->setSocket($socket);
 

--- a/tests/Monolog/Handler/SyslogUdpHandlerTest.php
+++ b/tests/Monolog/Handler/SyslogUdpHandlerTest.php
@@ -33,8 +33,8 @@ class SyslogUdpHandlerTest extends TestCase
         $host = gethostname();
 
         $handler = $this->getMockBuilder('\Monolog\Handler\SyslogUdpHandler')
-            ->setConstructorArgs(["127.0.0.1", 514, "php", "authpriv"])
-            ->setMethods(['getDateTime'])
+            ->setConstructorArgs(array("127.0.0.1", 514, "php", "authpriv"))
+            ->setMethods(array('getDateTime'))
             ->getMock();
 
         $handler->method('getDateTime')


### PR DESCRIPTION
This pull request adds ability to build correct rfc5424 syslog messages and resolves #942 . SyslogUdpHandler got extra "ident" field for its constructor.