### PR TITLE
Add level parameter to payload when reporting Rollbar exceptions (#852)

### DIFF
--- a/src/Monolog/Handler/RollbarHandler.php
+++ b/src/Monolog/Handler/RollbarHandler.php
@@ -97,6 +97,7 @@ class RollbarHandler extends AbstractProcessingHandler
         ]);
 
         if (isset($context['exception']) && $context['exception'] instanceof Exception) {
+            $payload['level'] = $context['level'];
             $exception = $context['exception'];
             unset($context['exception']);
 

--- a/tests/Monolog/Handler/RollbarHandlerTest.php
+++ b/tests/Monolog/Handler/RollbarHandlerTest.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Exception;
+use Monolog\Test\TestCase;
+use Monolog\Logger;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+/**
+ * @author Erik Johansson <erik.pm.johansson@gmail.com>
+ * @see    https://rollbar.com/docs/notifier/rollbar-php/
+ *
+ * @coversDefaultClass Monolog\Handler\RollbarHandler
+ */
+class RollbarHandlerTest extends TestCase
+{
+    /**
+     * @var MockObject
+     */
+    private $rollbarNotifier;
+
+    /**
+     * @var array
+     */
+    private $reportedExceptionArguments = null;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->setupRollbarNotifierMock();
+    }
+
+    /**
+     * When reporting exceptions to Rollbar the
+     * level has to be set in the payload data
+     */
+    public function testExceptionLogLevel()
+    {
+        $handler = $this->createHandler();
+
+        $handler->handle($this->createExceptionRecord(Logger::DEBUG));
+
+        $this->assertEquals('debug', $this->reportedExceptionArguments['payload']['level']);
+    }
+
+    private function setupRollbarNotifierMock()
+    {
+        $this->rollbarNotifier = $this->getMockBuilder('RollbarNotifier')
+            ->setMethods(array('report_message', 'report_exception', 'flush'))
+            ->getMock();
+
+        $this->rollbarNotifier
+            ->expects($this->any())
+            ->method('report_exception')
+            ->willReturnCallback(function ($exception, $context, $payload) {
+                $this->reportedExceptionArguments = compact('exception', 'context', 'payload');
+            });
+    }
+
+    private function createHandler(): RollbarHandler
+    {
+        return new RollbarHandler($this->rollbarNotifier, Logger::DEBUG);
+    }
+
+    private function createExceptionRecord($level = Logger::DEBUG, $message = 'test', $exception = null): array
+    {
+        return $this->getRecord($level, $message, [
+            'exception' => $exception ?? new Exception()
+        ]);
+    }
+}


### PR DESCRIPTION
As mentioned by @AlexStansfield in #852, the level is not properly reflected in Rollbar when reporting exceptions. The issue is closed but it still didn't work for us.

So while digging into the Rollbar library I arrived at the same conclusion that Alex did; that the level has to be included in the payload data to work.

I have verified that this fix works with manual tests. I also took the opportunity to introduce a basic test case for the RollbarHandler as there wasn't one before.