### PR TITLE
Replace deprecated setExpectedException in PHPUnit tests.

### DIFF
--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -115,7 +115,8 @@ class NormalizerFormatterTest extends \PHPUnit_Framework_TestCase
     public function testFormatToStringExceptionHandle()
     {
         $formatter = new NormalizerFormatter('Y-m-d');
-        $this->expectException('RuntimeException', 'Could not convert to string');
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('Could not convert to string');
         $formatter->format([
             'myObject' => new TestToStringError(),
         ]);
@@ -313,7 +314,8 @@ class NormalizerFormatterTest extends \PHPUnit_Framework_TestCase
         $reflMethod = new \ReflectionMethod($formatter, 'handleJsonError');
         $reflMethod->setAccessible(true);
 
-        $this->expectException('RuntimeException', $msg);
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage($msg);
         $reflMethod->invoke($formatter, $code, 'faked');
     }
 

--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -115,7 +115,7 @@ class NormalizerFormatterTest extends \PHPUnit_Framework_TestCase
     public function testFormatToStringExceptionHandle()
     {
         $formatter = new NormalizerFormatter('Y-m-d');
-        $this->setExpectedException('RuntimeException', 'Could not convert to string');
+        $this->expectException('RuntimeException', 'Could not convert to string');
         $formatter->format([
             'myObject' => new TestToStringError(),
         ]);
@@ -313,7 +313,7 @@ class NormalizerFormatterTest extends \PHPUnit_Framework_TestCase
         $reflMethod = new \ReflectionMethod($formatter, 'handleJsonError');
         $reflMethod->setAccessible(true);
 
-        $this->setExpectedException('RuntimeException', $msg);
+        $this->expectException('RuntimeException', $msg);
         $reflMethod->invoke($formatter, $code, 'faked');
     }
 

--- a/tests/Monolog/Handler/ElasticSearchHandlerTest.php
+++ b/tests/Monolog/Handler/ElasticSearchHandlerTest.php
@@ -134,7 +134,8 @@ class ElasticSearchHandlerTest extends TestCase
         $handler = new ElasticSearchHandler($client, $handlerOpts);
 
         if ($expectedError) {
-            $this->expectException($expectedError[0], $expectedError[1]);
+            $this->expectException($expectedError[0]);
+            $this->expectExceptionMessage($expectedError[1]);
             $handler->handle($this->getRecord());
         } else {
             $this->assertFalse($handler->handle($this->getRecord()));

--- a/tests/Monolog/Handler/ElasticSearchHandlerTest.php
+++ b/tests/Monolog/Handler/ElasticSearchHandlerTest.php
@@ -134,7 +134,7 @@ class ElasticSearchHandlerTest extends TestCase
         $handler = new ElasticSearchHandler($client, $handlerOpts);
 
         if ($expectedError) {
-            $this->setExpectedException($expectedError[0], $expectedError[1]);
+            $this->expectException($expectedError[0], $expectedError[1]);
             $handler->handle($this->getRecord());
         } else {
             $this->assertFalse($handler->handle($this->getRecord()));

--- a/tests/Monolog/Handler/SyslogHandlerTest.php
+++ b/tests/Monolog/Handler/SyslogHandlerTest.php
@@ -38,7 +38,7 @@ class SyslogHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructInvalidFacility()
     {
-        $this->setExpectedException('UnexpectedValueException');
+        $this->expectException('UnexpectedValueException');
         $handler = new SyslogHandler('test', 'unknown');
     }
 }

--- a/tests/Monolog/RegistryTest.php
+++ b/tests/Monolog/RegistryTest.php
@@ -68,7 +68,7 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
         Registry::addLogger(new Logger('test1'), 'log');
         Registry::clear();
 
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->expectException('\InvalidArgumentException');
         Registry::getInstance('log');
     }
 
@@ -82,7 +82,7 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
         Registry::addLogger($loggerToAdd);
         Registry::removeLogger($remove);
 
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->expectException('\InvalidArgumentException');
         Registry::getInstance($loggerToAdd->getName());
     }
 


### PR DESCRIPTION
The `setExpectedException` method is deprecated in PHPUnit 5.2+ and removed in PHPUnit 6. This pull request simply replaces calls to `setExpectedException` with its replacement `expectException` and `expectExceptionMessage` (as needed).