### PR TITLE
SlackWebhookHandler: Explicitly set content-type header, and post JSON as body

### DIFF
--- a/src/Monolog/Handler/SlackWebhookHandler.php
+++ b/src/Monolog/Handler/SlackWebhookHandler.php
@@ -87,7 +87,8 @@ class SlackWebhookHandler extends AbstractProcessingHandler
         if (defined('CURLOPT_SAFE_UPLOAD')) {
             curl_setopt($ch, CURLOPT_SAFE_UPLOAD, true);
         }
-        curl_setopt($ch, CURLOPT_POSTFIELDS, array('payload' => $postString));
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-type: application/json']);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $postString);
 
         Curl\Util::execute($ch);
     }

--- a/src/Monolog/Handler/SlackWebhookHandler.php
+++ b/src/Monolog/Handler/SlackWebhookHandler.php
@@ -81,14 +81,18 @@ class SlackWebhookHandler extends AbstractProcessingHandler
         $postString = json_encode($postData);
 
         $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, $this->webhookUrl);
-        curl_setopt($ch, CURLOPT_POST, true);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        $options = [
+            CURLOPT_URL => $this->webhookUrl,
+            CURLOPT_POST => true,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HTTPHEADER => ['Content-type: application/json'],
+            CURLOPT_POSTFIELDS => $postString
+        ];
         if (defined('CURLOPT_SAFE_UPLOAD')) {
-            curl_setopt($ch, CURLOPT_SAFE_UPLOAD, true);
+            $options[CURLOPT_SAFE_UPLOAD] = true;
         }
-        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-type: application/json']);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, $postString);
+
+        curl_setopt_array($ch, $options);
 
         Curl\Util::execute($ch);
     }


### PR DESCRIPTION
Not setting the content-type header was causing issues with Rocket.Chat (slack compatible). I added the content-type, and removed the "payload" as per specification (https://api.slack.com/incoming-webhooks).

This is a more complete implementation of the slack webhooks, and also fixes the integration problems with Rocket.Chat.

From https://api.slack.com/incoming-webhooks:

"By declaring the content type, no further encoding of the POST body is needed — just provide valid JSON in UTF-8."

curl example

```
curl -X POST -H 'Content-type: application/json' \
--data '{"text":"This is a line of text.\nAnd this is another one."}' \
 https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
```
