### PR TITLE
Use first day/first month for date calculations in RotatingFileHanderTest

### DIFF
--- a/tests/Monolog/Handler/RotatingFileHandlerTest.php
+++ b/tests/Monolog/Handler/RotatingFileHandlerTest.php
@@ -111,10 +111,10 @@ class RotatingFileHandlerTest extends TestCase
             return $now + 86400 * $ago;
         };
         $monthCallback = function($ago) {
-            return gmmktime(0, 0, 0, date('n') + $ago, date('d'), date('Y'));
+            return gmmktime(0, 0, 0, date('n') + $ago, 1, date('Y'));
         };
         $yearCallback = function($ago) {
-            return gmmktime(0, 0, 0, date('n'), date('d'), date('Y') + $ago);
+            return gmmktime(0, 0, 0, 1, 1, date('Y') + $ago);
         };
 
         return array(


### PR DESCRIPTION
When making the calculations for the filename of the current month using
date('d') does not work because you may run into the situation where you run
the tests on a day in a month that does not exist in the previous month,
for example March 30th. As there is no Februari 30th, PHP will skip ahead
to March, and the filename for the "previous" month will incorrectly be
"2017-03" instead of the expected "2017-02". Using the first day of the
month instead of the current day of the month solves this problem.

For consisty we now also use the first month of each year for calculations
regarding years even if this is not necessary, it would break symmetry
if we don't, plus it makes it clear that the value is not relevant in the
calculation.