### PR TITLE
Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
         - php: 7.1
         - php: nightly
     fast_finish: true
+    allow_failures:
+        - php: nightly
 
 before_script:
   - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -553,6 +553,10 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
      */
     public function testUseMicrosecondTimestamps($micro, $assert, $assertFormat)
     {
+        if (PHP_VERSION_ID === 70103) {
+            $this->markTestSkipped();
+        }
+
         $logger = new Logger('foo');
         $logger->useMicrosecondTimestamps($micro);
         $handler = new TestHandler;


### PR DESCRIPTION
Fixes the Monolog build, which is currently having two problems:
* A [bug in PHP 7.1.3](https://bugs.php.net/bug.php?id=74258) means microseconds in DateTimes don't work
* The `php nightly` build on Travis is failing ATOW, because it is seg faulting while running Composer.