### PR TITLE
Support HeadlessChrome

### DIFF
--- a/src/Monolog/Handler/ChromePHPHandler.php
+++ b/src/Monolog/Handler/ChromePHPHandler.php
@@ -36,7 +36,7 @@ class ChromePHPHandler extends AbstractProcessingHandler
     /**
      * Regular expression to detect supported browsers (matches any Chrome, or Firefox 43+)
      */
-    const USER_AGENT_REGEX = '{\b(?:Chrome\/\d+(?:\.\d+)*|HeadlessChrome|Firefox\/(?:4[3-9]|[5-9]\d|\d{3,})(?:\.\d)*)\b}';
+    const USER_AGENT_REGEX = '{\b(?:Chrome/\d+(?:\.\d+)*|HeadlessChrome|Firefox/(?:4[3-9]|[5-9]\d|\d{3,})(?:\.\d)*)\b}';
 
     protected static $initialized = false;
 

--- a/src/Monolog/Handler/ChromePHPHandler.php
+++ b/src/Monolog/Handler/ChromePHPHandler.php
@@ -36,7 +36,7 @@ class ChromePHPHandler extends AbstractProcessingHandler
     /**
      * Regular expression to detect supported browsers (matches any Chrome, or Firefox 43+)
      */
-    const USER_AGENT_REGEX = '{\b(?:Chrome/\d+(?:\.\d+)*|Firefox/(?:4[3-9]|[5-9]\d|\d{3,})(?:\.\d)*)\b}';
+    const USER_AGENT_REGEX = '{\b(?:Chrome\/\d+(?:\.\d+)*|HeadlessChrome|Firefox\/(?:4[3-9]|[5-9]\d|\d{3,})(?:\.\d)*)\b}';
 
     protected static $initialized = false;
 

--- a/tests/Monolog/Handler/ChromePHPHandlerTest.php
+++ b/tests/Monolog/Handler/ChromePHPHandlerTest.php
@@ -25,8 +25,15 @@ class ChromePHPHandlerTest extends TestCase
         $_SERVER['HTTP_USER_AGENT'] = 'Monolog Test; Chrome/1.0';
     }
 
-    public function testHeaders()
+    /**
+     * testHeaders
+     *
+     * @dataProvider agentsProvider
+     */
+    public function testHeaders($agent)
     {
+        $_SERVER['HTTP_USER_AGENT'] = $agent;
+
         $handler = new TestChromePHPHandler();
         $handler->setFormatter($this->getIdentityFormatter());
         $handler->handle($this->getRecord(Logger::DEBUG));
@@ -45,6 +52,16 @@ class ChromePHPHandlerTest extends TestCase
         );
 
         $this->assertEquals($expected, $handler->getHeaders());
+    }
+
+    public function agentsProvider()
+    {
+        return [
+            ['Monolog Test; Chrome/1.0'],
+            ['Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0'],
+            ['Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/56.0.2924.76 Chrome/56.0.2924.76 Safari/537.36'],
+            ['Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome Safari/537.36'],
+        ];
     }
 
     public function testHeadersOverflow()

--- a/tests/Monolog/Handler/ChromePHPHandlerTest.php
+++ b/tests/Monolog/Handler/ChromePHPHandlerTest.php
@@ -26,8 +26,6 @@ class ChromePHPHandlerTest extends TestCase
     }
 
     /**
-     * testHeaders
-     *
      * @dataProvider agentsProvider
      */
     public function testHeaders($agent)
@@ -54,14 +52,14 @@ class ChromePHPHandlerTest extends TestCase
         $this->assertEquals($expected, $handler->getHeaders());
     }
 
-    public function agentsProvider()
+    public static function agentsProvider()
     {
-        return [
-            ['Monolog Test; Chrome/1.0'],
-            ['Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0'],
-            ['Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/56.0.2924.76 Chrome/56.0.2924.76 Safari/537.36'],
-            ['Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome Safari/537.36'],
-        ];
+        return array(
+            array('Monolog Test; Chrome/1.0'),
+            array('Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0'),
+            array('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/56.0.2924.76 Chrome/56.0.2924.76 Safari/537.36'),
+            array('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome Safari/537.36'),
+        );
     }
 
     public function testHeadersOverflow()


### PR DESCRIPTION
We've started using Chromium 57 with the `--headless` flag during integration tests. This means we no longer need Xvfb to be installed.

However Chromium changes the Agent string to:
`'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome Safari/537.36'`
this doesn't match ChomeLogger's REGEX so our int tests won't get the Chrome logger data.

Can we have this? We are still on PHP 5.6 so I haven't been able to test against `master`.

Thanks.