### PR TITLE
Better PSR-3 message formatting

### DIFF
--- a/src/Monolog/Processor/PsrLogMessageProcessor.php
+++ b/src/Monolog/Processor/PsrLogMessageProcessor.php
@@ -20,7 +20,7 @@ namespace Monolog\Processor;
  */
 class PsrLogMessageProcessor
 {
-    const SIMPLE_DATE = "Y-m-d\TH:i:sP";
+    const SIMPLE_DATE = "Y-m-d\TH:i:s.uP";
 
     private $dateFormat;
 
@@ -51,7 +51,7 @@ class PsrLogMessageProcessor
             } elseif (is_object($val)) {
                 $replacements['{'.$key.'}'] = '[object '.get_class($val).']';
             } else {
-                $replacements['{'.$key.'}'] = '['.gettype($val).']';
+                $replacements['{'.$key.'}'] = 'array'.@json_encode($val);
             }
         }
 

--- a/tests/Monolog/Processor/PsrLogMessageProcessorTest.php
+++ b/tests/Monolog/Processor/PsrLogMessageProcessorTest.php
@@ -54,7 +54,10 @@ class PsrLogMessageProcessorTest extends \PHPUnit_Framework_TestCase
             [false,    ''],
             [$date, $date->format(PsrLogMessageProcessor::SIMPLE_DATE)],
             [new \stdClass, '[object stdClass]'],
-            [[], '[array]'],
+            [[], 'array[]'],
+            [[], 'array[]'],
+            [[1, 2, 3], 'array[1,2,3]'],
+            [['foo' => 'bar'], 'array{"foo":"bar"}'],
         ];
     }
 }


### PR DESCRIPTION
Does two things:

 - Include milliseconds in the default date format
 - Show actual content of the array