### PR TITLE
fix(logmatic handler): remove useless suffix url for endpoint

### DIFF
--- a/src/Monolog/Handler/LogmaticHandler.php
+++ b/src/Monolog/Handler/LogmaticHandler.php
@@ -52,8 +52,7 @@ class LogmaticHandler extends SocketHandler
         }
 
         $endpoint = $useSSL ? 'ssl://api.logmatic.io:10515' : 'api.logmatic.io:10514';
-        $endpoint .= '/v1/';
-
+        
         parent::__construct($endpoint, $level, $bubble);
 
         $this->logToken = $token;


### PR DESCRIPTION
Logmatic handler.

Fix "Parsing failure" in socketHandler class on some environment. 