### PR TITLE
PHP Versions less than 5.3.6 throws undefined constant DEBUG_BACKTRAC…

### DIFF
--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -60,10 +60,7 @@ class IntrospectionProcessor
         * As of 5.3.6, DEBUG_BACKTRACE_IGNORE_ARGS option was added.
         * Any version less than 5.3.6 must use the DEBUG_BACKTRACE_IGNORE_ARGS constant value '2'.
         */
-        if (!defined('DEBUG_BACKTRACE_IGNORE_ARGS')) {
-            define('DEBUG_BACKTRACE_IGNORE_ARGS', 2);   
-        }
-        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+        $trace = debug_backtrace((PHP_VERSION_ID < 50306) ? 2 : DEBUG_BACKTRACE_IGNORE_ARGS);
 
         // skip first since it's always the current method
         array_shift($trace);

--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -55,7 +55,7 @@ class IntrospectionProcessor
             return $record;
         }
 
-        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+        $trace = debug_backtrace((version_compare(PHP_VERSION, '5.3.6') < 0) ? 2 : DEBUG_BACKTRACE_IGNORE_ARGS);
 
         // skip first since it's always the current method
         array_shift($trace);

--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -55,7 +55,15 @@ class IntrospectionProcessor
             return $record;
         }
 
-        $trace = debug_backtrace((version_compare(PHP_VERSION, '5.3.6') < 0) ? 2 : DEBUG_BACKTRACE_IGNORE_ARGS);
+        /*
+        * http://php.net/manual/en/function.debug-backtrace.php
+        * As of 5.3.6, DEBUG_BACKTRACE_IGNORE_ARGS option was added.
+        * Any version less than 5.3.6 must use the DEBUG_BACKTRACE_IGNORE_ARGS constant value '2'.
+        */
+        if (!defined('DEBUG_BACKTRACE_IGNORE_ARGS')) {
+            define('DEBUG_BACKTRACE_IGNORE_ARGS', 2);   
+        }
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 
         // skip first since it's always the current method
         array_shift($trace);


### PR DESCRIPTION
…E_IGNORE_ARGS

Notice: Use of undefined constant DEBUG_BACKTRACE_IGNORE_ARGS - assumed 'DEBUG_BACKTRACE_IGNORE_ARGS' in /vendor/monolog/monolog/src/Monolog/Processor/IntrospectionProcessor.php on line 58