### PR TITLE
Fixed test of RotatingFileHandler when the current day is 31 + fixed hhvm build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,11 @@ matrix:
         - php: 5.6
         - php: 7
         - php: 7.1
-        - php: hhvm
+        # Use the newer stack for HHVM as HHVM does not support Precise anymore since a long time and so Precise has an outdated version
+        - php: hhvm-3.18
+          sudo: required
+          dist: trusty
+          group: edge
     fast_finish: true
 
 before_script:

--- a/tests/Monolog/Handler/RotatingFileHandlerTest.php
+++ b/tests/Monolog/Handler/RotatingFileHandlerTest.php
@@ -27,7 +27,7 @@ class RotatingFileHandlerTest extends TestCase
      */
     public $lastError;
 
-    public function setUp()
+    protected function setUp()
     {
         $dir = __DIR__.'/Fixtures';
         chmod($dir, 0777);
@@ -111,7 +111,7 @@ class RotatingFileHandlerTest extends TestCase
             return $now + 86400 * $ago;
         };
         $monthCallback = function($ago) {
-            return gmmktime(0, 0, 0, date('n') + $ago, date('d'), date('Y'));
+            return gmmktime(0, 0, 0, date('n') + $ago, 1, date('Y'));
         };
         $yearCallback = function($ago) {
             return gmmktime(0, 0, 0, date('n'), date('d'), date('Y') + $ago);
@@ -201,7 +201,7 @@ class RotatingFileHandlerTest extends TestCase
         $this->assertEquals('footest', file_get_contents($log));
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         foreach (glob(__DIR__.'/Fixtures/*.rot') as $file) {
             unlink($file);


### PR DESCRIPTION
This did not work because the current way to generate date is weak.
So now we choose the first day of each month. Like that there are no
more issue.

To better understand the issue:

```
php > dump(date('Y-m', gmmktime(0, 0, 0, 5 - 1, 31, 2017)));
"2017-05"
php > dump(date('Y-m', gmmktime(0, 0, 0, 5 - 2, 31, 2017)));
"2017-03"
php > dump(date('Y-m', gmmktime(0, 0, 0, 5 - 3, 31, 2017)));
"2017-03"
php > dump(date('Y-m', gmmktime(0, 0, 0, 5 - 4, 31, 2017)));
"2017-01"
```

replace #998 which was on master.