### PR TITLE
Remove extra line-break at end of line in LineFormatter()

### DIFF
--- a/src/Monolog/Formatter/LineFormatter.php
+++ b/src/Monolog/Formatter/LineFormatter.php
@@ -106,7 +106,7 @@ class LineFormatter extends NormalizerFormatter
             $output = preg_replace('/%(?:extra|context)\..+?%/', '', $output);
         }
 
-        return $output;
+        return rtrim($output,"\r\n");
     }
 
     public function formatBatch(array $records): string


### PR DESCRIPTION
Remove extra line-break at end of line in format(), so that when sent to ErrorLogHandler() and extra line-break does not appear between logged lines. This behavior is seen on both Windows and Linux (RedHat) systems with PHP v7.x.

Before change output in php error log is:
```txt
[31-May-2017 17:11:55 UTC] [NOTICE] test1 

[31-May-2017 17:11:55 UTC] [NOTICE] test2 {"a":"val"}

```
after change the output is:
```txt
[31-May-2017 17:11:55 UTC] [NOTICE] test1 
[31-May-2017 17:11:55 UTC] [NOTICE] test2 {"a":"val"}