### PR TITLE
Fix SwiftMailerHandler with Swiftmailer 6.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "doctrine/couchdb": "~1.0@dev",
         "aws/aws-sdk-php": "^2.4.9 || ^3.0",
         "php-amqplib/php-amqplib": "~2.4",
-        "swiftmailer/swiftmailer": "~5.3",
+        "swiftmailer/swiftmailer": "^5.3|^6.0",
         "php-console/php-console": "^3.1.3",
         "jakub-onderka/php-parallel-lint": "^0.9",
         "predis/predis": "^1.1",

--- a/src/Monolog/Handler/SwiftMailerHandler.php
+++ b/src/Monolog/Handler/SwiftMailerHandler.php
@@ -14,6 +14,7 @@ namespace Monolog\Handler;
 use Monolog\Logger;
 use Monolog\Formatter\LineFormatter;
 use Swift_Message;
+use Swift;
 
 /**
  * SwiftMailerHandler uses Swift_Mailer to send the emails
@@ -79,7 +80,11 @@ class SwiftMailerHandler extends MailHandler
         }
 
         $message->setBody($content, $mime);
-        $message->setDate(time());
+        if (version_compare(Swift::VERSION, '6.0.0', '>=')) {
+            $message->setDate(new \DateTimeImmutable());
+        } else {
+            $message->setDate(time());
+        }
 
         return $message;
     }

--- a/tests/Monolog/Handler/SwiftMailerHandlerTest.php
+++ b/tests/Monolog/Handler/SwiftMailerHandlerTest.php
@@ -99,7 +99,7 @@ class SwiftMailerHandlerTest extends TestCase
 
     public function testMessageHaveUniqueId()
     {
-        $messageTemplate = \Swift_Message::newInstance();
+        $messageTemplate = new \Swift_Message();
         $handler = new SwiftMailerHandler($this->mailer, $messageTemplate);
 
         $method = new \ReflectionMethod('Monolog\Handler\SwiftMailerHandler', 'buildMessage');


### PR DESCRIPTION
After #993, I think this workaround may be the best option for now.

For Swiftmailer <6, `Swift::VERSION` is equal to `@SWIFT_VERSION_NUMBER@` [as we can see here](https://github.com/swiftmailer/swiftmailer/blob/v5.4.8/lib/classes/Swift.php), so `version_compare()` will return false anyway.

This seems to have been fixed in Swiftmailer 6, [as we can see here](https://github.com/swiftmailer/swiftmailer/blob/v6.0.1/lib/classes/Swift.php), so this workaround should work.

This fixes #992 by the way, which I'm experiencing on one of my apps.

What do you think?
