### PR TITLE
Fixed message not being passed to client when capturing an exception

### DIFF
--- a/src/Monolog/Handler/RavenHandler.php
+++ b/src/Monolog/Handler/RavenHandler.php
@@ -181,7 +181,7 @@ class RavenHandler extends AbstractProcessingHandler
         }
 
         if (isset($record['context']['exception']) && $record['context']['exception'] instanceof \Throwable) {
-            $options['extra']['message'] = $record['formatted'];
+            $options['message'] = $record['formatted'];
             $this->ravenClient->captureException($record['context']['exception'], $options);
         } else {
             $this->ravenClient->captureMessage($record['formatted'], [], $options);


### PR DESCRIPTION
The raven client expects the message to be at the first level of the `$data` array when passing an exception.
see https://github.com/getsentry/sentry-php/blob/master/lib/Raven/Client.php#L795