### PR TITLE
Fix WhatFailureGroupHandler::handleBatch when the handler has processors

### DIFF
--- a/src/Monolog/Handler/WhatFailureGroupHandler.php
+++ b/src/Monolog/Handler/WhatFailureGroupHandler.php
@@ -48,6 +48,16 @@ class WhatFailureGroupHandler extends GroupHandler
      */
     public function handleBatch(array $records)
     {
+        if ($this->processors) {
+            $processed = array();
+            foreach ($records as $record) {
+                foreach ($this->processors as $processor) {
+                    $processed[] = call_user_func($processor, $record);
+                }
+            }
+            $records = $processed;
+        }
+
         foreach ($this->handlers as $handler) {
             try {
                 $handler->handleBatch($records);

--- a/tests/Monolog/Handler/WhatFailureGroupHandlerTest.php
+++ b/tests/Monolog/Handler/WhatFailureGroupHandlerTest.php
@@ -88,6 +88,29 @@ class WhatFailureGroupHandlerTest extends TestCase
     }
 
     /**
+     * @covers Monolog\Handler\WhatFailureGroupHandler::handleBatch
+     */
+    public function testHandleBatchUsesProcessors()
+    {
+        $testHandlers = array(new TestHandler(), new TestHandler());
+        $handler = new WhatFailureGroupHandler($testHandlers);
+        $handler->pushProcessor(function ($record) {
+            $record['extra']['foo'] = true;
+
+            return $record;
+        });
+        $handler->handleBatch(array($this->getRecord(Logger::DEBUG), $this->getRecord(Logger::INFO)));
+        foreach ($testHandlers as $test) {
+            $this->assertTrue($test->hasDebugRecords());
+            $this->assertTrue($test->hasInfoRecords());
+            $this->assertTrue(count($test->getRecords()) === 2);
+            $records = $test->getRecords();
+            $this->assertTrue($records[0]['extra']['foo']);
+            $this->assertTrue($records[1]['extra']['foo']);
+        }
+    }
+
+    /**
      * @covers Monolog\Handler\WhatFailureGroupHandler::handle
      */
     public function testHandleException()


### PR DESCRIPTION
Matches https://github.com/Seldaek/monolog/commit/69fb2aa1c16dc532b0a9f8d704cfe51407e3b604 but for `WhatFailureGroupHandler`.