### PR TITLE
fix-for-slack-record-encoding

### DIFF
--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -211,8 +211,8 @@ class SlackRecord
         $hasNonNumericKeys = !count(array_filter(array_keys($normalized), 'is_numeric'));
 
         return $hasSecondDimension || $hasNonNumericKeys
-            ? json_encode($normalized, $prettyPrintFlag)
-            : json_encode($normalized);
+            ? json_encode($normalized, $prettyPrintFlag|JSON_UNESCAPED_UNICODE)
+            : json_encode($normalized, JSON_UNESCAPED_UNICODE);
     }
 
     /**


### PR DESCRIPTION
When message appears in slack channel, there is a problem with cyrillic symbols. They are encoded in unicode and not readable. This fix allow to avoid such problem. 