### PR TITLE
Check if monolog runs in web context

### DIFF
--- a/src/Monolog/Handler/AbstractBrowserHandler.php
+++ b/src/Monolog/Handler/AbstractBrowserHandler.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Monolog\Handler;
+
+abstract class AbstractBrowserHandler extends AbstractProcessingHandler
+{
+
+    /**
+     * Checks if PHP's serving a web request
+     * @return bool
+     */
+    public function isWebRequest(): bool
+    {
+        return 'cli' !== php_sapi_name();
+    }
+}

--- a/src/Monolog/Handler/ChromePHPHandler.php
+++ b/src/Monolog/Handler/ChromePHPHandler.php
@@ -22,8 +22,11 @@ use Monolog\Logger;
  *
  * @author Christophe Coevoet <stof@notk.org>
  */
-class ChromePHPHandler extends AbstractBrowserHandler
+class ChromePHPHandler extends AbstractProcessingHandler
 {
+
+    use WebRequestRecognizerTrait;
+
     /**
      * Version of the extension
      */

--- a/src/Monolog/Handler/ChromePHPHandler.php
+++ b/src/Monolog/Handler/ChromePHPHandler.php
@@ -22,7 +22,7 @@ use Monolog\Logger;
  *
  * @author Christophe Coevoet <stof@notk.org>
  */
-class ChromePHPHandler extends AbstractProcessingHandler
+class ChromePHPHandler extends AbstractBrowserHandler
 {
     /**
      * Version of the extension
@@ -75,6 +75,10 @@ class ChromePHPHandler extends AbstractProcessingHandler
      */
     public function handleBatch(array $records)
     {
+        if (false === $this->isWebRequest()) {
+            return;
+        }
+
         $messages = [];
 
         foreach ($records as $record) {
@@ -108,6 +112,10 @@ class ChromePHPHandler extends AbstractProcessingHandler
      */
     protected function write(array $record)
     {
+        if (false === $this->isWebRequest()) {
+            return;
+        }
+
         self::$json['rows'][] = $record['formatted'];
 
         $this->send();

--- a/src/Monolog/Handler/ChromePHPHandler.php
+++ b/src/Monolog/Handler/ChromePHPHandler.php
@@ -115,7 +115,7 @@ class ChromePHPHandler extends AbstractProcessingHandler
      */
     protected function write(array $record)
     {
-        if (false === $this->isWebRequest()) {
+        if (!$this->isWebRequest()) {
             return;
         }
 

--- a/src/Monolog/Handler/ChromePHPHandler.php
+++ b/src/Monolog/Handler/ChromePHPHandler.php
@@ -78,7 +78,7 @@ class ChromePHPHandler extends AbstractProcessingHandler
      */
     public function handleBatch(array $records)
     {
-        if (false === $this->isWebRequest()) {
+        if (!$this->isWebRequest()) {
             return;
         }
 

--- a/src/Monolog/Handler/FirePHPHandler.php
+++ b/src/Monolog/Handler/FirePHPHandler.php
@@ -19,8 +19,11 @@ use Monolog\Formatter\FormatterInterface;
  *
  * @author Eric Clemmons (@ericclemmons) <eric@uxdriven.com>
  */
-class FirePHPHandler extends AbstractBrowserHandler
+class FirePHPHandler extends AbstractProcessingHandler
 {
+
+    use WebRequestRecognizerTrait;
+
     /**
      * WildFire JSON header message format
      */

--- a/src/Monolog/Handler/FirePHPHandler.php
+++ b/src/Monolog/Handler/FirePHPHandler.php
@@ -133,7 +133,7 @@ class FirePHPHandler extends AbstractProcessingHandler
      */
     protected function write(array $record)
     {
-        if (!self::$sendHeaders || false === $this->isWebRequest()) {
+        if (!self::$sendHeaders || !$this->isWebRequest()) {
             return;
         }
 

--- a/src/Monolog/Handler/FirePHPHandler.php
+++ b/src/Monolog/Handler/FirePHPHandler.php
@@ -19,7 +19,7 @@ use Monolog\Formatter\FormatterInterface;
  *
  * @author Eric Clemmons (@ericclemmons) <eric@uxdriven.com>
  */
-class FirePHPHandler extends AbstractProcessingHandler
+class FirePHPHandler extends AbstractBrowserHandler
 {
     /**
      * WildFire JSON header message format
@@ -130,7 +130,7 @@ class FirePHPHandler extends AbstractProcessingHandler
      */
     protected function write(array $record)
     {
-        if (!self::$sendHeaders) {
+        if (!self::$sendHeaders || false === $this->isWebRequest()) {
             return;
         }
 

--- a/src/Monolog/Handler/WebRequestRecognizerTrait.php
+++ b/src/Monolog/Handler/WebRequestRecognizerTrait.php
@@ -2,7 +2,7 @@
 
 namespace Monolog\Handler;
 
-abstract class AbstractBrowserHandler extends AbstractProcessingHandler
+trait WebRequestRecognizerTrait
 {
 
     /**

--- a/src/Monolog/Handler/WebRequestRecognizerTrait.php
+++ b/src/Monolog/Handler/WebRequestRecognizerTrait.php
@@ -11,6 +11,6 @@ trait WebRequestRecognizerTrait
      */
     protected function isWebRequest(): bool
     {
-        return 'cli' !== php_sapi_name();
+        return 'cli' !== \PHP_SAPI && 'phpdbg' !== \PHP_SAPI;
     }
 }

--- a/src/Monolog/Handler/WebRequestRecognizerTrait.php
+++ b/src/Monolog/Handler/WebRequestRecognizerTrait.php
@@ -9,7 +9,7 @@ trait WebRequestRecognizerTrait
      * Checks if PHP's serving a web request
      * @return bool
      */
-    public function isWebRequest(): bool
+    protected function isWebRequest(): bool
     {
         return 'cli' !== php_sapi_name();
     }

--- a/tests/Monolog/Handler/ChromePHPHandlerTest.php
+++ b/tests/Monolog/Handler/ChromePHPHandlerTest.php
@@ -153,4 +153,9 @@ class TestChromePHPHandler extends ChromePHPHandler
     {
         return $this->headers;
     }
+
+    protected function isWebRequest(): bool
+    {
+        return true;
+    }
 }

--- a/tests/Monolog/Handler/FirePHPHandlerTest.php
+++ b/tests/Monolog/Handler/FirePHPHandlerTest.php
@@ -93,4 +93,9 @@ class TestFirePHPHandler extends FirePHPHandler
     {
         return $this->headers;
     }
+
+    protected function isWebRequest(): bool
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
I faced the problem that if I use the FirePHP and ChromePHP handlers in a non-web context especially the firephp handler collected a lot of data (it stores every record in an internal array). So if you have a long process (for example a migration task) and the this process logs a lot of data you end up with a huge amount of memory in the end.

This PR checks if monolog/PHP runs in web context and if not doesn't do anything in case of the ChromePHP and FirePHP handlers.

**I will fix the tests once I got feedback for the idea and if it will be accepted.**