### PR TITLE
Add Hostname Processor

### DIFF
--- a/doc/02-handlers-formatters-processors.md
+++ b/doc/02-handlers-formatters-processors.md
@@ -155,6 +155,7 @@
 - [_GitProcessor_](../src/Monolog/Processor/GitProcessor.php): Adds the current git branch and commit to a log record.
 - [_MercurialProcessor_](../src/Monolog/Processor/MercurialProcessor.php): Adds the current hg branch and commit to a log record.
 - [_TagProcessor_](../src/Monolog/Processor/TagProcessor.php): Adds an array of predefined tags to a log record.
+- [_HostnameProcessor_](../src/Monolog/Processor/HostnameProcessor.php): Adds the current hostname to a log record.
 
 ## Third Party Packages
 

--- a/src/Monolog/Processor/HostnameProcessor.php
+++ b/src/Monolog/Processor/HostnameProcessor.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+/**
+ * Adds value of gethostname into the log extra
+ *
+ * @author Billie Thompson
+ */
+class HostnameProcessor
+{
+    public function __invoke(array $record): array
+    {
+        $record['extra']['hostname'] = gethostname();
+
+        return $record;
+    }
+}

--- a/tests/Monolog/Processor/HostnameProcessorTest.php
+++ b/tests/Monolog/Processor/HostnameProcessorTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+use Monolog\Test\TestCase;
+
+class HostnameProcessorTest extends TestCase
+{
+    /**
+     * @covers Monolog\Processor\HostnameProcessor::__invoke
+     */
+    public function testProcessor()
+    {
+        $processor = new HostnameProcessor();
+        $record = $processor($this->getRecord());
+        $this->assertArrayHasKey('hostname', $record['extra']);
+        $this->assertInternalType('string', $record['extra']['hostname']);
+        $this->assertNotEmpty($record['extra']['hostname']);
+        $this->assertEquals(gethostname(), $record['extra']['hostname']);
+    }
+}


### PR DESCRIPTION
I have found myself reimplementing this processor a number of times for
different clients. This processor is useful when you're running a number
of instances of an application across multiple hosts. This allows you to
narrow incidents to a specific host.