### PR TITLE
Check maximum allowed size of sqs message

### DIFF
--- a/src/Monolog/Handler/SqsHandler.php
+++ b/src/Monolog/Handler/SqsHandler.php
@@ -21,6 +21,12 @@ use Monolog\Logger;
  */
 class SqsHandler extends AbstractProcessingHandler
 {
+
+    /** 256 KB in bytes - maximum message size in SQS */
+    const MAX_MESSAGE_SIZE = 262144;
+    /** 100 KB in bytes - head message size for new error log */
+    const HEAD_MESSAGE_SIZE = 102400;
+
     /** @var SqsClient */
     private $client;
     /** @var string */
@@ -45,9 +51,14 @@ class SqsHandler extends AbstractProcessingHandler
             throw new \InvalidArgumentException('SqsHandler accepts only formatted records as a string');
         }
 
+        $messageBody = $record['formatted'];
+        if (strlen($messageBody) >= self::MAX_MESSAGE_SIZE) {
+            $messageBody = substr($messageBody, 0, self::HEAD_MESSAGE_SIZE);
+        }
+
         $this->client->sendMessage([
             'QueueUrl' => $this->queueUrl,
-            'MessageBody' => $record['formatted'],
+            'MessageBody' => $messageBody,
         ]);
     }
 }


### PR DESCRIPTION
SQS messages have upper limit of their body. 
It's better to log something instead of skip or fail this logg. 

I would prefer to log new error message, when this happen, via logger instance, but it's not accessible there.
i.e.: `$this->logger->error('Too long message for SQS handler [' . $headOfMessage . '...]')` 
Does anybody know, how to achive this and keep constructor minimal?