### PR TITLE
Queue interop handler.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "php-console/php-console": "^3.1.3",
         "jakub-onderka/php-parallel-lint": "^0.9",
         "predis/predis": "^1.1",
-        "phpspec/prophecy": "^1.6.1"
+        "phpspec/prophecy": "^1.6.1",
+        "queue-interop/queue-interop": "^0.5"
     },
     "suggest": {
         "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
@@ -41,7 +42,8 @@
         "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
         "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
         "rollbar/rollbar": "Allow sending log messages to Rollbar",
-        "php-console/php-console": "Allow sending log messages to Google Chrome"
+        "php-console/php-console": "Allow sending log messages to Google Chrome",
+        "queue-interop/queue-interop": "Allow sending log messages to any MQ compatible with queue-interop"
     },
     "autoload": {
         "psr-4": {"Monolog\\": "src/Monolog"}

--- a/src/Monolog/Handler/QueueInteropHandler.php
+++ b/src/Monolog/Handler/QueueInteropHandler.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Interop\Queue\PsrContext;
+use Interop\Queue\PsrDestination;
+use Monolog\Logger;
+use Monolog\Formatter\JsonFormatter;
+
+class QueueInteropHandler extends AbstractProcessingHandler
+{
+    /**
+     * @var PsrContext
+     */
+    private $context;
+
+    /**
+     * @var PsrDestination
+     */
+    private $destination;
+
+    /**
+     * @param PsrContext $context
+     * @param PsrDestination|string    $destination
+     * @param int                      $level
+     * @param bool                     $bubble       Whether the messages that are handled can bubble up the stack or not
+     */
+    public function __construct(PsrContext $context, $destination = 'log', $level = Logger::DEBUG, $bubble = true)
+    {
+        $this->context = $context;
+
+        if (false == $destination instanceof PsrDestination) {
+            $destination = $this->context->createTopic($destination);
+        }
+
+        $this->destination = $destination;
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function write(array $record)
+    {
+        $message = $this->context->createMessage($record["formatted"], [
+            'content_type' => 'application/json',
+        ]);
+
+        $this->context->createProducer()->send($this->destination, $message);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDefaultFormatter()
+    {
+        return new JsonFormatter(JsonFormatter::BATCH_MODE_JSON, false);
+    }
+}

--- a/src/Monolog/Handler/QueueInteropHandler.php
+++ b/src/Monolog/Handler/QueueInteropHandler.php
@@ -39,7 +39,7 @@ class QueueInteropHandler extends AbstractProcessingHandler
         $this->context = $context;
 
         if (false == $destination instanceof PsrDestination) {
-            $destination = $this->context->createTopic($destination);
+            $destination = $this->context->createQueue($destination);
         }
 
         $this->destination = $destination;


### PR DESCRIPTION
This handler allows to send logs to MQ using any [queue-interop](https://github.com/queue-interop/queue-interop) compatible transports (there 10th of them). 

Here's an example, the code could be found [here](https://github.com/php-enqueue/enqueue-sandbox/tree/master/monolog):

```php
<?php

use Monolog\Handler\QueueInteropHandler;
use Monolog\Logger;

require_once __DIR__.'/vendor/autoload.php';

$context = (new \Enqueue\Fs\FsConnectionFactory('file://'.__DIR__.'/queue'))->createContext();

// create a log channel
$log = new Logger('name');
$log->pushHandler(new QueueInteropHandler($context));

// add records to the log
$log->warning('Foo');
$log->error('Bar');
```

the consumer may look like this: 

```php
<?php

use Enqueue\Consumption\QueueConsumer;
use Interop\Queue\PsrMessage;
use Interop\Queue\PsrProcessor;

require_once __DIR__.'/vendor/autoload.php';

$context = (new \Enqueue\Fs\FsConnectionFactory('file://'.__DIR__.'/queue'))->createContext();

$consumer = new QueueConsumer($context);
$consumer->bind('log', function(PsrMessage $message) {
    echo $message->getBody().PHP_EOL;

    return PsrProcessor::ACK;
});

$consumer->consume();

```

TODO: 

* [ ] tests
* [ ] docs
