### PR TITLE
[WIP] Amqp interop handler.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "php-console/php-console": "^3.1.3",
         "jakub-onderka/php-parallel-lint": "^0.9",
         "predis/predis": "^1.1",
-        "phpspec/prophecy": "^1.6.1"
+        "phpspec/prophecy": "^1.6.1",
+        "queue-interop/queue-interop": "^0.5"
     },
     "suggest": {
         "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
@@ -41,7 +42,8 @@
         "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
         "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
         "rollbar/rollbar": "Allow sending log messages to Rollbar",
-        "php-console/php-console": "Allow sending log messages to Google Chrome"
+        "php-console/php-console": "Allow sending log messages to Google Chrome",
+        "queue-interop/queue-interop": "Allow sending log messages to any MQ compatible with queue-interop"
     },
     "autoload": {
         "psr-4": {"Monolog\\": "src/Monolog"}

--- a/src/Monolog/Handler/AmqpInteropHandler.php
+++ b/src/Monolog/Handler/AmqpInteropHandler.php
@@ -89,8 +89,22 @@ class AmqpInteropHandler extends AbstractProcessingHandler
         $message = $this->context->createMessage($record["formatted"]);
         $message->setContentType('application/json');
         $message->setDeliveryMode(AmqpMessage::DELIVERY_MODE_PERSISTENT);
+        $message->setRoutingKey($this->getRoutingKey($record));
 
         $this->context->createProducer()->send($this->destination, $message);
+    }
+
+    /**
+     * Gets the routing key for the AMQP exchange
+     *
+     * @param  array  $record
+     * @return string
+     */
+    private function getRoutingKey(array $record)
+    {
+        $routingKey = sprintf('%s.%s', $record['level_name'], $record['channel']);
+
+        return strtolower($routingKey);
     }
 
     /**

--- a/src/Monolog/Handler/AmqpInteropHandler.php
+++ b/src/Monolog/Handler/AmqpInteropHandler.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Interop\Amqp\AmqpContext;
+use Interop\Amqp\AmqpDestination;
+use Interop\Amqp\AmqpMessage;
+use Interop\Amqp\AmqpQueue;
+use Interop\Amqp\AmqpTopic;
+use Monolog\Logger;
+use Monolog\Formatter\JsonFormatter;
+
+class AmqpInteropHandler extends AbstractProcessingHandler
+{
+    /**
+     * @var AmqpContext
+     */
+    private $context;
+
+    /**
+     * @var AmqpDestination
+     */
+    private $destination;
+
+    /**
+     * @var bool
+     */
+    private $shouldDeclare;
+
+    /**
+     * @var bool
+     */
+    private $wasDeclared;
+
+    /**
+     * @param AmqpContext            $context
+     * @param AmqpDestination|string $destination
+     * @param int                    $level
+     * @param bool                   $bubble Whether the messages that are handled can bubble up the stack or not
+     */
+    public function __construct(AmqpContext $context, $destination = 'log', $level = Logger::DEBUG, $bubble = true)
+    {
+        $this->context = $context;
+        $this->shouldDeclare = true;
+        $this->wasDelcared = false;
+
+        if (false == $destination instanceof AmqpDestination) {
+            $destination = $this->context->createQueue($destination);
+        }
+
+        $this->destination = $destination;
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * @param bool $shouldDeclare
+     */
+    public function setShouldDeclare(bool $shouldDeclare)
+    {
+        $this->shouldDeclare = $shouldDeclare;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function write(array $record)
+    {
+        if ($this->shouldDeclare && false == $this->wasDeclared) {
+            if ($this->destination instanceof AmqpTopic) {
+                $this->context->declareTopic($this->destination);
+            }
+            if ($this->destination instanceof AmqpQueue) {
+                $this->context->declareQueue($this->destination);
+            }
+
+            $this->wasDeclared = true;
+        }
+
+        $message = $this->context->createMessage($record["formatted"]);
+        $message->setContentType('application/json');
+        $message->setDeliveryMode(AmqpMessage::DELIVERY_MODE_PERSISTENT);
+
+        $this->context->createProducer()->send($this->destination, $message);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDefaultFormatter()
+    {
+        return new JsonFormatter(JsonFormatter::BATCH_MODE_JSON, false);
+    }
+}

--- a/src/Monolog/Handler/QueueInteropHandler.php
+++ b/src/Monolog/Handler/QueueInteropHandler.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Interop\Queue\PsrContext;
+use Interop\Queue\PsrDestination;
+use Monolog\Logger;
+use Monolog\Formatter\JsonFormatter;
+
+class QueueInteropHandler extends AbstractProcessingHandler
+{
+    /**
+     * @var PsrContext
+     */
+    private $context;
+
+    /**
+     * @var PsrDestination
+     */
+    private $destination;
+
+    /**
+     * @param PsrContext $context
+     * @param PsrDestination|string    $destination
+     * @param int                      $level
+     * @param bool                     $bubble       Whether the messages that are handled can bubble up the stack or not
+     */
+    public function __construct(PsrContext $context, $destination = 'log', $level = Logger::DEBUG, $bubble = true)
+    {
+        $this->context = $context;
+
+        if (false == $destination instanceof PsrDestination) {
+            $destination = $this->context->createTopic($destination);
+        }
+
+        $this->destination = $destination;
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function write(array $record)
+    {
+        $message = $this->context->createMessage($record["formatted"], [
+            'content_type' => 'application/json',
+        ]);
+
+        $this->context->createProducer()->send($this->destination, $message);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getDefaultFormatter()
+    {
+        return new JsonFormatter(JsonFormatter::BATCH_MODE_JSON, false);
+    }
+}

--- a/src/Monolog/Handler/QueueInteropHandler.php
+++ b/src/Monolog/Handler/QueueInteropHandler.php
@@ -39,7 +39,7 @@ class QueueInteropHandler extends AbstractProcessingHandler
         $this->context = $context;
 
         if (false == $destination instanceof PsrDestination) {
-            $destination = $this->context->createTopic($destination);
+            $destination = $this->context->createQueue($destination);
         }
 
         $this->destination = $destination;


### PR DESCRIPTION
based on https://github.com/Seldaek/monolog/pull/1033, and should be merged after that one only. 

It is better than [AmqpHandler](https://github.com/Seldaek/monolog/blob/master/src/Monolog/Handler/AmqpHandler.php) in several ways

* monolog is not coupled to amqp implementation but only interfaces.
* monolog can work with any amqp-interop compatible trnasport. There are amqp-interop transports that work on top of phpamqplib as well as php-amqp extension.
* it can declare exchange