### PR TITLE
s/Boolean/boolean/

### DIFF
--- a/src/Monolog/Handler/HandlerInterface.php
+++ b/src/Monolog/Handler/HandlerInterface.php
@@ -29,7 +29,7 @@ interface HandlerInterface
      *
      * @param array $record Partial log record containing only a level key
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isHandling(array $record): bool;
 
@@ -44,7 +44,7 @@ interface HandlerInterface
      * calling further handlers in the stack with a given log record.
      *
      * @param  array   $record The record to handle
-     * @return Boolean true means that this handler handled the record, and that bubbling is not permitted.
+     * @return boolean true means that this handler handled the record, and that bubbling is not permitted.
      *                        false means the record was either not processed or that this handler allows bubbling.
      */
     public function handle(array $record): bool;


### PR DESCRIPTION
Having `@return` specify `Boolean` (with initial capital 'B') causes some static analyzers think it's a class (`Monolog\Handler\Boolean`). Also, it's not allowed according to phpdocumentor's BNF[1] (it only accepts all-lowercase version).

[1] https://www.phpdoc.org/docs/latest/references/phpdoc/types.html