### PR TITLE
Remove misleading reference to RFC 5424 standard

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -87,8 +87,6 @@ class Logger implements LoggerInterface
     const API = 2;
 
     /**
-     * Logging levels from syslog protocol defined in RFC 5424
-     *
      * This is a static variable and not a constant to serve as an extension point for custom levels
      *
      * @var string[] $levels Logging levels with the levels as key


### PR DESCRIPTION
Log levels (both the severity and the code) used here are not [RFC 5424](https://www.rfc-editor.org/rfc/rfc5424.txt) compliant.

I find it would be better off removing the misleading comment than changing log levels for end-users.