### PR TITLE
Check for directory before throwing 'no existing directory' exception

### DIFF
--- a/src/Monolog/Handler/StreamHandler.php
+++ b/src/Monolog/Handler/StreamHandler.php
@@ -169,7 +169,7 @@ class StreamHandler extends AbstractProcessingHandler
             set_error_handler([$this, 'customErrorHandler']);
             $status = mkdir($dir, 0777, true);
             restore_error_handler();
-            if (false === $status) {
+            if (false === $status && !is_dir($dir)) {
                 throw new \UnexpectedValueException(sprintf('There is no existing directory at "%s" and its not buildable: '.$this->errorMessage, $dir));
             }
         }


### PR DESCRIPTION
In `StreamHandler::createDir()` it's possible for a directory to be created (by another request for example) between checking if the directory exists and actually attempting to create the directory. As a result it's possible that an `UnexpectedValueException` will be thrown even if the directory exists, since `mkdir` will error in this situation.

This PR simply adds an additional test for the absence of the directory before throwing the exception.