### PR TITLE
Sync RollbarHandler with the latest changes rollbar/rollbar package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "php-console/php-console": "^3.1.3",
         "jakub-onderka/php-parallel-lint": "^0.9",
         "predis/predis": "^1.1",
-        "phpspec/prophecy": "^1.6.1"
+        "phpspec/prophecy": "^1.6.1",
+        "rollbar/rollbar": "^1.3"
     },
     "suggest": {
         "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",

--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,7 @@
         "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
         "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
         "rollbar/rollbar": "Allow sending log messages to Rollbar",
-        "php-console/php-console": "Allow sending log messages to Google Chrome",
-        "rollbar/rollbar": "^1.3"
+        "php-console/php-console": "Allow sending log messages to Google Chrome"
     },
     "autoload": {
         "psr-4": {"Monolog\\": "src/Monolog"}

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "psr/log": "^1.0.1",
-        "rollbar/rollbar": "^1.3"
+        "psr/log": "^1.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",
@@ -42,7 +41,8 @@
         "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
         "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
         "rollbar/rollbar": "Allow sending log messages to Rollbar",
-        "php-console/php-console": "Allow sending log messages to Google Chrome"
+        "php-console/php-console": "Allow sending log messages to Google Chrome",
+        "rollbar/rollbar": "^1.3"
     },
     "autoload": {
         "psr-4": {"Monolog\\": "src/Monolog"}

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "psr/log": "^1.0.1",
-        "rollbar/rollbar": "^1.3"
+        "psr/log": "^1.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     ],
     "require": {
         "php": "^7.0",
-        "psr/log": "^1.0.1"
+        "psr/log": "^1.0.1",
+        "rollbar/rollbar": "^1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/src/Monolog/Handler/RollbarHandler.php
+++ b/src/Monolog/Handler/RollbarHandler.php
@@ -11,7 +11,7 @@
 
 namespace Monolog\Handler;
 
-use RollbarNotifier;
+use Rollbar\RollbarLogger;
 use Throwable;
 use Monolog\Logger;
 
@@ -19,7 +19,7 @@ use Monolog\Logger;
  * Sends errors to Rollbar
  *
  * If the context data contains a `payload` key, that is used as an array
- * of payload options to RollbarNotifier's report_message/report_exception methods.
+ * of payload options to RollbarLogger's log method.
  *
  * Rollbar's context info will contain the context + extra keys from the log record
  * merged, and then on top of that a few keys:
@@ -34,11 +34,9 @@ use Monolog\Logger;
 class RollbarHandler extends AbstractProcessingHandler
 {
     /**
-     * Rollbar notifier
-     *
-     * @var RollbarNotifier
+     * @var RollbarLogger
      */
-    protected $rollbarNotifier;
+    protected $rollbarLogger;
 
     protected $levelMap = [
         Logger::DEBUG     => 'debug',
@@ -61,13 +59,13 @@ class RollbarHandler extends AbstractProcessingHandler
     protected $initialized = false;
 
     /**
-     * @param RollbarNotifier $rollbarNotifier RollbarNotifier object constructed with valid token
+     * @param RollbarLogger   $rollbarLogger   RollbarLogger object constructed with valid token
      * @param int             $level           The minimum logging level at which this handler will be triggered
      * @param bool            $bubble          Whether the messages that are handled can bubble up the stack or not
      */
-    public function __construct(RollbarNotifier $rollbarNotifier, $level = Logger::ERROR, $bubble = true)
+    public function __construct(RollbarLogger $rollbarLogger, $level = Logger::ERROR, $bubble = true)
     {
-        $this->rollbarNotifier = $rollbarNotifier;
+        $this->rollbarLogger = $rollbarLogger;
 
         parent::__construct($level, $bubble);
     }
@@ -84,11 +82,6 @@ class RollbarHandler extends AbstractProcessingHandler
         }
 
         $context = $record['context'];
-        $payload = [];
-        if (isset($context['payload'])) {
-            $payload = $context['payload'];
-            unset($context['payload']);
-        }
         $context = array_merge($context, $record['extra'], [
             'level' => $this->levelMap[$record['level']],
             'monolog_level' => $record['level_name'],
@@ -97,19 +90,14 @@ class RollbarHandler extends AbstractProcessingHandler
         ]);
 
         if (isset($context['exception']) && $context['exception'] instanceof Throwable) {
-            $payload['level'] = $context['level'];
             $exception = $context['exception'];
             unset($context['exception']);
-
-            $this->rollbarNotifier->report_exception($exception, $context, $payload);
+            $toLog = $exception;
         } else {
-            $this->rollbarNotifier->report_message(
-                $record['message'],
-                $context['level'],
-                $context,
-                $payload
-            );
+            $toLog = $record['message'];
         }
+        
+        $this->rollbarLogger->log($context['level'], $toLog, $context);
 
         $this->hasRecords = true;
     }
@@ -117,7 +105,7 @@ class RollbarHandler extends AbstractProcessingHandler
     public function flush()
     {
         if ($this->hasRecords) {
-            $this->rollbarNotifier->flush();
+            $this->rollbarLogger->flush();
             $this->hasRecords = false;
         }
     }

--- a/src/Monolog/Handler/RollbarHandler.php
+++ b/src/Monolog/Handler/RollbarHandler.php
@@ -19,7 +19,7 @@ use Monolog\Logger;
  * Sends errors to Rollbar
  *
  * If the context data contains a `payload` key, that is used as an array
- * of payload options to RollbarLogger's log method.
+ * of payload options to RollbarLogger's log method. 
  *
  * Rollbar's context info will contain the context + extra keys from the log record
  * merged, and then on top of that a few keys:

--- a/tests/Monolog/Handler/RollbarHandlerTest.php
+++ b/tests/Monolog/Handler/RollbarHandlerTest.php
@@ -41,10 +41,32 @@ class RollbarHandlerTest extends TestCase
 
         $this->setupRollbarLoggerMock();
     }
+    
+    protected function checkRequirements()
+    {
+        parent::checkRequirements();
+        
+        $annotations = $this->getAnnotations();
+
+        foreach (['class', 'method'] as $depth) {
+            if (empty($annotations[$depth]['requires'])) {
+                continue;
+            }
+    
+            $requires = array_flip($annotations[$depth]['requires']);
+    
+            if (isset($requires['Rollbar']) && !class_exists(\Rollbar\Rollbar::class) ) {
+                $this->markTestSkipped('This test only runs if suggested package rollbar/rollbar is installed.');
+            }
+        }
+
+    }
 
     /**
      * When reporting exceptions to Rollbar the
      * level has to be set in the payload data
+     * 
+     * @requires Rollbar
      */
     public function testExceptionLogLevel()
     {

--- a/tests/Monolog/Handler/RollbarHandlerTest.php
+++ b/tests/Monolog/Handler/RollbarHandlerTest.php
@@ -41,32 +41,10 @@ class RollbarHandlerTest extends TestCase
 
         $this->setupRollbarLoggerMock();
     }
-    
-    protected function checkRequirements()
-    {
-        parent::checkRequirements();
-        
-        $annotations = $this->getAnnotations();
-
-        foreach (['class', 'method'] as $depth) {
-            if (empty($annotations[$depth]['requires'])) {
-                continue;
-            }
-    
-            $requires = array_flip($annotations[$depth]['requires']);
-    
-            if (isset($requires['Rollbar']) && !class_exists(\Rollbar\Rollbar::class) ) {
-                $this->markTestSkipped('This test only runs if suggested package rollbar/rollbar is installed.');
-            }
-        }
-
-    }
 
     /**
      * When reporting exceptions to Rollbar the
      * level has to be set in the payload data
-     * 
-     * @requires Rollbar
      */
     public function testExceptionLogLevel()
     {


### PR DESCRIPTION
We received a request to update Monolog's `RollbarHandler` to be in sync with the latest version of our SDK ( https://github.com/rollbar/rollbar-php ). The github issue can be found here: https://github.com/rollbar/rollbar-php/issues/249

This PR makes the `RollbarHandler` up to date with `rollbar-php` v1.0+.

Please, review and merge to master if it looks good to go.