### PR TITLE
Don't stop processing other handlers if one fails

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -315,10 +315,12 @@ class Logger implements LoggerInterface
         }
 
         while ($handler = current($this->handlers)) {
-            if (true === $handler->handle($record)) {
-                break;
-            }
-
+            try {
+                if (true === $handler->handle($record)) {
+                    break;
+                }
+            } catch (\Exception $e) {}
+            
             next($this->handlers);
         }
 


### PR DESCRIPTION
If one handler throws exception while processing the record the other ones won't process the record because of the exception.

I suggest you surround that part with a try catch, so all handlers will try to logg properly the record.
That way will be more fault tolerant the logging.