### PR TITLE
Normalization of arrays containing self references

### DIFF
--- a/src/Monolog/Formatter/JsonFormatter.php
+++ b/src/Monolog/Formatter/JsonFormatter.php
@@ -138,8 +138,12 @@ class JsonFormatter extends NormalizerFormatter
      *
      * @return mixed
      */
-    protected function normalize($data)
+    protected function normalize($data, $depth = 0)
     {
+        if ($depth > 9) {
+            return 'Over 9 levels deep, aborting normalization';
+        }
+
         if (is_array($data) || $data instanceof \Traversable) {
             $normalized = array();
 
@@ -149,7 +153,7 @@ class JsonFormatter extends NormalizerFormatter
                     $normalized['...'] = 'Over 1000 items, aborting normalization';
                     break;
                 }
-                $normalized[$key] = $this->normalize($value);
+                $normalized[$key] = $this->normalize($value, $depth+1);
             }
 
             return $normalized;

--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -55,8 +55,12 @@ class NormalizerFormatter implements FormatterInterface
         return $records;
     }
 
-    protected function normalize($data)
+    protected function normalize($data, $depth = 0)
     {
+        if ($depth > 9) {
+            return 'Over 9 levels deep, aborting normalization';
+        }
+
         if (null === $data || is_scalar($data)) {
             if (is_float($data)) {
                 if (is_infinite($data)) {
@@ -79,7 +83,7 @@ class NormalizerFormatter implements FormatterInterface
                     $normalized['...'] = 'Over 1000 items ('.count($data).' total), aborting normalization';
                     break;
                 }
-                $normalized[$key] = $this->normalize($value);
+                $normalized[$key] = $this->normalize($value, $depth+1);
             }
 
             return $normalized;

--- a/src/Monolog/Formatter/WildfireFormatter.php
+++ b/src/Monolog/Formatter/WildfireFormatter.php
@@ -102,12 +102,12 @@ class WildfireFormatter extends NormalizerFormatter
         throw new \BadMethodCallException('Batch formatting does not make sense for the WildfireFormatter');
     }
 
-    protected function normalize($data)
+    protected function normalize($data, $depth = 0)
     {
         if (is_object($data) && !$data instanceof \DateTime) {
             return $data;
         }
 
-        return parent::normalize($data);
+        return parent::normalize($data, $depth);
     }
 }

--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -193,6 +193,15 @@ class NormalizerFormatterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(@json_encode(array($foo, $bar)), $res);
     }
 
+    public function testCanNormalizeReferences()
+    {
+        $formatter = new NormalizerFormatter();
+        $x = ['foo' => 'bar'];
+        $y = ['x' => &$x];
+        $x['y'] = &$y;
+        $formatter->format($y);
+    }
+
     public function testIgnoresInvalidTypes()
     {
         // set up the recursion

--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -196,8 +196,8 @@ class NormalizerFormatterTest extends \PHPUnit_Framework_TestCase
     public function testCanNormalizeReferences()
     {
         $formatter = new NormalizerFormatter();
-        $x = ['foo' => 'bar'];
-        $y = ['x' => &$x];
+        $x = array('foo' => 'bar');
+        $y = array('x' => &$x);
         $x['y'] = &$y;
         $formatter->format($y);
     }


### PR DESCRIPTION
Backport of #808 for issue #924 .

`Monolog\Handler\StreamHandlerTest::testWriteNonExistingResource` is hanging on my machine on 1.x, so we'll see what happens in Travis.