### PR TITLE
Change private to protected

### DIFF
--- a/src/Monolog/Handler/SlackWebhookHandler.php
+++ b/src/Monolog/Handler/SlackWebhookHandler.php
@@ -27,13 +27,13 @@ class SlackWebhookHandler extends AbstractProcessingHandler
      * Slack Webhook token
      * @var string
      */
-    private $webhookUrl;
+    protected $webhookUrl;
 
     /**
      * Instance of the SlackRecord util class preparing data for Slack API.
      * @var SlackRecord
      */
-    private $slackRecord;
+    protected $slackRecord;
 
     /**
      * @param string      $webhookUrl             Slack Webhook URL


### PR DESCRIPTION
See: https://github.com/Seldaek/monolog/issues/1039

Also, in similar handler classes (see: [mandrill](https://github.com/Seldaek/monolog/blob/master/src/Monolog/Handler/MandrillHandler.php) or [newrelic](https://github.com/Seldaek/monolog/blob/master/src/Monolog/Handler/NewRelicHandler.php)), all properties are `protected` (and not `private`)