### PR TITLE
Include InsightOps handler

### DIFF
--- a/doc/02-handlers-formatters-processors.md
+++ b/doc/02-handlers-formatters-processors.md
@@ -55,6 +55,7 @@
 - _RollbarHandler_: Logs records to a [Rollbar](https://rollbar.com/) account.
 - _SyslogUdpHandler_: Logs records to a remote [Syslogd](http://www.rsyslog.com/) server.
 - _LogEntriesHandler_: Logs records to a [LogEntries](http://logentries.com/) account.
+- _InsightOpsHandler_: Logs records to a [InsightOps](https://www.rapid7.com/products/insightops/) account.
 
 ### Logging in development
 

--- a/src/Monolog/Handler/InsightOpsHandler.php
+++ b/src/Monolog/Handler/InsightOpsHandler.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+ namespace Monolog\Handler;
+ 
+ use Monolog\Logger;
+
+/**
+ * Inspired on LogEntriesHandler.
+ *
+ * @author Robert Kaufmann III <rok3@rok3.me>
+ * @author Gabriel Machado <gabriel.ms1@hotmail.com>
+ */
+class InsightOpsHandler extends SocketHandler
+{
+    /**
+     * @var string
+     */
+    protected $logToken;
+
+    /**
+     * @param string $token  Log token supplied by InsightOps
+     * @param string $region Region where InsightOps account is hosted. Could be 'us' or 'eu'.
+     * @param bool   $useSSL Whether or not SSL encryption should be used
+     * @param int    $level  The minimum logging level to trigger this handler
+     * @param bool   $bubble Whether or not messages that are handled should bubble up the stack.
+     *
+     * @throws MissingExtensionException If SSL encryption is set to true and OpenSSL is missing
+     */
+    public function __construct($token, $region = 'us', $useSSL = true, $level = Logger::DEBUG, $bubble = true)
+    {
+        if ($useSSL && !extension_loaded('openssl')) {
+            throw new MissingExtensionException('The OpenSSL PHP plugin is required to use SSL encrypted connection for LogEntriesHandler');
+        }
+
+        $endpoint = $useSSL
+            ? 'ssl://' . $region . '.data.logs.insight.rapid7.com:443'
+            : $region . '.data.logs.insight.rapid7.com:80';
+
+        parent::__construct($endpoint, $level, $bubble);
+        $this->logToken = $token;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param  array  $record
+     * @return string
+     */
+    protected function generateDataStream($record)
+    {
+        return $this->logToken . ' ' . $record['formatted'];
+    }
+}

--- a/tests/Monolog/Handler/InsightOpsHandlerTest.php
+++ b/tests/Monolog/Handler/InsightOpsHandlerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+ namespace Monolog\Handler;
+ 
+ use Monolog\TestCase;
+ use Monolog\Logger;
+
+/**
+ * @author Robert Kaufmann III <rok3@rok3.me>
+ * @author Gabriel Machado <gabriel.ms1@hotmail.com>
+ */
+class InsightOpsHandlerTest extends TestCase
+{
+    /**
+     * @var resource
+     */
+    private $resource;
+
+    /**
+     * @var LogEntriesHandler
+     */
+    private $handler;
+
+    public function testWriteContent()
+    {
+        $this->createHandler();
+        $this->handler->handle($this->getRecord(Logger::CRITICAL, 'Critical write test'));
+
+        fseek($this->resource, 0);
+        $content = fread($this->resource, 1024);
+
+        $this->assertRegexp('/testToken \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] test.CRITICAL: Critical write test/', $content);
+    }
+
+    public function testWriteBatchContent()
+    {
+        $this->createHandler();
+        $this->handler->handleBatch($this->getMultipleRecords());
+
+        fseek($this->resource, 0);
+        $content = fread($this->resource, 1024);
+
+        $this->assertRegexp('/(testToken \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] .* \[\] \[\]\n){3}/', $content);
+    }
+
+    private function createHandler()
+    {
+        $useSSL = extension_loaded('openssl');
+        $args = array('testToken', 'us', $useSSL, Logger::DEBUG, true);
+        $this->resource = fopen('php://memory', 'a');
+        $this->handler = $this->getMock(
+            '\Monolog\Handler\InsightOpsHandler',
+            array('fsockopen', 'streamSetTimeout', 'closeSocket'),
+            $args
+        );
+
+        $reflectionProperty = new \ReflectionProperty('\Monolog\Handler\SocketHandler', 'connectionString');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($this->handler, 'localhost:1234');
+
+        $this->handler->expects($this->any())
+            ->method('fsockopen')
+            ->will($this->returnValue($this->resource));
+        $this->handler->expects($this->any())
+            ->method('streamSetTimeout')
+            ->will($this->returnValue(true));
+        $this->handler->expects($this->any())
+            ->method('closeSocket')
+            ->will($this->returnValue(true));
+    }
+}


### PR DESCRIPTION
[Rapid7 bought Logentries](https://www.rapid7.com/about/press-releases/rapid7-acquires-logentries/) and decided to [rebrand it to InsightOps](https://www.rapid7.com/info/logentries-insightops/).

InsightOps works the same way that LogEntries, except that a new endpoint (either on Europe or US) is used.

Since Monolog supports LogEntries, I think its good to support InsightOps as well.