### PR TITLE
Fix Comparison operator in RotatingFileHandler

### DIFF
--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -98,7 +98,7 @@ class RotatingFileHandler extends StreamHandler
             $this->mustRotate = !file_exists($this->url);
         }
 
-        if ($this->nextRotation < $record['datetime']) {
+        if ($this->nextRotation <= $record['datetime']) {
             $this->mustRotate = true;
             $this->close();
         }


### PR DESCRIPTION
This fixes the handling of comparing $this->nextRotation and $record['datetime'] whether Log-file must be rotated.
At present, Log-file can't be rotated in the case of just 'YYYY-MM-DD 00:00:00.000000'.
