### PR TITLE
Change LogstashFormatter prefix properties to keys

### DIFF
--- a/src/Monolog/Formatter/LogstashFormatter.php
+++ b/src/Monolog/Formatter/LogstashFormatter.php
@@ -32,30 +32,30 @@ class LogstashFormatter extends NormalizerFormatter
     protected $applicationName;
 
     /**
-     * @var string a prefix for 'extra' fields from the Monolog record (optional)
+     * @var string the key for 'extra' fields from the Monolog record
      */
-    protected $extraPrefix;
+    protected $extraKey;
 
     /**
-     * @var string a prefix for 'context' fields from the Monolog record (optional)
+     * @var string the key for 'context' fields from the Monolog record
      */
-    protected $contextPrefix;
+    protected $contextKey;
 
     /**
      * @param string $applicationName the application that sends the data, used as the "type" field of logstash
      * @param string $systemName      the system/machine name, used as the "source" field of logstash, defaults to the hostname of the machine
-     * @param string $extraPrefix     prefix for extra keys inside logstash "fields"
-     * @param string $contextPrefix   prefix for context keys inside logstash "fields", defaults to ctxt_
+     * @param string $extraKey        the key for extra keys inside logstash "fields", defaults to extra
+     * @param string $contextKey      the key for context keys inside logstash "fields", defaults to context
      */
-    public function __construct(string $applicationName, string $systemName = null, string $extraPrefix = null, string $contextPrefix = 'ctxt_')
+    public function __construct(string $applicationName, string $systemName = null, string $extraKey = 'extra', string $contextKey = 'context')
     {
         // logstash requires a ISO 8601 format date with optional millisecond precision.
         parent::__construct('Y-m-d\TH:i:s.uP');
 
         $this->systemName = $systemName ?: gethostname();
         $this->applicationName = $applicationName;
-        $this->extraPrefix = $extraPrefix;
-        $this->contextPrefix = $contextPrefix;
+        $this->extraKey = $extraKey;
+        $this->contextKey = $contextKey;
     }
 
     /**
@@ -90,10 +90,10 @@ class LogstashFormatter extends NormalizerFormatter
             $message['type'] = $this->applicationName;
         }
         if (!empty($record['extra'])) {
-            $message[$this->extraPrefix.'extra'] = $record['extra'];
+            $message[$this->extraKey] = $record['extra'];
         }
         if (!empty($record['context'])) {
-            $message[$this->contextPrefix.'context'] = $record['context'];
+            $message[$this->contextKey] = $record['context'];
         }
 
         return $this->toJson($message) . "\n";

--- a/tests/Monolog/Formatter/LogstashFormatterTest.php
+++ b/tests/Monolog/Formatter/LogstashFormatterTest.php
@@ -27,7 +27,7 @@ class LogstashFormatterTest extends \PHPUnit\Framework\TestCase
      */
     public function testDefaultFormatterV1()
     {
-        $formatter = new LogstashFormatter('test', 'hostname', null, 'ctxt_');
+        $formatter = new LogstashFormatter('test', 'hostname');
         $record = [
             'level' => Logger::ERROR,
             'level_name' => 'ERROR',
@@ -49,7 +49,7 @@ class LogstashFormatterTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('test', $message['type']);
         $this->assertEquals('hostname', $message['host']);
 
-        $formatter = new LogstashFormatter('mysystem', null, null, 'ctxt_');
+        $formatter = new LogstashFormatter('mysystem');
 
         $message = json_decode($formatter->format($record), true);
 
@@ -61,7 +61,7 @@ class LogstashFormatterTest extends \PHPUnit\Framework\TestCase
      */
     public function testFormatWithFileAndLineV1()
     {
-        $formatter = new LogstashFormatter('test', null, null, 'ctxt_');
+        $formatter = new LogstashFormatter('test');
         $record = [
             'level' => Logger::ERROR,
             'level_name' => 'ERROR',
@@ -83,7 +83,7 @@ class LogstashFormatterTest extends \PHPUnit\Framework\TestCase
      */
     public function testFormatWithContextV1()
     {
-        $formatter = new LogstashFormatter('test', null, null, 'ctxt_');
+        $formatter = new LogstashFormatter('test');
         $record = [
             'level' => Logger::ERROR,
             'level_name' => 'ERROR',
@@ -96,17 +96,17 @@ class LogstashFormatterTest extends \PHPUnit\Framework\TestCase
 
         $message = json_decode($formatter->format($record), true);
 
-        $this->assertArrayHasKey('ctxt_context', $message);
-        $this->assertArrayHasKey('from', $message['ctxt_context']);
-        $this->assertEquals('logger', $message['ctxt_context']['from']);
+        $this->assertArrayHasKey('context', $message);
+        $this->assertArrayHasKey('from', $message['context']);
+        $this->assertEquals('logger', $message['context']['from']);
 
         // Test with extraPrefix
-        $formatter = new LogstashFormatter('test', null, null, 'CTX');
+        $formatter = new LogstashFormatter('test', null, 'extra', 'CTX');
         $message = json_decode($formatter->format($record), true);
 
-        $this->assertArrayHasKey('CTXcontext', $message);
-        $this->assertArrayHasKey('from', $message['CTXcontext']);
-        $this->assertEquals('logger', $message['CTXcontext']['from']);
+        $this->assertArrayHasKey('CTX', $message);
+        $this->assertArrayHasKey('from', $message['CTX']);
+        $this->assertEquals('logger', $message['CTX']['from']);
     }
 
     /**
@@ -114,7 +114,7 @@ class LogstashFormatterTest extends \PHPUnit\Framework\TestCase
      */
     public function testFormatWithExtraV1()
     {
-        $formatter = new LogstashFormatter('test', null, null, 'ctxt_');
+        $formatter = new LogstashFormatter('test');
         $record = [
             'level' => Logger::ERROR,
             'level_name' => 'ERROR',
@@ -132,17 +132,17 @@ class LogstashFormatterTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('pair', $message['extra']['key']);
 
         // Test with extraPrefix
-        $formatter = new LogstashFormatter('test', null, 'EXT', 'ctxt_');
+        $formatter = new LogstashFormatter('test', null, 'EXTRA');
         $message = json_decode($formatter->format($record), true);
 
-        $this->assertArrayHasKey('EXTextra', $message);
-        $this->assertArrayHasKey('key', $message['EXTextra']);
-        $this->assertEquals('pair', $message['EXTextra']['key']);
+        $this->assertArrayHasKey('EXTRA', $message);
+        $this->assertArrayHasKey('key', $message['EXTRA']);
+        $this->assertEquals('pair', $message['EXTRA']['key']);
     }
 
     public function testFormatWithApplicationNameV1()
     {
-        $formatter = new LogstashFormatter('app', 'test', null, 'ctxt_');
+        $formatter = new LogstashFormatter('app', 'test');
         $record = [
             'level' => Logger::ERROR,
             'level_name' => 'ERROR',


### PR DESCRIPTION
It doesn't really make sense to let half of the key be configurable and the other half hardcoded.
Previously, the prefixes made sense because it wasn't a nested array so each key was dynamic.