### PR TITLE
Fixing file rotation when similar files are present

### DIFF
--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -166,7 +166,7 @@ class RotatingFileHandler extends StreamHandler
         $fileInfo = pathinfo($this->filename);
         $glob = str_replace(
             ['{filename}', '{date}'],
-            [$fileInfo['filename'], '*'],
+            [$fileInfo['filename'], '[0-9][0-9][0-9][0-9]*'],
             $fileInfo['dirname'] . '/' . $this->filenameFormat
         );
         if (!empty($fileInfo['extension'])) {

--- a/tests/Monolog/Handler/RotatingFileHandlerTest.php
+++ b/tests/Monolog/Handler/RotatingFileHandlerTest.php
@@ -193,6 +193,40 @@ class RotatingFileHandlerTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider rotationWhenSimilarFilesExistTests
+     */
+    public function testRotationWhenSimilarFileNamesExist($dateFormat)
+    {
+        touch($old1 = __DIR__.'/Fixtures/foo-foo-'.date($dateFormat).'.rot');
+        touch($old2 = __DIR__.'/Fixtures/foo-bar-'.date($dateFormat).'.rot');
+
+        $log = __DIR__.'/Fixtures/foo-'.date($dateFormat).'.rot';
+
+        $handler = new RotatingFileHandler(__DIR__.'/Fixtures/foo.rot', 2);
+        $handler->setFormatter($this->getIdentityFormatter());
+        $handler->setFilenameFormat('{filename}-{date}', $dateFormat);
+        $handler->handle($this->getRecord());
+        $handler->close();
+
+        $this->assertTrue(file_exists($log));
+    }
+
+    public function rotationWhenSimilarFilesExistTests()
+    {
+
+        return [
+            'Rotation is triggered when the file of the current day is not present but similar exists'
+                => [RotatingFileHandler::FILE_PER_DAY],
+
+            'Rotation is triggered when the file of the current month is not present but similar exists'
+                => [RotatingFileHandler::FILE_PER_MONTH],
+
+            'Rotation is triggered when the file of the current year is not present but similar exists'
+                => [RotatingFileHandler::FILE_PER_YEAR],
+        ];
+    }
+
     public function testReuseCurrentFile()
     {
         $log = __DIR__.'/Fixtures/foo-'.date('Y-m-d').'.rot';


### PR DESCRIPTION
When file rotate is active and there are files with similar names like dev-2017-08-18.log and dev-doctrine-2017-08-18.log and dev-requests-2017-08-18.log the current Glob pattern will match all of them and not the one we want. The problem was that if we had set it up for max files to be 2 and file dev-2017-08-18.log was not present It will have not been created. Changing the pattern from * to [0-9][0-9][0-9][0-9]* will make the matching more targeted to the file we want.