### PR TITLE
Update Docblock to specify allowing string Log Levels

### DIFF
--- a/src/Monolog/Handler/AbstractHandler.php
+++ b/src/Monolog/Handler/AbstractHandler.php
@@ -24,8 +24,8 @@ abstract class AbstractHandler extends Handler
     protected $bubble = true;
 
     /**
-     * @param int     $level  The minimum logging level at which this handler will be triggered
-     * @param Boolean $bubble Whether the messages that are handled can bubble up the stack or not
+     * @param int|string $level  The minimum logging level at which this handler will be triggered
+     * @param Boolean    $bubble Whether the messages that are handled can bubble up the stack or not
      */
     public function __construct($level = Logger::DEBUG, $bubble = true)
     {


### PR DESCRIPTION
When running a static analyser against my code, If I'm using Monolog as a PSR-3 Compatible logger, I get a errors similar to the following:-

```
------ --------------------------------------------------------------------------------------------------------- 
  Line   console.php                                                                                              
 ------ --------------------------------------------------------------------------------------------------------- 
  47     Parameter #2 $level of class Monolog\Handler\StreamHandler constructor expects int, mixed|string given.  
  50     Parameter #2 $level of class Monolog\Handler\StreamHandler constructor expects int, string given.        
  57     Parameter #2 $level of class Monolog\Handler\RavenHandler constructor expects int, string given.  
 ------ --------------------------------------------------------------------------------------------------------- 
```

This is a little frustrating, as it boils down to the fact that whilst Monolog will accept a string as a log level - it's docblocks don't reflect the fact.