### PR TITLE
FIX: Fixes #1074 By passing 4th param to captureMessage().

### DIFF
--- a/src/Monolog/Handler/RavenHandler.php
+++ b/src/Monolog/Handler/RavenHandler.php
@@ -184,7 +184,13 @@ class RavenHandler extends AbstractProcessingHandler
             $options['extra']['message'] = $record['formatted'];
             $this->ravenClient->captureException($record['context']['exception'], $options);
         } else {
-            $this->ravenClient->captureMessage($record['formatted'], [], $options);
+            $stack = false;
+            
+            if (!empty($record['stack'])) {
+                $stack = (bool) $record['stack'];
+            }
+            
+            $this->ravenClient->captureMessage($record['formatted'], array(), $options, $stack);
         }
 
         // restore the user context if it was modified


### PR DESCRIPTION
A 4th param is now passed to to `RavenHandler::captureMessage()`