### PR TITLE
Added SlackRecord parameter for markdown supppport in attachments

### DIFF
--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -76,6 +76,12 @@ class SlackRecord
     private $excludeFields;
 
     /**
+     * List of fields to use markdown in when using an attachment
+     * @var [type]
+     */
+    private $markdownIn;
+
+    /**
      * @var FormatterInterface
      */
     private $formatter;
@@ -85,7 +91,7 @@ class SlackRecord
      */
     private $normalizerFormatter;
 
-    public function __construct($channel = null, $username = null, $useAttachment = true, $userIcon = null, $useShortAttachment = false, $includeContextAndExtra = false, array $excludeFields = array(), FormatterInterface $formatter = null)
+    public function __construct($channel = null, $username = null, $useAttachment = true, $userIcon = null, $useShortAttachment = false, $includeContextAndExtra = false, array $excludeFields = array(), array $markdownIn = array(), FormatterInterface $formatter = null)
     {
         $this->channel = $channel;
         $this->username = $username;
@@ -94,6 +100,7 @@ class SlackRecord
         $this->useShortAttachment = $useShortAttachment;
         $this->includeContextAndExtra = $includeContextAndExtra;
         $this->excludeFields = $excludeFields;
+        $this->markdownIn = $markdownIn;
         $this->formatter = $formatter;
 
         if ($this->includeContextAndExtra) {
@@ -126,7 +133,7 @@ class SlackRecord
                 'text'      => $message,
                 'color'     => $this->getAttachmentColor($record['level']),
                 'fields'    => array(),
-                'mrkdwn_in' => array('fields'),
+                'mrkdwn_in' => $this->markdownIn,
                 'ts'        => $record['datetime']->getTimestamp(),
             );
 

--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -48,7 +48,7 @@ class SlackHandler extends SocketHandler
      * @param  array                     $excludeFields          Dot separated list of fields to exclude from slack message. E.g. ['context.field1', 'extra.field2']
      * @throws MissingExtensionException If no OpenSSL PHP extension configured
      */
-    public function __construct($token, $channel, $username = null, $useAttachment = true, $iconEmoji = null, $level = Logger::CRITICAL, $bubble = true, $useShortAttachment = false, $includeContextAndExtra = false, array $excludeFields = array())
+    public function __construct($token, $channel, $username = null, $useAttachment = true, $iconEmoji = null, $level = Logger::CRITICAL, $bubble = true, $useShortAttachment = false, $includeContextAndExtra = false, array $excludeFields = array(), $markdownIn = array('fields'))
     {
         if (!extension_loaded('openssl')) {
             throw new MissingExtensionException('The OpenSSL PHP extension is required to use the SlackHandler');
@@ -64,6 +64,7 @@ class SlackHandler extends SocketHandler
             $useShortAttachment,
             $includeContextAndExtra,
             $excludeFields,
+            $markdownIn,
             $this->formatter
         );
 

--- a/src/Monolog/Handler/SlackWebhookHandler.php
+++ b/src/Monolog/Handler/SlackWebhookHandler.php
@@ -46,8 +46,9 @@ class SlackWebhookHandler extends AbstractProcessingHandler
      * @param int         $level                  The minimum logging level at which this handler will be triggered
      * @param bool        $bubble                 Whether the messages that are handled can bubble up the stack or not
      * @param array       $excludeFields          Dot separated list of fields to exclude from slack message. E.g. ['context.field1', 'extra.field2']
+     * @param array       $markdownIn             List of fields to use markdown in when using an attachment
      */
-    public function __construct($webhookUrl, $channel = null, $username = null, $useAttachment = true, $iconEmoji = null, $useShortAttachment = false, $includeContextAndExtra = false, $level = Logger::CRITICAL, $bubble = true, array $excludeFields = array())
+    public function __construct($webhookUrl, $channel = null, $username = null, $useAttachment = true, $iconEmoji = null, $useShortAttachment = false, $includeContextAndExtra = false, $level = Logger::CRITICAL, $bubble = true, array $excludeFields = array(), $markdownIn = array('fields'))
     {
         parent::__construct($level, $bubble);
 
@@ -61,6 +62,7 @@ class SlackWebhookHandler extends AbstractProcessingHandler
             $useShortAttachment,
             $includeContextAndExtra,
             $excludeFields,
+            $markdownIn,
             $this->formatter
         );
     }

--- a/tests/Monolog/Handler/Slack/SlackRecordTest.php
+++ b/tests/Monolog/Handler/Slack/SlackRecordTest.php
@@ -189,7 +189,7 @@ class SlackRecordTest extends TestCase
             }));
 
         $message = 'Test message';
-        $record = new SlackRecord(null, null, false, null, false, false, array(), $formatter);
+        $record = new SlackRecord(null, null, false, null, false, false, array(), array(), $formatter);
         $data = $record->getSlackData($this->getRecord(Logger::WARNING, $message));
 
         $this->assertArrayHasKey('text', $data);


### PR DESCRIPTION
Was attempting to bold messages when using the Slack handler and attachments and it wasn't processing the message as markdown. Currently markdown support is set statically to only 'fields.' Added argument that excepts an array to allow user to allow markdown in 'text' and 'pretext' as allowed in the Slack documentation.