### PR TITLE
Rename Boolean in phpDocs to bool on 1.x

### DIFF
--- a/src/Monolog/Handler/AbstractHandler.php
+++ b/src/Monolog/Handler/AbstractHandler.php
@@ -32,8 +32,8 @@ abstract class AbstractHandler implements HandlerInterface
     protected $processors = array();
 
     /**
-     * @param int     $level  The minimum logging level at which this handler will be triggered
-     * @param Boolean $bubble Whether the messages that are handled can bubble up the stack or not
+     * @param int  $level  The minimum logging level at which this handler will be triggered
+     * @param bool $bubble Whether the messages that are handled can bubble up the stack or not
      */
     public function __construct($level = Logger::DEBUG, $bubble = true)
     {
@@ -141,8 +141,8 @@ abstract class AbstractHandler implements HandlerInterface
     /**
      * Sets the bubbling behavior.
      *
-     * @param  Boolean $bubble true means that this handler allows bubbling.
-     *                         false means that bubbling is not permitted.
+     * @param  bool $bubble true means that this handler allows bubbling.
+     *                      false means that bubbling is not permitted.
      * @return self
      */
     public function setBubble($bubble)
@@ -155,8 +155,8 @@ abstract class AbstractHandler implements HandlerInterface
     /**
      * Gets the bubbling behavior.
      *
-     * @return Boolean true means that this handler allows bubbling.
-     *                 false means that bubbling is not permitted.
+     * @return bool true means that this handler allows bubbling.
+     *              false means that bubbling is not permitted.
      */
     public function getBubble()
     {

--- a/src/Monolog/Handler/AbstractSyslogHandler.php
+++ b/src/Monolog/Handler/AbstractSyslogHandler.php
@@ -53,9 +53,9 @@ abstract class AbstractSyslogHandler extends AbstractProcessingHandler
     );
 
     /**
-     * @param mixed   $facility
-     * @param int     $level    The minimum logging level at which this handler will be triggered
-     * @param Boolean $bubble   Whether the messages that are handled can bubble up the stack or not
+     * @param mixed $facility
+     * @param int   $level The minimum logging level at which this handler will be triggered
+     * @param bool  $bubble Whether the messages that are handled can bubble up the stack or not
      */
     public function __construct($facility = LOG_USER, $level = Logger::DEBUG, $bubble = true)
     {

--- a/src/Monolog/Handler/BufferHandler.php
+++ b/src/Monolog/Handler/BufferHandler.php
@@ -34,8 +34,8 @@ class BufferHandler extends AbstractHandler
      * @param HandlerInterface $handler         Handler.
      * @param int              $bufferLimit     How many entries should be buffered at most, beyond that the oldest items are removed from the buffer.
      * @param int              $level           The minimum logging level at which this handler will be triggered
-     * @param Boolean          $bubble          Whether the messages that are handled can bubble up the stack or not
-     * @param Boolean          $flushOnOverflow If true, the buffer is flushed when the max size has been reached, by default oldest entries are discarded
+     * @param bool             $bubble          Whether the messages that are handled can bubble up the stack or not
+     * @param bool             $flushOnOverflow If true, the buffer is flushed when the max size has been reached, by default oldest entries are discarded
      */
     public function __construct(HandlerInterface $handler, $bufferLimit = 0, $level = Logger::DEBUG, $bubble = true, $flushOnOverflow = false)
     {

--- a/src/Monolog/Handler/ChromePHPHandler.php
+++ b/src/Monolog/Handler/ChromePHPHandler.php
@@ -45,7 +45,7 @@ class ChromePHPHandler extends AbstractProcessingHandler
      *
      * Chrome limits the headers to 256KB, so when we sent 240KB we stop sending
      *
-     * @var Boolean
+     * @var bool
      */
     protected static $overflowed = false;
 
@@ -58,8 +58,8 @@ class ChromePHPHandler extends AbstractProcessingHandler
     protected static $sendHeaders = true;
 
     /**
-     * @param int     $level  The minimum logging level at which this handler will be triggered
-     * @param Boolean $bubble Whether the messages that are handled can bubble up the stack or not
+     * @param int  $level  The minimum logging level at which this handler will be triggered
+     * @param bool $bubble Whether the messages that are handled can bubble up the stack or not
      */
     public function __construct($level = Logger::DEBUG, $bubble = true)
     {

--- a/src/Monolog/Handler/DeduplicationHandler.php
+++ b/src/Monolog/Handler/DeduplicationHandler.php
@@ -60,7 +60,7 @@ class DeduplicationHandler extends BufferHandler
      * @param string           $deduplicationStore The file/path where the deduplication log should be kept
      * @param int              $deduplicationLevel The minimum logging level for log records to be looked at for deduplication purposes
      * @param int              $time               The period (in seconds) during which duplicate entries should be suppressed after a given log is sent through
-     * @param Boolean          $bubble             Whether the messages that are handled can bubble up the stack or not
+     * @param bool             $bubble             Whether the messages that are handled can bubble up the stack or not
      */
     public function __construct(HandlerInterface $handler, $deduplicationStore = null, $deduplicationLevel = Logger::ERROR, $time = 60, $bubble = true)
     {

--- a/src/Monolog/Handler/ElasticSearchHandler.php
+++ b/src/Monolog/Handler/ElasticSearchHandler.php
@@ -46,10 +46,10 @@ class ElasticSearchHandler extends AbstractProcessingHandler
     protected $options = array();
 
     /**
-     * @param Client  $client  Elastica Client object
-     * @param array   $options Handler configuration
-     * @param int     $level   The minimum logging level at which this handler will be triggered
-     * @param Boolean $bubble  Whether the messages that are handled can bubble up the stack or not
+     * @param Client $client  Elastica Client object
+     * @param array  $options Handler configuration
+     * @param int    $level   The minimum logging level at which this handler will be triggered
+     * @param bool   $bubble  Whether the messages that are handled can bubble up the stack or not
      */
     public function __construct(Client $client, array $options = array(), $level = Logger::DEBUG, $bubble = true)
     {

--- a/src/Monolog/Handler/ErrorLogHandler.php
+++ b/src/Monolog/Handler/ErrorLogHandler.php
@@ -28,10 +28,10 @@ class ErrorLogHandler extends AbstractProcessingHandler
     protected $expandNewlines;
 
     /**
-     * @param int     $messageType    Says where the error should go.
-     * @param int     $level          The minimum logging level at which this handler will be triggered
-     * @param Boolean $bubble         Whether the messages that are handled can bubble up the stack or not
-     * @param Boolean $expandNewlines If set to true, newlines in the message will be expanded to be take multiple log entries
+     * @param int  $messageType    Says where the error should go.
+     * @param int  $level          The minimum logging level at which this handler will be triggered
+     * @param bool $bubble         Whether the messages that are handled can bubble up the stack or not
+     * @param bool $expandNewlines If set to true, newlines in the message will be expanded to be take multiple log entries
      */
     public function __construct($messageType = self::OPERATING_SYSTEM, $level = Logger::DEBUG, $bubble = true, $expandNewlines = false)
     {

--- a/src/Monolog/Handler/FilterHandler.php
+++ b/src/Monolog/Handler/FilterHandler.php
@@ -40,7 +40,7 @@ class FilterHandler extends AbstractHandler
     /**
      * Whether the messages that are handled can bubble up the stack or not
      *
-     * @var Boolean
+     * @var bool
      */
     protected $bubble;
 
@@ -48,7 +48,7 @@ class FilterHandler extends AbstractHandler
      * @param callable|HandlerInterface $handler        Handler or factory callable($record, $this).
      * @param int|array                 $minLevelOrList A list of levels to accept or a minimum level if maxLevel is provided
      * @param int                       $maxLevel       Maximum level to accept, only used if $minLevelOrList is not an array
-     * @param Boolean                   $bubble         Whether the messages that are handled can bubble up the stack or not
+     * @param bool                      $bubble         Whether the messages that are handled can bubble up the stack or not
      */
     public function __construct($handler, $minLevelOrList = Logger::DEBUG, $maxLevel = Logger::EMERGENCY, $bubble = true)
     {

--- a/src/Monolog/Handler/FingersCrossed/ActivationStrategyInterface.php
+++ b/src/Monolog/Handler/FingersCrossed/ActivationStrategyInterface.php
@@ -22,7 +22,7 @@ interface ActivationStrategyInterface
      * Returns whether the given record activates the handler.
      *
      * @param  array   $record
-     * @return Boolean
+     * @return bool
      */
     public function isHandlerActivated(array $record);
 }

--- a/src/Monolog/Handler/FingersCrossedHandler.php
+++ b/src/Monolog/Handler/FingersCrossedHandler.php
@@ -41,8 +41,8 @@ class FingersCrossedHandler extends AbstractHandler
      * @param callable|HandlerInterface       $handler            Handler or factory callable($record, $fingersCrossedHandler).
      * @param int|ActivationStrategyInterface $activationStrategy Strategy which determines when this handler takes action
      * @param int                             $bufferSize         How many entries should be buffered at most, beyond that the oldest items are removed from the buffer.
-     * @param Boolean                         $bubble             Whether the messages that are handled can bubble up the stack or not
-     * @param Boolean                         $stopBuffering      Whether the handler should stop buffering after being triggered (default true)
+     * @param bool                            $bubble             Whether the messages that are handled can bubble up the stack or not
+     * @param bool                            $stopBuffering      Whether the handler should stop buffering after being triggered (default true)
      * @param int                             $passthruLevel      Minimum level to always flush to handler on close, even if strategy not triggered
      */
     public function __construct($handler, $activationStrategy = null, $bufferSize = 0, $bubble = true, $stopBuffering = true, $passthruLevel = null)

--- a/src/Monolog/Handler/FirePHPHandler.php
+++ b/src/Monolog/Handler/FirePHPHandler.php
@@ -158,7 +158,7 @@ class FirePHPHandler extends AbstractProcessingHandler
     /**
      * Verifies if the headers are accepted by the current user agent
      *
-     * @return Boolean
+     * @return bool
      */
     protected function headersAccepted()
     {

--- a/src/Monolog/Handler/GroupHandler.php
+++ b/src/Monolog/Handler/GroupHandler.php
@@ -23,8 +23,8 @@ class GroupHandler extends AbstractHandler
     protected $handlers;
 
     /**
-     * @param array   $handlers Array of Handlers.
-     * @param Boolean $bubble   Whether the messages that are handled can bubble up the stack or not
+     * @param array $handlers Array of Handlers.
+     * @param bool  $bubble   Whether the messages that are handled can bubble up the stack or not
      */
     public function __construct(array $handlers, $bubble = true)
     {

--- a/src/Monolog/Handler/HandlerInterface.php
+++ b/src/Monolog/Handler/HandlerInterface.php
@@ -31,7 +31,7 @@ interface HandlerInterface
      *
      * @param array $record Partial log record containing only a level key
      *
-     * @return Boolean
+     * @return bool
      */
     public function isHandling(array $record);
 
@@ -46,7 +46,7 @@ interface HandlerInterface
      * calling further handlers in the stack with a given log record.
      *
      * @param  array   $record The record to handle
-     * @return Boolean true means that this handler handled the record, and that bubbling is not permitted.
+     * @return bool true means that this handler handled the record, and that bubbling is not permitted.
      *                        false means the record was either not processed or that this handler allows bubbling.
      */
     public function handle(array $record);

--- a/src/Monolog/Handler/IFTTTHandler.php
+++ b/src/Monolog/Handler/IFTTTHandler.php
@@ -30,10 +30,10 @@ class IFTTTHandler extends AbstractProcessingHandler
     private $secretKey;
 
     /**
-     * @param string  $eventName The name of the IFTTT Maker event that should be triggered
-     * @param string  $secretKey A valid IFTTT secret key
-     * @param int     $level     The minimum logging level at which this handler will be triggered
-     * @param Boolean $bubble    Whether the messages that are handled can bubble up the stack or not
+     * @param string $eventName The name of the IFTTT Maker event that should be triggered
+     * @param string $secretKey A valid IFTTT secret key
+     * @param int    $level     The minimum logging level at which this handler will be triggered
+     * @param bool   $bubble    Whether the messages that are handled can bubble up the stack or not
      */
     public function __construct($eventName, $secretKey, $level = Logger::ERROR, $bubble = true)
     {

--- a/src/Monolog/Handler/MandrillHandler.php
+++ b/src/Monolog/Handler/MandrillHandler.php
@@ -27,7 +27,7 @@ class MandrillHandler extends MailHandler
      * @param string                  $apiKey  A valid Mandrill API key
      * @param callable|\Swift_Message $message An example message for real messages, only the body will be replaced
      * @param int                     $level   The minimum logging level at which this handler will be triggered
-     * @param Boolean                 $bubble  Whether the messages that are handled can bubble up the stack or not
+     * @param bool                    $bubble  Whether the messages that are handled can bubble up the stack or not
      */
     public function __construct($apiKey, $message, $level = Logger::ERROR, $bubble = true)
     {

--- a/src/Monolog/Handler/PsrHandler.php
+++ b/src/Monolog/Handler/PsrHandler.php
@@ -31,7 +31,7 @@ class PsrHandler extends AbstractHandler
     /**
      * @param LoggerInterface $logger The underlying PSR-3 compliant logger to which messages will be proxied
      * @param int             $level  The minimum logging level at which this handler will be triggered
-     * @param Boolean         $bubble Whether the messages that are handled can bubble up the stack or not
+     * @param bool            $bubble Whether the messages that are handled can bubble up the stack or not
      */
     public function __construct(LoggerInterface $logger, $level = Logger::DEBUG, $bubble = true)
     {

--- a/src/Monolog/Handler/PushoverHandler.php
+++ b/src/Monolog/Handler/PushoverHandler.php
@@ -69,8 +69,8 @@ class PushoverHandler extends SocketHandler
      * @param string|array $users             Pushover user id or array of ids the message will be sent to
      * @param string       $title             Title sent to the Pushover API
      * @param int          $level             The minimum logging level at which this handler will be triggered
-     * @param Boolean      $bubble            Whether the messages that are handled can bubble up the stack or not
-     * @param Boolean      $useSSL            Whether to connect via SSL. Required when pushing messages to users that are not
+     * @param bool         $bubble            Whether the messages that are handled can bubble up the stack or not
+     * @param bool         $useSSL            Whether to connect via SSL. Required when pushing messages to users that are not
      *                                        the pushover.net app owner. OpenSSL is required for this option.
      * @param int          $highPriorityLevel The minimum logging level at which this handler will start
      *                                        sending "high priority" requests to the Pushover API

--- a/src/Monolog/Handler/RavenHandler.php
+++ b/src/Monolog/Handler/RavenHandler.php
@@ -57,7 +57,7 @@ class RavenHandler extends AbstractProcessingHandler
     /**
      * @param Raven_Client $ravenClient
      * @param int          $level       The minimum logging level at which this handler will be triggered
-     * @param Boolean      $bubble      Whether the messages that are handled can bubble up the stack or not
+     * @param bool         $bubble      Whether the messages that are handled can bubble up the stack or not
      */
     public function __construct(Raven_Client $ravenClient, $level = Logger::DEBUG, $bubble = true)
     {

--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -39,9 +39,9 @@ class RotatingFileHandler extends StreamHandler
      * @param string   $filename
      * @param int      $maxFiles       The maximal amount of files to keep (0 means unlimited)
      * @param int      $level          The minimum logging level at which this handler will be triggered
-     * @param Boolean  $bubble         Whether the messages that are handled can bubble up the stack or not
+     * @param bool     $bubble         Whether the messages that are handled can bubble up the stack or not
      * @param int|null $filePermission Optional file permissions (default (0644) are only for owner read/write)
-     * @param Boolean  $useLocking     Try to lock log file before doing any writes
+     * @param bool     $useLocking     Try to lock log file before doing any writes
      */
     public function __construct($filename, $maxFiles = 0, $level = Logger::DEBUG, $bubble = true, $filePermission = null, $useLocking = false)
     {

--- a/src/Monolog/Handler/SocketHandler.php
+++ b/src/Monolog/Handler/SocketHandler.php
@@ -33,9 +33,9 @@ class SocketHandler extends AbstractProcessingHandler
     private $lastWritingAt;
 
     /**
-     * @param string  $connectionString Socket connection string
-     * @param int     $level            The minimum logging level at which this handler will be triggered
-     * @param Boolean $bubble           Whether the messages that are handled can bubble up the stack or not
+     * @param string $connectionString Socket connection string
+     * @param int    $level            The minimum logging level at which this handler will be triggered
+     * @param bool   $bubble           Whether the messages that are handled can bubble up the stack or not
      */
     public function __construct($connectionString, $level = Logger::DEBUG, $bubble = true)
     {

--- a/src/Monolog/Handler/StreamHandler.php
+++ b/src/Monolog/Handler/StreamHandler.php
@@ -32,9 +32,9 @@ class StreamHandler extends AbstractProcessingHandler
     /**
      * @param resource|string $stream
      * @param int             $level          The minimum logging level at which this handler will be triggered
-     * @param Boolean         $bubble         Whether the messages that are handled can bubble up the stack or not
+     * @param bool            $bubble         Whether the messages that are handled can bubble up the stack or not
      * @param int|null        $filePermission Optional file permissions (default (0644) are only for owner read/write)
-     * @param Boolean         $useLocking     Try to lock log file before doing any writes
+     * @param bool            $useLocking     Try to lock log file before doing any writes
      *
      * @throws \Exception                If a missing directory is not buildable
      * @throws \InvalidArgumentException If stream is not a resource or string

--- a/src/Monolog/Handler/SyslogHandler.php
+++ b/src/Monolog/Handler/SyslogHandler.php
@@ -32,11 +32,11 @@ class SyslogHandler extends AbstractSyslogHandler
     protected $logopts;
 
     /**
-     * @param string  $ident
-     * @param mixed   $facility
-     * @param int     $level    The minimum logging level at which this handler will be triggered
-     * @param Boolean $bubble   Whether the messages that are handled can bubble up the stack or not
-     * @param int     $logopts  Option flags for the openlog() call, defaults to LOG_PID
+     * @param string $ident
+     * @param mixed  $facility
+     * @param int    $level    The minimum logging level at which this handler will be triggered
+     * @param bool   $bubble   Whether the messages that are handled can bubble up the stack or not
+     * @param int    $logopts  Option flags for the openlog() call, defaults to LOG_PID
      */
     public function __construct($ident, $facility = LOG_USER, $level = Logger::DEBUG, $bubble = true, $logopts = LOG_PID)
     {

--- a/src/Monolog/Handler/SyslogUdpHandler.php
+++ b/src/Monolog/Handler/SyslogUdpHandler.php
@@ -25,12 +25,12 @@ class SyslogUdpHandler extends AbstractSyslogHandler
     protected $ident;
 
     /**
-     * @param string  $host
-     * @param int     $port
-     * @param mixed   $facility
-     * @param int     $level    The minimum logging level at which this handler will be triggered
-     * @param Boolean $bubble   Whether the messages that are handled can bubble up the stack or not
-     * @param string  $ident    Program name or tag for each log message.
+     * @param string $host
+     * @param int    $port
+     * @param mixed  $facility
+     * @param int    $level    The minimum logging level at which this handler will be triggered
+     * @param bool   $bubble   Whether the messages that are handled can bubble up the stack or not
+     * @param string $ident    Program name or tag for each log message.
      */
     public function __construct($host, $port = 514, $facility = LOG_USER, $level = Logger::DEBUG, $bubble = true, $ident = 'php')
     {

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -281,7 +281,7 @@ class Logger implements LoggerInterface
      * @param  int     $level   The logging level
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @return Boolean Whether the record has been processed
+     * @return bool Whether the record has been processed
      */
     public function addRecord($level, $message, array $context = array())
     {
@@ -484,7 +484,7 @@ class Logger implements LoggerInterface
      * Checks whether the Logger has a handler that listens on the given level
      *
      * @param  int     $level
-     * @return Boolean
+     * @return bool
      */
     public function isHandling($level)
     {


### PR DESCRIPTION
### Why?
It might seem a little pedantic, but because the declaration of boolean values in doctypes wasn't in accordance with standards (according to [phpdoc.org](https://docs.phpdoc.org/guides/types.html) and the proposed [PSR-5](https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#appendix-a-types)), it sometimes gives issues in my IDE and it always gives problems when running for example [vimeo/psalm](https://github.com/vimeo/psalm) over a project using Monolog, because `Boolean` in the doctype is (rightfully) interpreted as class `Monolog[\Namespace]\Boolean`.