### PR TITLE
Ucfirsting context/extra keys without shortAttachment

### DIFF
--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -257,7 +257,7 @@ class SlackRecord
     {
         $fields = array();
         foreach ($data as $key => $value) {
-            $fields[] = $this->generateAttachmentField($key, $value);
+            $fields[] = $this->generateAttachmentField(ucfirst($key), $value);
         }
 
         return $fields;


### PR DESCRIPTION
If one's using includeContextAndExtra, the keys "extra" and "context" will be correctly displayed when using useShortAttachment (thanks to the ucfirst at line 148), but won't be correctly displayed otherwise.