### PR TITLE
microtime uses UTC always

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -316,8 +316,8 @@ class Logger implements LoggerInterface
 			$timestamp = microtime(true);
 
 			// apply offset of the timezone as microtime() is always UTC
-			if (self::$timezone && self::$timezone->getName() !== 'UTC') {
-				$datetime  = new \DateTime('now', self::$timezone);
+			if (static::$timezone && static::$timezone->getName() !== 'UTC') {
+				$datetime  = new \DateTime('now', static::$timezone);
 				$timestamp += $datetime->getOffset();
 			}
 

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -311,9 +311,16 @@ class Logger implements LoggerInterface
             static::$timezone = new \DateTimeZone(date_default_timezone_get() ?: 'UTC');
         }
 
+		$timestamp = microtime(true);
+
+		// apply offset of the timezone as microtime() is always UTC
+		if (self::$timezone && self::$timezone->getName() !== 'UTC') {
+			$timestamp += (new \DateTime('now', self::$timezone))->getOffset();
+		}
+
         // php7.1+ always has microseconds enabled, so we do not need this hack
         if ($this->microsecondTimestamps && PHP_VERSION_ID < 70100) {
-            $ts = \DateTime::createFromFormat('U.u', sprintf('%.6F', microtime(true)), static::$timezone);
+            $ts = \DateTime::createFromFormat('U.u', sprintf('%.6F', $timestamp), static::$timezone);
         } else {
             $ts = new \DateTime(null, static::$timezone);
         }

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -311,15 +311,15 @@ class Logger implements LoggerInterface
             static::$timezone = new \DateTimeZone(date_default_timezone_get() ?: 'UTC');
         }
 
-		$timestamp = microtime(true);
-
-		// apply offset of the timezone as microtime() is always UTC
-		if (self::$timezone && self::$timezone->getName() !== 'UTC') {
-			$timestamp += (new \DateTime('now', self::$timezone))->getOffset();
-		}
-
         // php7.1+ always has microseconds enabled, so we do not need this hack
         if ($this->microsecondTimestamps && PHP_VERSION_ID < 70100) {
+			$timestamp = microtime(true);
+
+			// apply offset of the timezone as microtime() is always UTC
+			if (self::$timezone && self::$timezone->getName() !== 'UTC') {
+				$timestamp += (new \DateTime('now', self::$timezone))->getOffset();
+			}
+
             $ts = \DateTime::createFromFormat('U.u', sprintf('%.6F', $timestamp), static::$timezone);
         } else {
             $ts = new \DateTime(null, static::$timezone);

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -317,7 +317,8 @@ class Logger implements LoggerInterface
 
 			// apply offset of the timezone as microtime() is always UTC
 			if (self::$timezone && self::$timezone->getName() !== 'UTC') {
-				$timestamp += (new \DateTime('now', self::$timezone))->getOffset();
+				$datetime  = new \DateTime('now', self::$timezone);
+				$timestamp += $datetime->getOffset();
 			}
 
             $ts = \DateTime::createFromFormat('U.u', sprintf('%.6F', $timestamp), static::$timezone);


### PR DESCRIPTION
- based on https://github.com/Seldaek/monolog/blob/master/src/Monolog/DateTimeImmutable.php#L34
- cannot use output of microtime, because it uses UTC and ignores actual timezone