### PR TITLE
Add getter for webhook url in SlackWebhookHandler class

### DIFF
--- a/src/Monolog/Handler/SlackWebhookHandler.php
+++ b/src/Monolog/Handler/SlackWebhookHandler.php
@@ -70,6 +70,11 @@ class SlackWebhookHandler extends AbstractProcessingHandler
         return $this->slackRecord;
     }
 
+    public function getWebhookUrl()
+    {
+        return $this->webhookUrl;
+    }
+
     /**
      * {@inheritdoc}
      *


### PR DESCRIPTION
Add getter so that the subclass can easy to inherit SlackWebhookHandler class