### PR TITLE
Merge context & extra

### DIFF
--- a/src/Monolog/Formatter/LineFormatter.php
+++ b/src/Monolog/Formatter/LineFormatter.php
@@ -27,18 +27,26 @@ class LineFormatter extends NormalizerFormatter
     protected $allowInlineLineBreaks;
     protected $ignoreEmptyContextAndExtra;
     protected $includeStacktraces;
+    protected $combineContextAndExtra;
 
     /**
      * @param string $format                     The format of the message
      * @param string $dateFormat                 The format of the timestamp: one supported by DateTime::format
      * @param bool   $allowInlineLineBreaks      Whether to allow inline line breaks in log entries
      * @param bool   $ignoreEmptyContextAndExtra Removes brackets from output when Context or Extra are empty
+     * @param bool   $combineContextAndExtra     Merge Context and Extra into a single JSON object
      */
-    public function __construct(string $format = null, string $dateFormat = null, bool $allowInlineLineBreaks = false, bool $ignoreEmptyContextAndExtra = false)
-    {
+    public function __construct(
+        string $format = null,
+        string $dateFormat = null,
+        bool $allowInlineLineBreaks = false,
+        bool $ignoreEmptyContextAndExtra = false,
+        bool $combineContextAndExtra = false
+    ) {
         $this->format = $format ?: static::SIMPLE_FORMAT;
         $this->allowInlineLineBreaks = $allowInlineLineBreaks;
         $this->ignoreEmptyContextAndExtra = $ignoreEmptyContextAndExtra;
+        $this->combineContextAndExtra($combineContextAndExtra);
         parent::__construct($dateFormat);
     }
 
@@ -61,6 +69,23 @@ class LineFormatter extends NormalizerFormatter
     }
 
     /**
+     * Combine Context and Extra
+     *
+     * Some log consumers expect a single dictionary of name values
+     * instead of the default two that monolog will create (context & extra).
+     * If `combineContextAndExtra` is set to `true`, `context` and `extra` will
+     * be merged with `context` overwriting any `extra` with the same name.
+     *
+     * @param bool $combine set to true to combine context and extra
+     *
+     * @return void
+     */
+    public function combineContextAndExtra(bool $combine = false)
+    {
+        $this->combineContextAndExtra = $combine;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function format(array $record): string
@@ -68,6 +93,11 @@ class LineFormatter extends NormalizerFormatter
         $vars = parent::format($record);
 
         $output = $this->format;
+
+        if ($this->combineContextAndExtra) {
+            $vars['context'] = array_merge($vars['extra'], $vars['context']);
+            $vars['extra'] = array();
+        }
 
         foreach ($vars['extra'] as $var => $val) {
             if (false !== strpos($output, '%extra.'.$var.'%')) {
@@ -89,7 +119,9 @@ class LineFormatter extends NormalizerFormatter
                 // strip the trailing space
                 $output = str_replace('%context% ', '', $output);
             }
+        }
 
+        if ($this->ignoreEmptyContextAndExtra || $this->combineContextAndExtra) {
             if (empty($vars['extra'])) {
                 unset($vars['extra']);
                 // strip leading space

--- a/src/Monolog/Formatter/LineFormatter.php
+++ b/src/Monolog/Formatter/LineFormatter.php
@@ -32,7 +32,7 @@ class LineFormatter extends NormalizerFormatter
      * @param string $format                     The format of the message
      * @param string $dateFormat                 The format of the timestamp: one supported by DateTime::format
      * @param bool   $allowInlineLineBreaks      Whether to allow inline line breaks in log entries
-     * @param bool   $ignoreEmptyContextAndExtra
+     * @param bool   $ignoreEmptyContextAndExtra Removes brackets from output when Context or Extra are empty
      */
     public function __construct(string $format = null, string $dateFormat = null, bool $allowInlineLineBreaks = false, bool $ignoreEmptyContextAndExtra = false)
     {
@@ -86,12 +86,14 @@ class LineFormatter extends NormalizerFormatter
         if ($this->ignoreEmptyContextAndExtra) {
             if (empty($vars['context'])) {
                 unset($vars['context']);
-                $output = str_replace('%context%', '', $output);
+                // strip the trailing space
+                $output = str_replace('%context% ', '', $output);
             }
 
             if (empty($vars['extra'])) {
                 unset($vars['extra']);
-                $output = str_replace('%extra%', '', $output);
+                // strip leading space
+                $output = str_replace(' %extra%', '', $output);
             }
         }
 

--- a/tests/Monolog/Formatter/LineFormatterTest.php
+++ b/tests/Monolog/Formatter/LineFormatterTest.php
@@ -88,7 +88,7 @@ class LineFormatterTest extends \PHPUnit\Framework\TestCase
             'extra' => [],
             'message' => 'log',
         ]);
-        $this->assertEquals('['.date('Y-m-d').'] meh.ERROR: log  '."\n", $message);
+        $this->assertEquals('['.date('Y-m-d').'] meh.ERROR: log'."\n", $message);
     }
 
     public function testContextAndExtraReplacement()
@@ -223,6 +223,62 @@ class LineFormatterTest extends \PHPUnit\Framework\TestCase
         );
 
         $this->assertRegExp('/foo\nbar/', $message);
+    }
+
+    public function testIgnoreEmptyContextAndExtraNotEmpty()
+    {
+        $expectedPattern = '/I love logging! {"foo":"bar"} {"baz":"qux"}\n/';
+        $messageRecord = [
+            'message' => 'I love logging!',
+            'context' => ['foo' => 'bar'],
+            'extra' => ['baz' => 'qux']
+        ];
+
+        $formatter = new LineFormatter(null, null, false, true);
+        $message = $formatter->format($messageRecord);
+        $this->assertRegExp($expectedPattern, $message);
+    }
+
+    public function testIgnoreEmptyContextAndExtraEmptyContext()
+    {
+        $expectedPattern = '/I love logging! {"baz":"qux"}\n/';
+        $messageRecord = [
+            'message' => 'I love logging!',
+            'context' => [],
+            'extra' => ['baz' => 'qux']
+        ];
+
+        $formatter = new LineFormatter(null, null, false, true);
+        $message = $formatter->format($messageRecord);
+        $this->assertRegExp($expectedPattern, $message);
+    }
+
+    public function testIgnoreEmptyContextAndExtraEmptyExtra()
+    {
+        $expectedPattern = '/I love logging! {"foo":"bar"}\n/';
+        $messageRecord = [
+            'message' => 'I love logging!',
+            'context' => ['foo' => 'bar'],
+            'extra' => []
+        ];
+
+        $formatter = new LineFormatter(null, null, false, true);
+        $message = $formatter->format($messageRecord);
+        $this->assertRegExp($expectedPattern, $message);
+    }
+
+    public function testIgnoreEmptyContextAndExtraAllEmpty()
+    {
+        $expectedPattern = '/I love logging!\n/';
+        $messageRecord = [
+            'message' => 'I love logging!',
+            'context' => [],
+            'extra' => []
+        ];
+
+        $formatter = new LineFormatter(null, null, false, true);
+        $message = $formatter->format($messageRecord);
+        $this->assertRegExp($expectedPattern, $message);
     }
 }
 

--- a/tests/Monolog/Formatter/LineFormatterTest.php
+++ b/tests/Monolog/Formatter/LineFormatterTest.php
@@ -280,6 +280,91 @@ class LineFormatterTest extends \PHPUnit\Framework\TestCase
         $message = $formatter->format($messageRecord);
         $this->assertRegExp($expectedPattern, $message);
     }
+
+    public function testCombineContextAndExtraAllEmpty()
+    {
+        $expectedPattern = '/I love logging! \[\]\n/';
+        $messageRecord = [
+            'message' => 'I love logging!',
+            'context' => [],
+            'extra' => []
+        ];
+
+        $formatter = new LineFormatter(null, null, false, false, true);
+        $message = $formatter->format($messageRecord);
+        $this->assertRegExp($expectedPattern, $message);
+    }
+
+    public function testCombineContextAndExtraWithNoConflict()
+    {
+        $expectedPattern = '/I love logging! {"baz":"qux","foo":"bar"}\n/';
+        $messageRecord = [
+            'message' => 'I love logging!',
+            'context' => ['foo' => 'bar'],
+            'extra' => ['baz' => 'qux']
+        ];
+
+        $formatter = new LineFormatter(null, null, false, false, true);
+        $message = $formatter->format($messageRecord);
+        $this->assertRegExp($expectedPattern, $message);
+    }
+
+    public function testCombineContextAndExtraWithConflict()
+    {
+        $expectedPattern = '/I love logging! {"foo":"bar"}\n/';
+        $messageRecord = [
+            'message' => 'I love logging!',
+            'context' => ['foo' => 'bar'],
+            'extra' => ['foo' => 'qux']
+        ];
+
+        $formatter = new LineFormatter(null, null, false, false, true);
+        $message = $formatter->format($messageRecord);
+        $this->assertRegExp($expectedPattern, $message);
+    }
+
+    public function testCombineContextAndExtraWithNoContext()
+    {
+        $expectedPattern = '/I love logging! {"baz":"qux"}\n/';
+        $messageRecord = [
+            'message' => 'I love logging!',
+            'context' => [],
+            'extra' => ['baz' => 'qux']
+        ];
+
+        $formatter = new LineFormatter(null, null, false, false, true);
+        $message = $formatter->format($messageRecord);
+        $this->assertRegExp($expectedPattern, $message);
+    }
+
+    public function testCombineContextAndExtraWithNoExtra()
+    {
+        $expectedPattern = '/I love logging! {"foo":"bar"}\n/';
+        $messageRecord = [
+            'message' => 'I love logging!',
+            'context' => ['foo' => 'bar'],
+            'extra' => []
+        ];
+
+        $formatter = new LineFormatter(null, null, false, false, true);
+        $message = $formatter->format($messageRecord);
+        $this->assertRegExp($expectedPattern, $message);
+    }
+
+    public function testCombineContextAndExtraSetter()
+    {
+        $expectedPattern = '/I love logging! {"baz":"qux","foo":"bar"}\n/';
+        $messageRecord = [
+            'message' => 'I love logging!',
+            'context' => ['foo' => 'bar'],
+            'extra' => ['baz' => 'qux']
+        ];
+
+        $formatter = new LineFormatter();
+        $formatter->combineContextAndExtra(true);
+        $message = $formatter->format($messageRecord);
+        $this->assertRegExp($expectedPattern, $message);
+    }
 }
 
 class TestFoo


### PR DESCRIPTION
fixes: #1091

1.  Note that there are two commits, the first one adds some coverage and fixes some whitespace nits with `ignoreEmptyContextAndExtra`

2. The second commit introduces the `combineContextAndExtra` option and tests to cover the new option.

I chose to have context win if there is a collision between extra and context.  It makes most sense to me to allow an individual log event to override an extra.