### PR TITLE
Improve tests assertions

### DIFF
--- a/tests/Monolog/ErrorHandlerTest.php
+++ b/tests/Monolog/ErrorHandlerTest.php
@@ -39,7 +39,7 @@ class ErrorHandlerTest extends \PHPUnit\Framework\TestCase
 
         $errHandler->registerErrorHandler([], true);
         $prop = $this->getPrivatePropertyValue($errHandler, 'previousErrorHandler');
-        $this->assertTrue(is_callable($prop));
+        $this->assertInternalType('callable', $prop);
     }
 
     public function fatalHandlerProvider()
@@ -74,8 +74,8 @@ class ErrorHandlerTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame($res, $errHandler);
         $this->assertTrue($this->getPrivatePropertyValue($errHandler, 'hasFatalErrorHandler'));
-        $this->assertEquals($expectedReservedMemory, $this->getPrivatePropertyValue($errHandler, 'reservedMemory'));
-        $this->assertEquals($expectedFatalLevel, $this->getPrivatePropertyValue($errHandler, 'fatalLevel'));
+        $this->assertSame($expectedReservedMemory, $this->getPrivatePropertyValue($errHandler, 'reservedMemory'));
+        $this->assertSame($expectedFatalLevel, $this->getPrivatePropertyValue($errHandler, 'fatalLevel'));
     }
 
     public function testHandleException()
@@ -92,7 +92,7 @@ class ErrorHandlerTest extends \PHPUnit\Framework\TestCase
 
         $errHandler->registerExceptionHandler([], true);
         $prop = $this->getPrivatePropertyValue($errHandler, 'previousExceptionHandler');
-        $this->assertTrue(is_callable($prop));
+        $this->assertInternalType('callable', $prop);
     }
 
     public function testCodeToString()
@@ -100,24 +100,24 @@ class ErrorHandlerTest extends \PHPUnit\Framework\TestCase
         $method = new \ReflectionMethod(ErrorHandler::class, 'codeToString');
         $method->setAccessible(true);
 
-        $this->assertEquals('E_ERROR', $method->invokeArgs(null, [E_ERROR]));
-        $this->assertEquals('E_WARNING', $method->invokeArgs(null, [E_WARNING]));
-        $this->assertEquals('E_PARSE', $method->invokeArgs(null, [E_PARSE]));
-        $this->assertEquals('E_NOTICE', $method->invokeArgs(null, [E_NOTICE]));
-        $this->assertEquals('E_CORE_ERROR', $method->invokeArgs(null, [E_CORE_ERROR]));
-        $this->assertEquals('E_CORE_WARNING', $method->invokeArgs(null, [E_CORE_WARNING]));
-        $this->assertEquals('E_COMPILE_ERROR', $method->invokeArgs(null, [E_COMPILE_ERROR]));
-        $this->assertEquals('E_COMPILE_WARNING', $method->invokeArgs(null, [E_COMPILE_WARNING]));
-        $this->assertEquals('E_USER_ERROR', $method->invokeArgs(null, [E_USER_ERROR]));
-        $this->assertEquals('E_USER_WARNING', $method->invokeArgs(null, [E_USER_WARNING]));
-        $this->assertEquals('E_USER_NOTICE', $method->invokeArgs(null, [E_USER_NOTICE]));
-        $this->assertEquals('E_STRICT', $method->invokeArgs(null, [E_STRICT]));
-        $this->assertEquals('E_RECOVERABLE_ERROR', $method->invokeArgs(null, [E_RECOVERABLE_ERROR]));
-        $this->assertEquals('E_DEPRECATED', $method->invokeArgs(null, [E_DEPRECATED]));
-        $this->assertEquals('E_USER_DEPRECATED', $method->invokeArgs(null, [E_USER_DEPRECATED]));
+        $this->assertSame('E_ERROR', $method->invokeArgs(null, [E_ERROR]));
+        $this->assertSame('E_WARNING', $method->invokeArgs(null, [E_WARNING]));
+        $this->assertSame('E_PARSE', $method->invokeArgs(null, [E_PARSE]));
+        $this->assertSame('E_NOTICE', $method->invokeArgs(null, [E_NOTICE]));
+        $this->assertSame('E_CORE_ERROR', $method->invokeArgs(null, [E_CORE_ERROR]));
+        $this->assertSame('E_CORE_WARNING', $method->invokeArgs(null, [E_CORE_WARNING]));
+        $this->assertSame('E_COMPILE_ERROR', $method->invokeArgs(null, [E_COMPILE_ERROR]));
+        $this->assertSame('E_COMPILE_WARNING', $method->invokeArgs(null, [E_COMPILE_WARNING]));
+        $this->assertSame('E_USER_ERROR', $method->invokeArgs(null, [E_USER_ERROR]));
+        $this->assertSame('E_USER_WARNING', $method->invokeArgs(null, [E_USER_WARNING]));
+        $this->assertSame('E_USER_NOTICE', $method->invokeArgs(null, [E_USER_NOTICE]));
+        $this->assertSame('E_STRICT', $method->invokeArgs(null, [E_STRICT]));
+        $this->assertSame('E_RECOVERABLE_ERROR', $method->invokeArgs(null, [E_RECOVERABLE_ERROR]));
+        $this->assertSame('E_DEPRECATED', $method->invokeArgs(null, [E_DEPRECATED]));
+        $this->assertSame('E_USER_DEPRECATED', $method->invokeArgs(null, [E_USER_DEPRECATED]));
 
-        $this->assertEquals('Unknown PHP error', $method->invokeArgs(null, ['RANDOM_TEXT']));
-        $this->assertEquals('Unknown PHP error', $method->invokeArgs(null, [E_ALL]));
+        $this->assertSame('Unknown PHP error', $method->invokeArgs(null, ['RANDOM_TEXT']));
+        $this->assertSame('Unknown PHP error', $method->invokeArgs(null, [E_ALL]));
     }
 }
 

--- a/tests/Monolog/Formatter/ChromePHPFormatterTest.php
+++ b/tests/Monolog/Formatter/ChromePHPFormatterTest.php
@@ -33,7 +33,7 @@ class ChromePHPFormatterTest extends \PHPUnit\Framework\TestCase
 
         $message = $formatter->format($record);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 'meh',
                 [
@@ -66,7 +66,7 @@ class ChromePHPFormatterTest extends \PHPUnit\Framework\TestCase
 
         $message = $formatter->format($record);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 'meh',
                 [
@@ -99,7 +99,7 @@ class ChromePHPFormatterTest extends \PHPUnit\Framework\TestCase
 
         $message = $formatter->format($record);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 'meh',
                 'log',
@@ -137,7 +137,7 @@ class ChromePHPFormatterTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 [
                     'meh',

--- a/tests/Monolog/Formatter/ElasticaFormatterTest.php
+++ b/tests/Monolog/Formatter/ElasticaFormatterTest.php
@@ -56,8 +56,8 @@ class ElasticaFormatterTest extends \PHPUnit\Framework\TestCase
 
         // Document parameters
         $params = $doc->getParams();
-        $this->assertEquals('my_index', $params['_index']);
-        $this->assertEquals('doc_type', $params['_type']);
+        $this->assertSame('my_index', $params['_index']);
+        $this->assertSame('doc_type', $params['_type']);
 
         // Document data values
         $data = $doc->getData();
@@ -73,7 +73,7 @@ class ElasticaFormatterTest extends \PHPUnit\Framework\TestCase
     public function testGetters()
     {
         $formatter = new ElasticaFormatter('my_index', 'doc_type');
-        $this->assertEquals('my_index', $formatter->getIndex());
-        $this->assertEquals('doc_type', $formatter->getType());
+        $this->assertSame('my_index', $formatter->getIndex());
+        $this->assertSame('doc_type', $formatter->getType());
     }
 }

--- a/tests/Monolog/Formatter/FlowdockFormatterTest.php
+++ b/tests/Monolog/Formatter/FlowdockFormatterTest.php
@@ -34,11 +34,11 @@ class FlowdockFormatterTest extends TestCase
         ];
         $formatted = $formatter->format($record);
 
-        $this->assertEquals($expected, $formatted['flowdock']);
+        $this->assertSame($expected, $formatted['flowdock']);
     }
 
     /**
-     * @ covers Monolog\Formatter\FlowdockFormatter::formatBatch
+     * @covers Monolog\Formatter\FlowdockFormatter::formatBatch
      */
     public function testFormatBatch()
     {

--- a/tests/Monolog/Formatter/FluentdFormatterTest.php
+++ b/tests/Monolog/Formatter/FluentdFormatterTest.php
@@ -23,11 +23,11 @@ class FluentdFormatterTest extends TestCase
     public function testConstruct()
     {
         $formatter = new FluentdFormatter();
-        $this->assertEquals(false, $formatter->isUsingLevelsInTag());
+        $this->assertFalse($formatter->isUsingLevelsInTag());
         $formatter = new FluentdFormatter(false);
-        $this->assertEquals(false, $formatter->isUsingLevelsInTag());
+        $this->assertFalse($formatter->isUsingLevelsInTag());
         $formatter = new FluentdFormatter(true);
-        $this->assertEquals(true, $formatter->isUsingLevelsInTag());
+        $this->assertTrue($formatter->isUsingLevelsInTag());
     }
 
     /**
@@ -39,7 +39,7 @@ class FluentdFormatterTest extends TestCase
         $record['datetime'] = new \DateTimeImmutable("@0");
 
         $formatter = new FluentdFormatter();
-        $this->assertEquals(
+        $this->assertSame(
             '["test",0,{"message":"test","extra":[],"level":300,"level_name":"WARNING"}]',
             $formatter->format($record)
         );
@@ -54,7 +54,7 @@ class FluentdFormatterTest extends TestCase
         $record['datetime'] = new \DateTimeImmutable("@0");
 
         $formatter = new FluentdFormatter(true);
-        $this->assertEquals(
+        $this->assertSame(
             '["test.error",0,{"message":"test","extra":[]}]',
             $formatter->format($record)
         );

--- a/tests/Monolog/Formatter/GelfMessageFormatterTest.php
+++ b/tests/Monolog/Formatter/GelfMessageFormatterTest.php
@@ -41,12 +41,12 @@ class GelfMessageFormatterTest extends \PHPUnit\Framework\TestCase
         $message = $formatter->format($record);
 
         $this->assertInstanceOf('Gelf\Message', $message);
-        $this->assertEquals(0, $message->getTimestamp());
-        $this->assertEquals('log', $message->getShortMessage());
-        $this->assertEquals('meh', $message->getFacility());
-        $this->assertEquals(null, $message->getLine());
-        $this->assertEquals(null, $message->getFile());
-        $this->assertEquals($this->isLegacy() ? 3 : 'error', $message->getLevel());
+        $this->assertSame(0.0, $message->getTimestamp());
+        $this->assertSame('log', $message->getShortMessage());
+        $this->assertSame('meh', $message->getFacility());
+        $this->assertNull($message->getLine());
+        $this->assertNull($message->getFile());
+        $this->assertSame($this->isLegacy() ? 3 : 'error', $message->getLevel());
         $this->assertNotEmpty($message->getHost());
 
         $formatter = new GelfMessageFormatter('mysystem');
@@ -54,7 +54,7 @@ class GelfMessageFormatterTest extends \PHPUnit\Framework\TestCase
         $message = $formatter->format($record);
 
         $this->assertInstanceOf('Gelf\Message', $message);
-        $this->assertEquals('mysystem', $message->getHost());
+        $this->assertSame('mysystem', $message->getHost());
     }
 
     /**
@@ -76,8 +76,8 @@ class GelfMessageFormatterTest extends \PHPUnit\Framework\TestCase
         $message = $formatter->format($record);
 
         $this->assertInstanceOf('Gelf\Message', $message);
-        $this->assertEquals('test', $message->getFile());
-        $this->assertEquals(14, $message->getLine());
+        $this->assertSame('test', $message->getFile());
+        $this->assertSame(14, $message->getLine());
     }
 
     /**
@@ -118,7 +118,7 @@ class GelfMessageFormatterTest extends \PHPUnit\Framework\TestCase
         $message_array = $message->toArray();
 
         $this->assertArrayHasKey('_ctxt_from', $message_array);
-        $this->assertEquals('logger', $message_array['_ctxt_from']);
+        $this->assertSame('logger', $message_array['_ctxt_from']);
 
         // Test with extraPrefix
         $formatter = new GelfMessageFormatter(null, null, 'CTX');
@@ -129,7 +129,7 @@ class GelfMessageFormatterTest extends \PHPUnit\Framework\TestCase
         $message_array = $message->toArray();
 
         $this->assertArrayHasKey('_CTXfrom', $message_array);
-        $this->assertEquals('logger', $message_array['_CTXfrom']);
+        $this->assertSame('logger', $message_array['_CTXfrom']);
     }
 
     /**
@@ -156,8 +156,8 @@ class GelfMessageFormatterTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf('Gelf\Message', $message);
 
-        $this->assertEquals("/some/file/in/dir.php", $message->getFile());
-        $this->assertEquals("56", $message->getLine());
+        $this->assertSame("/some/file/in/dir.php", $message->getFile());
+        $this->assertSame("56", $message->getLine());
     }
 
     /**
@@ -183,7 +183,7 @@ class GelfMessageFormatterTest extends \PHPUnit\Framework\TestCase
         $message_array = $message->toArray();
 
         $this->assertArrayHasKey('_key', $message_array);
-        $this->assertEquals('pair', $message_array['_key']);
+        $this->assertSame('pair', $message_array['_key']);
 
         // Test with extraPrefix
         $formatter = new GelfMessageFormatter(null, 'EXT');
@@ -194,7 +194,7 @@ class GelfMessageFormatterTest extends \PHPUnit\Framework\TestCase
         $message_array = $message->toArray();
 
         $this->assertArrayHasKey('_EXTkey', $message_array);
-        $this->assertEquals('pair', $message_array['_EXTkey']);
+        $this->assertSame('pair', $message_array['_EXTkey']);
     }
 
     public function testFormatWithLargeData()

--- a/tests/Monolog/Formatter/JsonFormatterTest.php
+++ b/tests/Monolog/Formatter/JsonFormatterTest.php
@@ -24,11 +24,11 @@ class JsonFormatterTest extends TestCase
     public function testConstruct()
     {
         $formatter = new JsonFormatter();
-        $this->assertEquals(JsonFormatter::BATCH_MODE_JSON, $formatter->getBatchMode());
-        $this->assertEquals(true, $formatter->isAppendingNewlines());
+        $this->assertSame(JsonFormatter::BATCH_MODE_JSON, $formatter->getBatchMode());
+        $this->assertTrue($formatter->isAppendingNewlines());
         $formatter = new JsonFormatter(JsonFormatter::BATCH_MODE_NEWLINES, false);
-        $this->assertEquals(JsonFormatter::BATCH_MODE_NEWLINES, $formatter->getBatchMode());
-        $this->assertEquals(false, $formatter->isAppendingNewlines());
+        $this->assertSame(JsonFormatter::BATCH_MODE_NEWLINES, $formatter->getBatchMode());
+        $this->assertFalse($formatter->isAppendingNewlines());
     }
 
     /**
@@ -38,11 +38,11 @@ class JsonFormatterTest extends TestCase
     {
         $formatter = new JsonFormatter();
         $record = $this->getRecord();
-        $this->assertEquals(json_encode($record)."\n", $formatter->format($record));
+        $this->assertSame(json_encode($record)."\n", $formatter->format($record));
 
         $formatter = new JsonFormatter(JsonFormatter::BATCH_MODE_JSON, false);
         $record = $this->getRecord();
-        $this->assertEquals('{"message":"test","context":[],"level":300,"level_name":"WARNING","channel":"test","datetime":"'.$record['datetime']->format('Y-m-d\TH:i:s.uP').'","extra":[]}', $formatter->format($record));
+        $this->assertSame('{"message":"test","context":[],"level":300,"level_name":"WARNING","channel":"test","datetime":"'.$record['datetime']->format('Y-m-d\TH:i:s.uP').'","extra":[]}', $formatter->format($record));
     }
 
     /**
@@ -56,7 +56,7 @@ class JsonFormatterTest extends TestCase
             $this->getRecord(Logger::WARNING),
             $this->getRecord(Logger::DEBUG),
         ];
-        $this->assertEquals(json_encode($records), $formatter->formatBatch($records));
+        $this->assertSame(json_encode($records), $formatter->formatBatch($records));
     }
 
     /**
@@ -73,7 +73,7 @@ class JsonFormatterTest extends TestCase
         array_walk($expected, function (&$value, $key) {
             $value = json_encode($value);
         });
-        $this->assertEquals(implode("\n", $expected), $formatter->formatBatch($records));
+        $this->assertSame(implode("\n", $expected), $formatter->formatBatch($records));
     }
 
     public function testDefFormatWithException()
@@ -118,7 +118,7 @@ class JsonFormatterTest extends TestCase
      */
     private function assertContextContainsFormattedException($expected, $actual)
     {
-        $this->assertEquals(
+        $this->assertSame(
             '{"level_name":"CRITICAL","channel":"core","context":{"exception":'.$expected.'},"datetime":null,"extra":[],"message":"foobar"}'."\n",
             $actual
         );

--- a/tests/Monolog/Formatter/LineFormatterTest.php
+++ b/tests/Monolog/Formatter/LineFormatterTest.php
@@ -27,7 +27,7 @@ class LineFormatterTest extends \PHPUnit\Framework\TestCase
             'datetime' => new \DateTimeImmutable,
             'extra' => [],
         ]);
-        $this->assertEquals('['.date('Y-m-d').'] log.WARNING: foo [] []'."\n", $message);
+        $this->assertSame('['.date('Y-m-d').'] log.WARNING: foo [] []'."\n", $message);
     }
 
     public function testDefFormatWithArrayContext()
@@ -46,7 +46,7 @@ class LineFormatterTest extends \PHPUnit\Framework\TestCase
                 'null' => null,
             ],
         ]);
-        $this->assertEquals('['.date('Y-m-d').'] meh.ERROR: foo {"foo":"bar","baz":"qux","bool":false,"null":null} []'."\n", $message);
+        $this->assertSame('['.date('Y-m-d').'] meh.ERROR: foo {"foo":"bar","baz":"qux","bool":false,"null":null} []'."\n", $message);
     }
 
     public function testDefFormatExtras()
@@ -60,7 +60,7 @@ class LineFormatterTest extends \PHPUnit\Framework\TestCase
             'extra' => ['ip' => '127.0.0.1'],
             'message' => 'log',
         ]);
-        $this->assertEquals('['.date('Y-m-d').'] meh.ERROR: log [] {"ip":"127.0.0.1"}'."\n", $message);
+        $this->assertSame('['.date('Y-m-d').'] meh.ERROR: log [] {"ip":"127.0.0.1"}'."\n", $message);
     }
 
     public function testFormatExtras()
@@ -74,7 +74,7 @@ class LineFormatterTest extends \PHPUnit\Framework\TestCase
             'extra' => ['ip' => '127.0.0.1', 'file' => 'test'],
             'message' => 'log',
         ]);
-        $this->assertEquals('['.date('Y-m-d').'] meh.ERROR: log [] test {"ip":"127.0.0.1"}'."\n", $message);
+        $this->assertSame('['.date('Y-m-d').'] meh.ERROR: log [] test {"ip":"127.0.0.1"}'."\n", $message);
     }
 
     public function testContextAndExtraOptionallyNotShownIfEmpty()
@@ -88,7 +88,7 @@ class LineFormatterTest extends \PHPUnit\Framework\TestCase
             'extra' => [],
             'message' => 'log',
         ]);
-        $this->assertEquals('['.date('Y-m-d').'] meh.ERROR: log  '."\n", $message);
+        $this->assertSame('['.date('Y-m-d').'] meh.ERROR: log  '."\n", $message);
     }
 
     public function testContextAndExtraReplacement()
@@ -102,7 +102,7 @@ class LineFormatterTest extends \PHPUnit\Framework\TestCase
             'extra' => ['foo' => 'xbar'],
             'message' => 'log',
         ]);
-        $this->assertEquals('bar => xbar', $message);
+        $this->assertSame('bar => xbar', $message);
     }
 
     public function testDefFormatWithObject()
@@ -117,7 +117,7 @@ class LineFormatterTest extends \PHPUnit\Framework\TestCase
             'message' => 'foobar',
         ]);
 
-        $this->assertEquals('['.date('Y-m-d').'] meh.ERROR: foobar [] {"foo":{"Monolog\\\\Formatter\\\\TestFoo":{"foo":"fooValue"}},"bar":{"Monolog\\\\Formatter\\\\TestBar":"bar"},"baz":[],"res":"[resource(stream)]"}'."\n", $message);
+        $this->assertSame('['.date('Y-m-d').'] meh.ERROR: foobar [] {"foo":{"Monolog\\\\Formatter\\\\TestFoo":{"foo":"fooValue"}},"bar":{"Monolog\\\\Formatter\\\\TestBar":"bar"},"baz":[],"res":"[resource(stream)]"}'."\n", $message);
     }
 
     public function testDefFormatWithException()
@@ -134,7 +134,7 @@ class LineFormatterTest extends \PHPUnit\Framework\TestCase
 
         $path = str_replace('\\/', '/', json_encode(__FILE__));
 
-        $this->assertEquals('['.date('Y-m-d').'] core.CRITICAL: foobar {"exception":"[object] (RuntimeException(code: 0): Foo at '.substr($path, 1, -1).':'.(__LINE__ - 8).')"} []'."\n", $message);
+        $this->assertSame('['.date('Y-m-d').'] core.CRITICAL: foobar {"exception":"[object] (RuntimeException(code: 0): Foo at '.substr($path, 1, -1).':'.(__LINE__ - 8).')"} []'."\n", $message);
     }
 
     public function testDefFormatWithExceptionAndStacktrace()
@@ -170,7 +170,7 @@ class LineFormatterTest extends \PHPUnit\Framework\TestCase
 
         $path = str_replace('\\/', '/', json_encode(__FILE__));
 
-        $this->assertEquals('['.date('Y-m-d').'] core.CRITICAL: foobar {"exception":"[object] (RuntimeException(code: 0): Foo at '.substr($path, 1, -1).':'.(__LINE__ - 8).', LogicException(code: 0): Wut? at '.substr($path, 1, -1).':'.(__LINE__ - 12).')"} []'."\n", $message);
+        $this->assertSame('['.date('Y-m-d').'] core.CRITICAL: foobar {"exception":"[object] (RuntimeException(code: 0): Foo at '.substr($path, 1, -1).':'.(__LINE__ - 8).', LogicException(code: 0): Wut? at '.substr($path, 1, -1).':'.(__LINE__ - 12).')"} []'."\n", $message);
     }
 
     public function testBatchFormat()
@@ -194,7 +194,7 @@ class LineFormatterTest extends \PHPUnit\Framework\TestCase
                 'extra' => [],
             ],
         ]);
-        $this->assertEquals('['.date('Y-m-d').'] test.CRITICAL: bar [] []'."\n".'['.date('Y-m-d').'] log.WARNING: foo [] []'."\n", $message);
+        $this->assertSame('['.date('Y-m-d').'] test.CRITICAL: bar [] []'."\n".'['.date('Y-m-d').'] log.WARNING: foo [] []'."\n", $message);
     }
 
     public function testFormatShouldStripInlineLineBreaks()

--- a/tests/Monolog/Formatter/LogglyFormatterTest.php
+++ b/tests/Monolog/Formatter/LogglyFormatterTest.php
@@ -21,9 +21,9 @@ class LogglyFormatterTest extends TestCase
     public function testConstruct()
     {
         $formatter = new LogglyFormatter();
-        $this->assertEquals(LogglyFormatter::BATCH_MODE_NEWLINES, $formatter->getBatchMode());
+        $this->assertSame(LogglyFormatter::BATCH_MODE_NEWLINES, $formatter->getBatchMode());
         $formatter = new LogglyFormatter(LogglyFormatter::BATCH_MODE_JSON);
-        $this->assertEquals(LogglyFormatter::BATCH_MODE_JSON, $formatter->getBatchMode());
+        $this->assertSame(LogglyFormatter::BATCH_MODE_JSON, $formatter->getBatchMode());
     }
 
     /**
@@ -34,8 +34,8 @@ class LogglyFormatterTest extends TestCase
         $formatter = new LogglyFormatter();
         $record = $this->getRecord();
         $formatted_decoded = json_decode($formatter->format($record), true);
-        $this->assertArrayNotHasKey("datetime", $formatted_decoded);
-        $this->assertArrayHasKey("timestamp", $formatted_decoded);
-        $this->assertEquals($record["datetime"]->format('Y-m-d\TH:i:s.uO'), $formatted_decoded["timestamp"]);
+        $this->assertArrayNotHasKey('datetime', $formatted_decoded);
+        $this->assertArrayHasKey('timestamp', $formatted_decoded);
+        $this->assertSame($record["datetime"]->format('Y-m-d\TH:i:s.uO'), $formatted_decoded["timestamp"]);
     }
 }

--- a/tests/Monolog/Formatter/LogmaticFormatterTest.php
+++ b/tests/Monolog/Formatter/LogmaticFormatterTest.php
@@ -30,7 +30,7 @@ class LogmaticFormatterTest extends TestCase
         $formatted_decoded = json_decode($formatter->format($record), true);
         $this->assertArrayHasKey('hostname', $formatted_decoded);
         $this->assertArrayHasKey('appname', $formatted_decoded);
-        $this->assertEquals('testHostname', $formatted_decoded['hostname']);
-        $this->assertEquals('testAppname', $formatted_decoded['appname']);
+        $this->assertSame('testHostname', $formatted_decoded['hostname']);
+        $this->assertSame('testAppname', $formatted_decoded['appname']);
     }
 }

--- a/tests/Monolog/Formatter/LogstashFormatterTest.php
+++ b/tests/Monolog/Formatter/LogstashFormatterTest.php
@@ -40,20 +40,20 @@ class LogstashFormatterTest extends \PHPUnit\Framework\TestCase
 
         $message = json_decode($formatter->format($record), true);
 
-        $this->assertEquals("1970-01-01T00:00:00.000000+00:00", $message['@timestamp']);
-        $this->assertEquals("1", $message['@version']);
-        $this->assertEquals('log', $message['message']);
-        $this->assertEquals('meh', $message['channel']);
-        $this->assertEquals('ERROR', $message['level']);
-        $this->assertEquals(Logger::ERROR, $message['monolog_level']);
-        $this->assertEquals('test', $message['type']);
-        $this->assertEquals('hostname', $message['host']);
+        $this->assertSame('1970-01-01T00:00:00.000000+00:00', $message['@timestamp']);
+        $this->assertSame(1, $message['@version']);
+        $this->assertSame('log', $message['message']);
+        $this->assertSame('meh', $message['channel']);
+        $this->assertSame('ERROR', $message['level']);
+        $this->assertSame(Logger::ERROR, $message['monolog_level']);
+        $this->assertSame('test', $message['type']);
+        $this->assertSame('hostname', $message['host']);
 
         $formatter = new LogstashFormatter('mysystem', null, null, 'ctxt_');
 
         $message = json_decode($formatter->format($record), true);
 
-        $this->assertEquals('mysystem', $message['type']);
+        $this->assertSame('mysystem', $message['type']);
     }
 
     /**
@@ -74,8 +74,8 @@ class LogstashFormatterTest extends \PHPUnit\Framework\TestCase
 
         $message = json_decode($formatter->format($record), true);
 
-        $this->assertEquals('test', $message['extra']['file']);
-        $this->assertEquals(14, $message['extra']['line']);
+        $this->assertSame('test', $message['extra']['file']);
+        $this->assertSame(14, $message['extra']['line']);
     }
 
     /**
@@ -98,7 +98,7 @@ class LogstashFormatterTest extends \PHPUnit\Framework\TestCase
 
         $this->assertArrayHasKey('ctxt_context', $message);
         $this->assertArrayHasKey('from', $message['ctxt_context']);
-        $this->assertEquals('logger', $message['ctxt_context']['from']);
+        $this->assertSame('logger', $message['ctxt_context']['from']);
 
         // Test with extraPrefix
         $formatter = new LogstashFormatter('test', null, null, 'CTX');
@@ -106,7 +106,7 @@ class LogstashFormatterTest extends \PHPUnit\Framework\TestCase
 
         $this->assertArrayHasKey('CTXcontext', $message);
         $this->assertArrayHasKey('from', $message['CTXcontext']);
-        $this->assertEquals('logger', $message['CTXcontext']['from']);
+        $this->assertSame('logger', $message['CTXcontext']['from']);
     }
 
     /**
@@ -129,7 +129,7 @@ class LogstashFormatterTest extends \PHPUnit\Framework\TestCase
 
         $this->assertArrayHasKey('extra', $message);
         $this->assertArrayHasKey('key', $message['extra']);
-        $this->assertEquals('pair', $message['extra']['key']);
+        $this->assertSame('pair', $message['extra']['key']);
 
         // Test with extraPrefix
         $formatter = new LogstashFormatter('test', null, 'EXT', 'ctxt_');
@@ -137,7 +137,7 @@ class LogstashFormatterTest extends \PHPUnit\Framework\TestCase
 
         $this->assertArrayHasKey('EXTextra', $message);
         $this->assertArrayHasKey('key', $message['EXTextra']);
-        $this->assertEquals('pair', $message['EXTextra']['key']);
+        $this->assertSame('pair', $message['EXTextra']['key']);
     }
 
     public function testFormatWithApplicationNameV1()
@@ -156,7 +156,7 @@ class LogstashFormatterTest extends \PHPUnit\Framework\TestCase
         $message = json_decode($formatter->format($record), true);
 
         $this->assertArrayHasKey('type', $message);
-        $this->assertEquals('app', $message['type']);
+        $this->assertSame('app', $message['type']);
     }
 
     public function testFormatWithLatin9Data()
@@ -176,12 +176,12 @@ class LogstashFormatterTest extends \PHPUnit\Framework\TestCase
 
         $message = json_decode($formatter->format($record), true);
 
-        $this->assertEquals("1970-01-01T00:00:00.000000+00:00", $message['@timestamp']);
-        $this->assertEquals('log', $message['message']);
-        $this->assertEquals('¯\_(ツ)_/¯', $message['channel']);
-        $this->assertEquals('ERROR', $message['level']);
-        $this->assertEquals('test', $message['type']);
-        $this->assertEquals('hostname', $message['host']);
-        $this->assertEquals('ÖWN; FBCR/OrangeEspaña; Versão/4.0; Färist', $message['extra']['user_agent']);
+        $this->assertSame("1970-01-01T00:00:00.000000+00:00", $message['@timestamp']);
+        $this->assertSame('log', $message['message']);
+        $this->assertSame('¯\_(ツ)_/¯', $message['channel']);
+        $this->assertSame('ERROR', $message['level']);
+        $this->assertSame('test', $message['type']);
+        $this->assertSame('hostname', $message['host']);
+        $this->assertSame('ÖWN; FBCR/OrangeEspaña; Versão/4.0; Färist', $message['extra']['user_agent']);
     }
 }

--- a/tests/Monolog/Formatter/MongoDBFormatterTest.php
+++ b/tests/Monolog/Formatter/MongoDBFormatterTest.php
@@ -70,14 +70,14 @@ class MongoDBFormatterTest extends \PHPUnit\Framework\TestCase
         $formattedRecord = $formatter->format($record);
 
         $this->assertCount(7, $formattedRecord);
-        $this->assertEquals('some log message', $formattedRecord['message']);
-        $this->assertEquals([], $formattedRecord['context']);
-        $this->assertEquals(Logger::WARNING, $formattedRecord['level']);
-        $this->assertEquals(Logger::getLevelName(Logger::WARNING), $formattedRecord['level_name']);
-        $this->assertEquals('test', $formattedRecord['channel']);
+        $this->assertSame('some log message', $formattedRecord['message']);
+        $this->assertSame([], $formattedRecord['context']);
+        $this->assertSame(Logger::WARNING, $formattedRecord['level']);
+        $this->assertSame(Logger::getLevelName(Logger::WARNING), $formattedRecord['level_name']);
+        $this->assertSame('test', $formattedRecord['channel']);
         $this->assertInstanceOf('MongoDB\BSON\UTCDateTime', $formattedRecord['datetime']);
-        $this->assertEquals('1453410690123', $formattedRecord['datetime']->__toString());
-        $this->assertEquals([], $formattedRecord['extra']);
+        $this->assertSame('1453410690123', $formattedRecord['datetime']->__toString());
+        $this->assertSame([], $formattedRecord['extra']);
     }
 
     public function testRecursiveFormat()
@@ -107,7 +107,7 @@ class MongoDBFormatterTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(5, $formattedRecord['context']);
         $this->assertInstanceOf('MongoDB\BSON\UTCDateTime', $formattedRecord['context']['stuff']);
-        $this->assertEquals('-29731710213', $formattedRecord['context']['stuff']->__toString());
+        $this->assertSame('-29731710213', $formattedRecord['context']['stuff']->__toString());
         $this->assertEquals(
             [
                 'foo' => 'something',
@@ -116,16 +116,16 @@ class MongoDBFormatterTest extends \PHPUnit\Framework\TestCase
             ],
             $formattedRecord['context']['some_object']
         );
-        $this->assertEquals('some string', $formattedRecord['context']['context_string']);
-        $this->assertEquals(123456, $formattedRecord['context']['context_int']);
+        $this->assertSame('some string', $formattedRecord['context']['context_string']);
+        $this->assertSame(123456, $formattedRecord['context']['context_int']);
 
         $this->assertCount(5, $formattedRecord['context']['except']);
-        $this->assertEquals('exception message', $formattedRecord['context']['except']['message']);
-        $this->assertEquals(987, $formattedRecord['context']['except']['code']);
+        $this->assertSame('exception message', $formattedRecord['context']['except']['message']);
+        $this->assertSame(987, $formattedRecord['context']['except']['code']);
         $this->assertInternalType('string', $formattedRecord['context']['except']['file']);
         $this->assertInternalType('integer', $formattedRecord['context']['except']['code']);
         $this->assertInternalType('string', $formattedRecord['context']['except']['trace']);
-        $this->assertEquals('Exception', $formattedRecord['context']['except']['class']);
+        $this->assertSame('Exception', $formattedRecord['context']['except']['class']);
     }
 
     public function testFormatDepthArray()
@@ -255,8 +255,8 @@ class MongoDBFormatterTest extends \PHPUnit\Framework\TestCase
         $formatter = new MongoDBFormatter(2, false);
         $formattedRecord = $formatter->format($record);
 
-        $this->assertEquals('exception message', $formattedRecord['context']['nest2']['message']);
-        $this->assertEquals(987, $formattedRecord['context']['nest2']['code']);
-        $this->assertEquals('[...]', $formattedRecord['context']['nest2']['trace']);
+        $this->assertSame('exception message', $formattedRecord['context']['nest2']['message']);
+        $this->assertSame(987, $formattedRecord['context']['nest2']['code']);
+        $this->assertSame('[...]', $formattedRecord['context']['nest2']['trace']);
     }
 }

--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -41,7 +41,7 @@ class NormalizerFormatterTest extends \PHPUnit\Framework\TestCase
             ],
         ]);
 
-        $this->assertEquals([
+        $this->assertSame([
             'level_name' => 'ERROR',
             'channel' => 'meh',
             'message' => 'foo',
@@ -72,10 +72,10 @@ class NormalizerFormatterTest extends \PHPUnit\Framework\TestCase
         ]);
 
         $this->assertGreaterThan(5, count($formatted['exception']['trace']));
-        $this->assertTrue(isset($formatted['exception']['previous']));
+        $this->assertArrayHasKey('previous', $formatted['exception']);
         unset($formatted['exception']['trace'], $formatted['exception']['previous']);
 
-        $this->assertEquals([
+        $this->assertSame([
             'exception' => [
                 'class'   => get_class($e2),
                 'message' => $e2->getMessage(),
@@ -99,7 +99,7 @@ class NormalizerFormatterTest extends \PHPUnit\Framework\TestCase
 
         unset($formatted['exception']['trace']);
 
-        $this->assertEquals([
+        $this->assertSame([
             'exception' => [
                 'class' => 'SoapFault',
                 'message' => 'bar',
@@ -143,7 +143,7 @@ class NormalizerFormatterTest extends \PHPUnit\Framework\TestCase
                 'extra' => [],
             ],
         ]);
-        $this->assertEquals([
+        $this->assertSame([
             [
                 'level_name' => 'CRITICAL',
                 'channel' => 'test',
@@ -191,7 +191,7 @@ class NormalizerFormatterTest extends \PHPUnit\Framework\TestCase
 
         restore_error_handler();
 
-        $this->assertEquals(@json_encode([$foo, $bar]), $res);
+        $this->assertSame(@json_encode([$foo, $bar]), $res);
     }
 
     public function testCanNormalizeReferences()
@@ -224,7 +224,7 @@ class NormalizerFormatterTest extends \PHPUnit\Framework\TestCase
 
         restore_error_handler();
 
-        $this->assertEquals(@json_encode([$resource]), $res);
+        $this->assertSame(@json_encode([$resource]), $res);
     }
 
     public function testNormalizeHandleLargeArrays()
@@ -242,7 +242,7 @@ class NormalizerFormatterTest extends \PHPUnit\Framework\TestCase
         ));
 
         $this->assertCount(1000, $res['context'][0]);
-        $this->assertEquals('Over 1000 items (2000 total), aborting normalization', $res['context'][0]['...']);
+        $this->assertSame('Over 1000 items (2000 total), aborting normalization', $res['context'][0]['...']);
     }
 
     /**

--- a/tests/Monolog/Handler/AbstractHandlerTest.php
+++ b/tests/Monolog/Handler/AbstractHandlerTest.php
@@ -26,13 +26,13 @@ class AbstractHandlerTest extends TestCase
     public function testConstructAndGetSet()
     {
         $handler = $this->getMockForAbstractClass('Monolog\Handler\AbstractHandler', [Logger::WARNING, false]);
-        $this->assertEquals(Logger::WARNING, $handler->getLevel());
-        $this->assertEquals(false, $handler->getBubble());
+        $this->assertSame(Logger::WARNING, $handler->getLevel());
+        $this->assertFalse($handler->getBubble());
 
         $handler->setLevel(Logger::ERROR);
         $handler->setBubble(true);
-        $this->assertEquals(Logger::ERROR, $handler->getLevel());
-        $this->assertEquals(true, $handler->getBubble());
+        $this->assertSame(Logger::ERROR, $handler->getLevel());
+        $this->assertTrue($handler->getBubble());
     }
 
     /**

--- a/tests/Monolog/Handler/AbstractProcessingHandlerTest.php
+++ b/tests/Monolog/Handler/AbstractProcessingHandlerTest.php
@@ -87,7 +87,7 @@ class AbstractProcessingHandlerTest extends TestCase
             }))
         ;
         $handler->handle($this->getRecord());
-        $this->assertEquals(6, count($handledRecord['extra']));
+        $this->assertCount(6, $handledRecord['extra']);
     }
 
     /**
@@ -104,8 +104,8 @@ class AbstractProcessingHandlerTest extends TestCase
         $logger->pushProcessor($processor1);
         $logger->pushProcessor($processor2);
 
-        $this->assertEquals($processor2, $logger->popProcessor());
-        $this->assertEquals($processor1, $logger->popProcessor());
+        $this->assertSame($processor2, $logger->popProcessor());
+        $this->assertSame($processor1, $logger->popProcessor());
         $logger->popProcessor();
     }
 

--- a/tests/Monolog/Handler/BrowserConsoleHandlerTest.php
+++ b/tests/Monolog/Handler/BrowserConsoleHandlerTest.php
@@ -45,7 +45,7 @@ c.log("%cfoo%cbar%c", "font-weight: normal", "color: red", "font-weight: normal"
 }})(console);
 EOF;
 
-        $this->assertEquals($expected, $this->generateScript());
+        $this->assertSame($expected, $this->generateScript());
     }
 
     public function testEscaping()
@@ -61,7 +61,7 @@ c.log("%c[foo] %c\"bar\\n[baz]\"%c", "font-weight: normal", "color: red", "font-
 }})(console);
 EOF;
 
-        $this->assertEquals($expected, $this->generateScript());
+        $this->assertSame($expected, $this->generateScript());
     }
 
     public function testAutolabel()
@@ -81,7 +81,7 @@ c.log("%c%cfoo%c", "font-weight: normal", "background-color: blue; color: white;
 }})(console);
 EOF;
 
-        $this->assertEquals($expected, $this->generateScript());
+        $this->assertSame($expected, $this->generateScript());
     }
 
     public function testContext()
@@ -100,7 +100,7 @@ c.groupEnd();
 }})(console);
 EOF;
 
-        $this->assertEquals($expected, $this->generateScript());
+        $this->assertSame($expected, $this->generateScript());
     }
 
     public function testConcurrentHandlers()
@@ -125,6 +125,6 @@ c.log("%ctest4", "font-weight: normal");
 }})(console);
 EOF;
 
-        $this->assertEquals($expected, $this->generateScript());
+        $this->assertSame($expected, $this->generateScript());
     }
 }

--- a/tests/Monolog/Handler/BufferHandlerTest.php
+++ b/tests/Monolog/Handler/BufferHandlerTest.php
@@ -33,7 +33,7 @@ class BufferHandlerTest extends TestCase
         $this->assertFalse($test->hasInfoRecords());
         $handler->close();
         $this->assertTrue($test->hasInfoRecords());
-        $this->assertTrue(count($test->getRecords()) === 2);
+        $this->assertCount(2, $test->getRecords());
     }
 
     /**

--- a/tests/Monolog/Handler/ChromePHPHandlerTest.php
+++ b/tests/Monolog/Handler/ChromePHPHandlerTest.php
@@ -49,7 +49,7 @@ class ChromePHPHandlerTest extends TestCase
             ]))),
         ];
 
-        $this->assertEquals($expected, $handler->getHeaders());
+        $this->assertSame($expected, $handler->getHeaders());
     }
 
     public static function agentsProvider()
@@ -99,7 +99,7 @@ class ChromePHPHandlerTest extends TestCase
             ]))),
         ];
 
-        $this->assertEquals($expected, $handler->getHeaders());
+        $this->assertSame($expected, $handler->getHeaders());
     }
 
     public function testConcurrentHandlers()
@@ -128,7 +128,7 @@ class ChromePHPHandlerTest extends TestCase
             ]))),
         ];
 
-        $this->assertEquals($expected, $handler2->getHeaders());
+        $this->assertSame($expected, $handler2->getHeaders());
     }
 }
 

--- a/tests/Monolog/Handler/DeduplicationHandlerTest.php
+++ b/tests/Monolog/Handler/DeduplicationHandlerTest.php
@@ -126,11 +126,11 @@ class DeduplicationHandlerTest extends TestCase
 
         // log is written as none of them are duplicate
         $handler->flush();
-        $this->assertSame(
+        $this->assertStringEqualsFile(
+            sys_get_temp_dir() . '/monolog_dedup.log',
             $record['datetime']->getTimestamp() . ":ERROR:test\n" .
             $record2['datetime']->getTimestamp() . ":CRITICAL:test\n" .
-            $record3['datetime']->getTimestamp() . ":CRITICAL:test\n",
-            file_get_contents(sys_get_temp_dir() . '/monolog_dedup.log')
+            $record3['datetime']->getTimestamp() . ":CRITICAL:test\n"
         );
         $this->assertTrue($test->hasErrorRecords());
         $this->assertTrue($test->hasCriticalRecords());
@@ -147,11 +147,11 @@ class DeduplicationHandlerTest extends TestCase
         $handler->flush();
 
         // log should now contain the new errors and the previous one that was recent enough
-        $this->assertSame(
+        $this->assertStringEqualsFile(
+            sys_get_temp_dir() . '/monolog_dedup.log',
             $record3['datetime']->getTimestamp() . ":CRITICAL:test\n" .
             $record['datetime']->getTimestamp() . ":ERROR:test\n" .
-            $record2['datetime']->getTimestamp() . ":CRITICAL:test\n",
-            file_get_contents(sys_get_temp_dir() . '/monolog_dedup.log')
+            $record2['datetime']->getTimestamp() . ":CRITICAL:test\n"
         );
         $this->assertTrue($test->hasErrorRecords());
         $this->assertTrue($test->hasCriticalRecords());

--- a/tests/Monolog/Handler/ElasticSearchHandlerTest.php
+++ b/tests/Monolog/Handler/ElasticSearchHandlerTest.php
@@ -91,8 +91,8 @@ class ElasticSearchHandlerTest extends TestCase
         $formatter = new ElasticaFormatter('index_new', 'type_new');
         $handler->setFormatter($formatter);
         $this->assertInstanceOf('Monolog\Formatter\ElasticaFormatter', $handler->getFormatter());
-        $this->assertEquals('index_new', $handler->getFormatter()->getIndex());
-        $this->assertEquals('type_new', $handler->getFormatter()->getType());
+        $this->assertSame('index_new', $handler->getFormatter()->getIndex());
+        $this->assertSame('type_new', $handler->getFormatter()->getType());
     }
 
     /**

--- a/tests/Monolog/Handler/FingersCrossedHandlerTest.php
+++ b/tests/Monolog/Handler/FingersCrossedHandlerTest.php
@@ -35,7 +35,7 @@ class FingersCrossedHandlerTest extends TestCase
         $handler->handle($this->getRecord(Logger::WARNING));
         $handler->close();
         $this->assertTrue($test->hasInfoRecords());
-        $this->assertTrue(count($test->getRecords()) === 3);
+        $this->assertCount(3, $test->getRecords());
     }
 
     /**
@@ -122,7 +122,7 @@ class FingersCrossedHandlerTest extends TestCase
         $this->assertFalse($test->hasInfoRecords());
         $handler->handle($this->getRecord(Logger::WARNING));
         $this->assertTrue($test->hasInfoRecords());
-        $this->assertTrue(count($test->getRecords()) === 3);
+        $this->assertCount(3, $test->getRecords());
     }
 
     /**

--- a/tests/Monolog/Handler/FirePHPHandlerTest.php
+++ b/tests/Monolog/Handler/FirePHPHandlerTest.php
@@ -40,7 +40,7 @@ class FirePHPHandlerTest extends TestCase
             'X-Wf-1-1-1-2'       => 'test',
         ];
 
-        $this->assertEquals($expected, $handler->getHeaders());
+        $this->assertSame($expected, $handler->getHeaders());
     }
 
     public function testConcurrentHandlers()
@@ -68,8 +68,8 @@ class FirePHPHandlerTest extends TestCase
             'X-Wf-1-1-1-4'       => 'test',
         ];
 
-        $this->assertEquals($expected, $handler->getHeaders());
-        $this->assertEquals($expected2, $handler2->getHeaders());
+        $this->assertSame($expected, $handler->getHeaders());
+        $this->assertSame($expected2, $handler2->getHeaders());
     }
 }
 

--- a/tests/Monolog/Handler/FleepHookHandlerTest.php
+++ b/tests/Monolog/Handler/FleepHookHandlerTest.php
@@ -47,8 +47,8 @@ class FleepHookHandlerTest extends TestCase
      */
     public function testConstructorSetsExpectedDefaults()
     {
-        $this->assertEquals(Logger::DEBUG, $this->handler->getLevel());
-        $this->assertEquals(true, $this->handler->getBubble());
+        $this->assertSame(Logger::DEBUG, $this->handler->getLevel());
+        $this->assertTrue($this->handler->getBubble());
     }
 
     /**
@@ -72,7 +72,7 @@ class FleepHookHandlerTest extends TestCase
         $handlerFormatter = $this->handler->getFormatter();
         $actual = $handlerFormatter->format($record);
 
-        $this->assertEquals($expected, $actual, 'Empty context and extra arrays should not be rendered');
+        $this->assertSame($expected, $actual, 'Empty context and extra arrays should not be rendered');
     }
 
     /**
@@ -80,6 +80,6 @@ class FleepHookHandlerTest extends TestCase
      */
     public function testConnectionStringisConstructedCorrectly()
     {
-        $this->assertEquals('ssl://' . FleepHookHandler::FLEEP_HOST . ':443', $this->handler->getConnectionString());
+        $this->assertSame('ssl://' . FleepHookHandler::FLEEP_HOST . ':443', $this->handler->getConnectionString());
     }
 }

--- a/tests/Monolog/Handler/GroupHandlerTest.php
+++ b/tests/Monolog/Handler/GroupHandlerTest.php
@@ -38,7 +38,7 @@ class GroupHandlerTest extends TestCase
         foreach ($testHandlers as $test) {
             $this->assertTrue($test->hasDebugRecords());
             $this->assertTrue($test->hasInfoRecords());
-            $this->assertTrue(count($test->getRecords()) === 2);
+            $this->assertCount(2, $test->getRecords());
         }
     }
 
@@ -53,7 +53,7 @@ class GroupHandlerTest extends TestCase
         foreach ($testHandlers as $test) {
             $this->assertTrue($test->hasDebugRecords());
             $this->assertTrue($test->hasInfoRecords());
-            $this->assertTrue(count($test->getRecords()) === 2);
+            $this->assertCount(2, $test->getRecords());
         }
     }
 
@@ -103,7 +103,7 @@ class GroupHandlerTest extends TestCase
         foreach ($testHandlers as $test) {
             $this->assertTrue($test->hasDebugRecords());
             $this->assertTrue($test->hasInfoRecords());
-            $this->assertTrue(count($test->getRecords()) === 2);
+            $this->assertCount(2, $test->getRecords());
             $records = $test->getRecords();
             $this->assertTrue($records[0]['extra']['foo']);
             $this->assertTrue($records[1]['extra']['foo']);

--- a/tests/Monolog/Handler/HandlerWrapperTest.php
+++ b/tests/Monolog/Handler/HandlerWrapperTest.php
@@ -55,7 +55,7 @@ class HandlerWrapperTest extends TestCase
             ->with($record)
             ->willReturn($result);
 
-        $this->assertEquals($result, $this->wrapper->isHandling($record));
+        $this->assertSame($result, $this->wrapper->isHandling($record));
     }
 
     /**
@@ -70,7 +70,7 @@ class HandlerWrapperTest extends TestCase
             ->with($record)
             ->willReturn($result);
 
-        $this->assertEquals($result, $this->wrapper->handle($record));
+        $this->assertSame($result, $this->wrapper->handle($record));
     }
 
     /**
@@ -85,6 +85,6 @@ class HandlerWrapperTest extends TestCase
             ->with($records)
             ->willReturn($result);
 
-        $this->assertEquals($result, $this->wrapper->handleBatch($records));
+        $this->assertSame($result, $this->wrapper->handleBatch($records));
     }
 }

--- a/tests/Monolog/Handler/NewRelicHandlerTest.php
+++ b/tests/Monolog/Handler/NewRelicHandlerTest.php
@@ -47,7 +47,7 @@ class NewRelicHandlerTest extends TestCase
     {
         $handler = new StubNewRelicHandler();
         $handler->handle($this->getRecord(Logger::ERROR, 'log message', ['a' => 'b']));
-        $this->assertEquals(['context_a' => 'b'], self::$customParameters);
+        $this->assertSame(['context_a' => 'b'], self::$customParameters);
     }
 
     public function testThehandlerCanAddExplodedContextParamsToTheNewRelicTrace()
@@ -58,7 +58,7 @@ class NewRelicHandlerTest extends TestCase
             'log message',
             ['a' => ['key1' => 'value1', 'key2' => 'value2']]
         ));
-        $this->assertEquals(
+        $this->assertSame(
             ['context_a_key1' => 'value1', 'context_a_key2' => 'value2'],
             self::$customParameters
         );
@@ -72,7 +72,7 @@ class NewRelicHandlerTest extends TestCase
         $handler = new StubNewRelicHandler();
         $handler->handle($record);
 
-        $this->assertEquals(['extra_c' => 'd'], self::$customParameters);
+        $this->assertSame(['extra_c' => 'd'], self::$customParameters);
     }
 
     public function testThehandlerCanAddExplodedExtraParamsToTheNewRelicTrace()
@@ -83,7 +83,7 @@ class NewRelicHandlerTest extends TestCase
         $handler = new StubNewRelicHandler(Logger::ERROR, true, self::$appname, true);
         $handler->handle($record);
 
-        $this->assertEquals(
+        $this->assertSame(
             ['extra_c_key1' => 'value1', 'extra_c_key2' => 'value2'],
             self::$customParameters
         );
@@ -117,7 +117,7 @@ class NewRelicHandlerTest extends TestCase
         $handler = new StubNewRelicHandler();
         $handler->handle($this->getRecord(Logger::ERROR, 'log message'));
 
-        $this->assertEquals(null, self::$appname);
+        $this->assertNull(self::$appname);
     }
 
     public function testTheAppNameCanBeInjectedFromtheConstructor()
@@ -125,7 +125,7 @@ class NewRelicHandlerTest extends TestCase
         $handler = new StubNewRelicHandler(Logger::DEBUG, false, 'myAppName');
         $handler->handle($this->getRecord(Logger::ERROR, 'log message'));
 
-        $this->assertEquals('myAppName', self::$appname);
+        $this->assertSame('myAppName', self::$appname);
     }
 
     public function testTheAppNameCanBeOverriddenFromEachLog()
@@ -133,7 +133,7 @@ class NewRelicHandlerTest extends TestCase
         $handler = new StubNewRelicHandler(Logger::DEBUG, false, 'myAppName');
         $handler->handle($this->getRecord(Logger::ERROR, 'log message', ['appname' => 'logAppName']));
 
-        $this->assertEquals('logAppName', self::$appname);
+        $this->assertSame('logAppName', self::$appname);
     }
 
     public function testTheTransactionNameIsNullByDefault()
@@ -141,7 +141,7 @@ class NewRelicHandlerTest extends TestCase
         $handler = new StubNewRelicHandler();
         $handler->handle($this->getRecord(Logger::ERROR, 'log message'));
 
-        $this->assertEquals(null, self::$transactionName);
+        $this->assertNull(self::$transactionName);
     }
 
     public function testTheTransactionNameCanBeInjectedFromTheConstructor()
@@ -149,7 +149,7 @@ class NewRelicHandlerTest extends TestCase
         $handler = new StubNewRelicHandler(Logger::DEBUG, false, null, false, 'myTransaction');
         $handler->handle($this->getRecord(Logger::ERROR, 'log message'));
 
-        $this->assertEquals('myTransaction', self::$transactionName);
+        $this->assertSame('myTransaction', self::$transactionName);
     }
 
     public function testTheTransactionNameCanBeOverriddenFromEachLog()
@@ -157,7 +157,7 @@ class NewRelicHandlerTest extends TestCase
         $handler = new StubNewRelicHandler(Logger::DEBUG, false, null, false, 'myTransaction');
         $handler->handle($this->getRecord(Logger::ERROR, 'log message', ['transaction_name' => 'logTransactName']));
 
-        $this->assertEquals('logTransactName', self::$transactionName);
+        $this->assertSame('logTransactName', self::$transactionName);
     }
 }
 

--- a/tests/Monolog/Handler/PHPConsoleHandlerTest.php
+++ b/tests/Monolog/Handler/PHPConsoleHandlerTest.php
@@ -109,13 +109,13 @@ class PHPConsoleHandlerTest extends TestCase
     public function testInitWithDefaultConnector()
     {
         $handler = new PHPConsoleHandler();
-        $this->assertEquals(spl_object_hash(Connector::getInstance()), spl_object_hash($handler->getConnector()));
+        $this->assertSame(spl_object_hash(Connector::getInstance()), spl_object_hash($handler->getConnector()));
     }
 
     public function testInitWithCustomConnector()
     {
         $handler = new PHPConsoleHandler([], $this->connector);
-        $this->assertEquals(spl_object_hash($this->connector), spl_object_hash($handler->getConnector()));
+        $this->assertSame(spl_object_hash($this->connector), spl_object_hash($handler->getConnector()));
     }
 
     public function testDebug()
@@ -214,9 +214,9 @@ class PHPConsoleHandlerTest extends TestCase
     public function testOptionUseOwnErrorsAndExceptionsHandler()
     {
         $this->initLogger(['useOwnErrorsHandler' => true, 'useOwnExceptionsHandler' => true]);
-        $this->assertEquals([VendorPhpConsoleHandler::getInstance(), 'handleError'], set_error_handler(function () {
+        $this->assertSame([VendorPhpConsoleHandler::getInstance(), 'handleError'], set_error_handler(function () {
         }));
-        $this->assertEquals([VendorPhpConsoleHandler::getInstance(), 'handleException'], set_exception_handler(function () {
+        $this->assertSame([VendorPhpConsoleHandler::getInstance(), 'handleException'], set_exception_handler(function () {
         }));
     }
 
@@ -268,6 +268,6 @@ class PHPConsoleHandlerTest extends TestCase
     public function testDumperOptions($option, $dumperProperty, $value)
     {
         new PHPConsoleHandler([$option => $value], $this->connector);
-        $this->assertEquals($value, $this->connector->getDumper()->$dumperProperty);
+        $this->assertSame($value, $this->connector->getDumper()->$dumperProperty);
     }
 }

--- a/tests/Monolog/Handler/ProcessHandlerTest.php
+++ b/tests/Monolog/Handler/ProcessHandlerTest.php
@@ -185,11 +185,11 @@ class ProcessHandlerTest extends TestCase
         $handler->handle($this->getRecord(Logger::WARNING, '21 is only the half truth'));
 
         $process = $property->getValue($handler);
-        $this->assertTrue(is_resource($process), 'Process is not running although it should.');
+        $this->assertInternalType('resource', $process, 'Process is not running although it should.');
 
         $handler->close();
 
         $process = $property->getValue($handler);
-        $this->assertFalse(is_resource($process), 'Process is still running although it should not.');
+        $this->assertNotInternalType('resource', $process, 'Process is still running although it should not.');
     }
 }

--- a/tests/Monolog/Handler/RavenHandlerTest.php
+++ b/tests/Monolog/Handler/RavenHandlerTest.php
@@ -62,7 +62,7 @@ class RavenHandlerTest extends TestCase
         $record = $this->getRecord(Logger::DEBUG, 'A test debug message');
         $handler->handle($record);
 
-        $this->assertEquals($ravenClient::DEBUG, $ravenClient->lastData['level']);
+        $this->assertSame($ravenClient::DEBUG, $ravenClient->lastData['level']);
         $this->assertContains($record['message'], $ravenClient->lastData['message']);
     }
 
@@ -74,7 +74,7 @@ class RavenHandlerTest extends TestCase
         $record = $this->getRecord(Logger::WARNING, 'A test warning message');
         $handler->handle($record);
 
-        $this->assertEquals($ravenClient::WARNING, $ravenClient->lastData['level']);
+        $this->assertSame($ravenClient::WARNING, $ravenClient->lastData['level']);
         $this->assertContains($record['message'], $ravenClient->lastData['message']);
     }
 
@@ -87,7 +87,7 @@ class RavenHandlerTest extends TestCase
         $record = $this->getRecord(Logger::INFO, 'test', ['tags' => $tags]);
         $handler->handle($record);
 
-        $this->assertEquals($tags, $ravenClient->lastData['tags']);
+        $this->assertSame($tags, $ravenClient->lastData['tags']);
     }
 
     public function testExtraParameters()
@@ -101,9 +101,9 @@ class RavenHandlerTest extends TestCase
         $record = $this->getRecord(Logger::INFO, 'test', ['checksum' => $checksum, 'release' => $release, 'event_id' => $eventId]);
         $handler->handle($record);
 
-        $this->assertEquals($checksum, $ravenClient->lastData['checksum']);
-        $this->assertEquals($release, $ravenClient->lastData['release']);
-        $this->assertEquals($eventId, $ravenClient->lastData['event_id']);
+        $this->assertSame($checksum, $ravenClient->lastData['checksum']);
+        $this->assertSame($release, $ravenClient->lastData['release']);
+        $this->assertSame($eventId, $ravenClient->lastData['event_id']);
     }
 
     public function testFingerprint()
@@ -115,7 +115,7 @@ class RavenHandlerTest extends TestCase
         $record = $this->getRecord(Logger::INFO, 'test', ['fingerprint' => $fingerprint]);
         $handler->handle($record);
 
-        $this->assertEquals($fingerprint, $ravenClient->lastData['fingerprint']);
+        $this->assertSame($fingerprint, $ravenClient->lastData['fingerprint']);
     }
 
     public function testUserContext()
@@ -136,7 +136,7 @@ class RavenHandlerTest extends TestCase
         $ravenClient->user_context(['id' => 'test_user_id']);
         // handle context
         $handler->handle($recordWithContext);
-        $this->assertEquals($user, $ravenClient->lastData['user']);
+        $this->assertSame($user, $ravenClient->lastData['user']);
 
         // check to see if its reset
         $handler->handle($recordWithNoContext);
@@ -146,7 +146,7 @@ class RavenHandlerTest extends TestCase
         // handle with null context
         $ravenClient->user_context(null);
         $handler->handle($recordWithContext);
-        $this->assertEquals($user, $ravenClient->lastData['user']);
+        $this->assertSame($user, $ravenClient->lastData['user']);
 
         // check to see if its reset
         $handler->handle($recordWithNoContext);
@@ -165,7 +165,7 @@ class RavenHandlerTest extends TestCase
             $handler->handle($record);
         }
 
-        $this->assertEquals($record['message'], $ravenClient->lastData['message']);
+        $this->assertSame($record['message'], $ravenClient->lastData['message']);
     }
 
     public function testHandleBatch()
@@ -248,12 +248,12 @@ class RavenHandlerTest extends TestCase
         $handler->setRelease($release);
         $record = $this->getRecord(Logger::INFO, 'test');
         $handler->handle($record);
-        $this->assertEquals($release, $ravenClient->lastData['release']);
+        $this->assertSame($release, $ravenClient->lastData['release']);
 
         $localRelease = 'v41.41.41';
         $record = $this->getRecord(Logger::INFO, 'test', ['release' => $localRelease]);
         $handler->handle($record);
-        $this->assertEquals($localRelease, $ravenClient->lastData['release']);
+        $this->assertSame($localRelease, $ravenClient->lastData['release']);
     }
 
     private function methodThatThrowsAnException()

--- a/tests/Monolog/Handler/RollbarHandlerTest.php
+++ b/tests/Monolog/Handler/RollbarHandlerTest.php
@@ -51,7 +51,7 @@ class RollbarHandlerTest extends TestCase
 
         $handler->handle($this->createExceptionRecord(Logger::DEBUG));
 
-        $this->assertEquals('debug', $this->reportedExceptionArguments['payload']['level']);
+        $this->assertSame('debug', $this->reportedExceptionArguments['payload']['level']);
     }
 
     private function setupRollbarNotifierMock()

--- a/tests/Monolog/Handler/RotatingFileHandlerTest.php
+++ b/tests/Monolog/Handler/RotatingFileHandlerTest.php
@@ -48,8 +48,8 @@ class RotatingFileHandlerTest extends TestCase
                 )
             );
         }
-        $this->assertEquals($code, $this->lastError['code'], sprintf('Expected an error with code %d to be triggered, got `%s` instead', $code, $this->lastError['code']));
-        $this->assertEquals($message, $this->lastError['message'], sprintf('Expected an error with message `%d` to be triggered, got `%s` instead', $message, $this->lastError['message']));
+        $this->assertSame($code, $this->lastError['code'], sprintf('Expected an error with code %d to be triggered, got `%s` instead', $code, $this->lastError['code']));
+        $this->assertSame($message, $this->lastError['message'], sprintf('Expected an error with message `%d` to be triggered, got `%s` instead', $message, $this->lastError['message']));
     }
 
     public function testRotationCreatesNewFile()
@@ -61,8 +61,8 @@ class RotatingFileHandlerTest extends TestCase
         $handler->handle($this->getRecord());
 
         $log = __DIR__.'/Fixtures/foo-'.date('Y-m-d').'.rot';
-        $this->assertTrue(file_exists($log));
-        $this->assertEquals('test', file_get_contents($log));
+        $this->assertFileExists($log);
+        $this->assertStringEqualsFile($log, 'test');
     }
 
     /**
@@ -88,12 +88,12 @@ class RotatingFileHandlerTest extends TestCase
 
         $handler->close();
 
-        $this->assertTrue(file_exists($log));
-        $this->assertTrue(file_exists($old1));
-        $this->assertEquals($createFile, file_exists($old2));
-        $this->assertEquals($createFile, file_exists($old3));
-        $this->assertEquals($createFile, file_exists($old4));
-        $this->assertEquals('test', file_get_contents($log));
+        $this->assertFileExists($log);
+        $this->assertFileExists($old1);
+        $this->assertSame($createFile, file_exists($old2));
+        $this->assertSame($createFile, file_exists($old3));
+        $this->assertSame($createFile, file_exists($old4));
+        $this->assertStringEqualsFile($log, 'test');
     }
 
     public function rotationTests()
@@ -200,7 +200,7 @@ class RotatingFileHandlerTest extends TestCase
         $handler = new RotatingFileHandler(__DIR__.'/Fixtures/foo.rot');
         $handler->setFormatter($this->getIdentityFormatter());
         $handler->handle($this->getRecord());
-        $this->assertEquals('footest', file_get_contents($log));
+        $this->assertStringEqualsFile($log, 'footest');
     }
 
     public function tearDown()

--- a/tests/Monolog/Handler/SocketHandlerTest.php
+++ b/tests/Monolog/Handler/SocketHandlerTest.php
@@ -51,7 +51,7 @@ class SocketHandlerTest extends TestCase
     {
         $this->createHandler('localhost:1234');
         $this->handler->setConnectionTimeout(10.1);
-        $this->assertEquals(10.1, $this->handler->getConnectionTimeout());
+        $this->assertSame(10.1, $this->handler->getConnectionTimeout());
     }
 
     /**
@@ -67,20 +67,20 @@ class SocketHandlerTest extends TestCase
     {
         $this->createHandler('localhost:1234');
         $this->handler->setTimeout(10.25);
-        $this->assertEquals(10.25, $this->handler->getTimeout());
+        $this->assertSame(10.25, $this->handler->getTimeout());
     }
 
     public function testSetWritingTimeout()
     {
         $this->createHandler('localhost:1234');
         $this->handler->setWritingTimeout(10.25);
-        $this->assertEquals(10.25, $this->handler->getWritingTimeout());
+        $this->assertSame(10.25, $this->handler->getWritingTimeout());
     }
 
     public function testSetConnectionString()
     {
         $this->createHandler('tcp://localhost:9090');
-        $this->assertEquals('tcp://localhost:9090', $this->handler->getConnectionString());
+        $this->assertSame('tcp://localhost:9090', $this->handler->getConnectionString());
     }
 
     /**
@@ -200,7 +200,7 @@ class SocketHandlerTest extends TestCase
         $this->writeRecord('test2');
         $this->writeRecord('test3');
         fseek($this->res, 0);
-        $this->assertEquals('test1test2test3', fread($this->res, 1024));
+        $this->assertSame('test1test2test3', fread($this->res, 1024));
     }
 
     public function testWriteWithMock()
@@ -237,9 +237,9 @@ class SocketHandlerTest extends TestCase
         $this->setMockHandler();
         $this->handler->setPersistent(true);
         $this->writeRecord('Hello world');
-        $this->assertTrue(is_resource($this->res));
+        $this->assertInternalType('resource', $this->res);
         $this->handler->close();
-        $this->assertTrue(is_resource($this->res));
+        $this->assertInternalType('resource', $this->res);
     }
 
     /**

--- a/tests/Monolog/Handler/StreamHandlerTest.php
+++ b/tests/Monolog/Handler/StreamHandlerTest.php
@@ -29,7 +29,7 @@ class StreamHandlerTest extends TestCase
         $handler->handle($this->getRecord(Logger::WARNING, 'test2'));
         $handler->handle($this->getRecord(Logger::WARNING, 'test3'));
         fseek($handle, 0);
-        $this->assertEquals('testtest2test3', fread($handle, 100));
+        $this->assertSame('testtest2test3', fread($handle, 100));
     }
 
     /**
@@ -39,9 +39,9 @@ class StreamHandlerTest extends TestCase
     {
         $handle = fopen('php://memory', 'a+');
         $handler = new StreamHandler($handle);
-        $this->assertTrue(is_resource($handle));
+        $this->assertInternalType('resource', $handle);
         $handler->close();
-        $this->assertTrue(is_resource($handle));
+        $this->assertInternalType('resource', $handle);
     }
 
     /**
@@ -53,7 +53,7 @@ class StreamHandlerTest extends TestCase
         $handler->handle($this->getRecord(Logger::WARNING, 'test'));
         $stream = $handler->getStream();
 
-        $this->assertTrue(is_resource($stream));
+        $this->assertInternalType('resource', $stream);
         $handler->close();
         $this->assertFalse(is_resource($stream));
     }
@@ -68,7 +68,7 @@ class StreamHandlerTest extends TestCase
         $handler->handle($this->getRecord(Logger::WARNING, 'testfoo'));
         $stream = $handler->getStream();
 
-        $this->assertTrue(is_resource($stream));
+        $this->assertInternalType('resource', $stream);
         fseek($stream, 0);
         $this->assertContains('testfoo', stream_get_contents($stream));
         $serialized = serialize($handler);
@@ -78,7 +78,7 @@ class StreamHandlerTest extends TestCase
         $handler->handle($this->getRecord(Logger::WARNING, 'testbar'));
         $stream = $handler->getStream();
 
-        $this->assertTrue(is_resource($stream));
+        $this->assertInternalType('resource', $stream);
         fseek($stream, 0);
         $contents = stream_get_contents($stream);
         $this->assertNotContains('testfoo', $contents);

--- a/tests/Monolog/Handler/SwiftMailerHandlerTest.php
+++ b/tests/Monolog/Handler/SwiftMailerHandlerTest.php
@@ -94,7 +94,7 @@ class SwiftMailerHandlerTest extends TestCase
         ];
         $handler->handleBatch($records);
 
-        $this->assertEquals('Alert: EMERGENCY test', $receivedMessage->getSubject());
+        $this->assertSame('Alert: EMERGENCY test', $receivedMessage->getSubject());
     }
 
     public function testMessageHaveUniqueId()
@@ -109,6 +109,6 @@ class SwiftMailerHandlerTest extends TestCase
         $builtMessage1 = $method->invoke($handler, $messageTemplate, []);
         $builtMessage2 = $method->invoke($handler, $messageTemplate, []);
 
-        $this->assertFalse($builtMessage1->getId() === $builtMessage2->getId(), 'Two different messages have the same id');
+        $this->assertNotSame($builtMessage1->getId(), $builtMessage2->getId(), 'Two different messages have the same id');
     }
 }

--- a/tests/Monolog/Handler/WhatFailureGroupHandlerTest.php
+++ b/tests/Monolog/Handler/WhatFailureGroupHandlerTest.php
@@ -38,7 +38,7 @@ class WhatFailureGroupHandlerTest extends TestCase
         foreach ($testHandlers as $test) {
             $this->assertTrue($test->hasDebugRecords());
             $this->assertTrue($test->hasInfoRecords());
-            $this->assertTrue(count($test->getRecords()) === 2);
+            $this->assertCount(2, $test->getRecords());
         }
     }
 
@@ -53,7 +53,7 @@ class WhatFailureGroupHandlerTest extends TestCase
         foreach ($testHandlers as $test) {
             $this->assertTrue($test->hasDebugRecords());
             $this->assertTrue($test->hasInfoRecords());
-            $this->assertTrue(count($test->getRecords()) === 2);
+            $this->assertCount(2, $test->getRecords());
         }
     }
 

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -22,7 +22,7 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
     public function testGetName()
     {
         $logger = new Logger('foo');
-        $this->assertEquals('foo', $logger->getName());
+        $this->assertSame('foo', $logger->getName());
     }
 
     /**
@@ -30,7 +30,7 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetLevelName()
     {
-        $this->assertEquals('ERROR', Logger::getLevelName(Logger::ERROR));
+        $this->assertSame('ERROR', Logger::getLevelName(Logger::ERROR));
     }
 
     /**
@@ -51,14 +51,14 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
      */
     public function testConvertPSR3ToMonologLevel()
     {
-        $this->assertEquals(Logger::toMonologLevel('debug'), 100);
-        $this->assertEquals(Logger::toMonologLevel('info'), 200);
-        $this->assertEquals(Logger::toMonologLevel('notice'), 250);
-        $this->assertEquals(Logger::toMonologLevel('warning'), 300);
-        $this->assertEquals(Logger::toMonologLevel('error'), 400);
-        $this->assertEquals(Logger::toMonologLevel('critical'), 500);
-        $this->assertEquals(Logger::toMonologLevel('alert'), 550);
-        $this->assertEquals(Logger::toMonologLevel('emergency'), 600);
+        $this->assertSame(100, Logger::toMonologLevel('debug'));
+        $this->assertSame(200, Logger::toMonologLevel('info'));
+        $this->assertSame(250, Logger::toMonologLevel('notice'));
+        $this->assertSame(300, Logger::toMonologLevel('warning'));
+        $this->assertSame(400, Logger::toMonologLevel('error'));
+        $this->assertSame(500, Logger::toMonologLevel('critical'));
+        $this->assertSame(550, Logger::toMonologLevel('alert'));
+        $this->assertSame(600, Logger::toMonologLevel('emergency'));
     }
 
     /**
@@ -80,7 +80,7 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
         $logger->pushHandler($handler);
         $logger->warning('test');
         list($record) = $handler->getRecords();
-        $this->assertEquals('foo', $record['channel']);
+        $this->assertSame('foo', $record['channel']);
     }
 
     /**
@@ -514,7 +514,7 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
             list($record) = $handler->getRecords();
 
             $this->assertEquals($tz, $record['datetime']->getTimezone());
-            $this->assertEquals($dt->format('Y/m/d H:i'), $record['datetime']->format('Y/m/d H:i'), 'Time should match timezone with microseconds set to: '.var_export($microseconds, true));
+            $this->assertSame($dt->format('Y/m/d H:i'), $record['datetime']->format('Y/m/d H:i'), 'Time should match timezone with microseconds set to: '.var_export($microseconds, true));
         }
     }
 
@@ -537,7 +537,7 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
             list($record) = $handler->getRecords();
 
             $this->assertEquals($tz, $record['datetime']->getTimezone());
-            $this->assertEquals($dt->format('Y/m/d H:i'), $record['datetime']->format('Y/m/d H:i'), 'Time should match timezone with microseconds set to: '.var_export($microseconds, true));
+            $this->assertSame($dt->format('Y/m/d H:i'), $record['datetime']->format('Y/m/d H:i'), 'Time should match timezone with microseconds set to: '.var_export($microseconds, true));
         }
     }
 

--- a/tests/Monolog/Processor/GitProcessorTest.php
+++ b/tests/Monolog/Processor/GitProcessorTest.php
@@ -24,6 +24,6 @@ class GitProcessorTest extends TestCase
         $record = $processor($this->getRecord());
 
         $this->assertArrayHasKey('git', $record['extra']);
-        $this->assertTrue(!is_array($record['extra']['git']['branch']));
+        $this->assertNotInternalType('array', $record['extra']['git']['branch']);
     }
 }

--- a/tests/Monolog/Processor/IntrospectionProcessorTest.php
+++ b/tests/Monolog/Processor/IntrospectionProcessorTest.php
@@ -47,10 +47,10 @@ class IntrospectionProcessorTest extends TestCase
         $tester = new \Acme\Tester;
         $tester->test($handler, $this->getRecord());
         list($record) = $handler->getRecords();
-        $this->assertEquals(__FILE__, $record['extra']['file']);
-        $this->assertEquals(18, $record['extra']['line']);
-        $this->assertEquals('Acme\Tester', $record['extra']['class']);
-        $this->assertEquals('test', $record['extra']['function']);
+        $this->assertSame(__FILE__, $record['extra']['file']);
+        $this->assertSame(18, $record['extra']['line']);
+        $this->assertSame('Acme\Tester', $record['extra']['class']);
+        $this->assertSame('test', $record['extra']['function']);
     }
 
     public function testProcessorFromFunc()
@@ -58,10 +58,10 @@ class IntrospectionProcessorTest extends TestCase
         $handler = $this->getHandler();
         \Acme\tester($handler, $this->getRecord());
         list($record) = $handler->getRecords();
-        $this->assertEquals(__FILE__, $record['extra']['file']);
-        $this->assertEquals(24, $record['extra']['line']);
-        $this->assertEquals(null, $record['extra']['class']);
-        $this->assertEquals('Acme\tester', $record['extra']['function']);
+        $this->assertSame(__FILE__, $record['extra']['file']);
+        $this->assertSame(24, $record['extra']['line']);
+        $this->assertNull($record['extra']['class']);
+        $this->assertSame('Acme\tester', $record['extra']['function']);
     }
 
     public function testLevelTooLow()
@@ -76,7 +76,7 @@ class IntrospectionProcessorTest extends TestCase
         $processor = new IntrospectionProcessor(Logger::CRITICAL);
         $actual = $processor($input);
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     public function testLevelEqual()
@@ -97,7 +97,7 @@ class IntrospectionProcessorTest extends TestCase
         $processor = new IntrospectionProcessor(Logger::CRITICAL);
         $actual = $processor($input);
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     public function testLevelHigher()
@@ -118,6 +118,6 @@ class IntrospectionProcessorTest extends TestCase
         $processor = new IntrospectionProcessor(Logger::CRITICAL);
         $actual = $processor($input);
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 }

--- a/tests/Monolog/Processor/MercurialProcessorTest.php
+++ b/tests/Monolog/Processor/MercurialProcessorTest.php
@@ -36,7 +36,7 @@ class MercurialProcessorTest extends TestCase
         $record = $processor($this->getRecord());
 
         $this->assertArrayHasKey('hg', $record['extra']);
-        $this->assertTrue(!is_array($record['extra']['hg']['branch']));
-        $this->assertTrue(!is_array($record['extra']['hg']['revision']));
+        $this->assertNotInternalType('array', $record['extra']['hg']['branch']);
+        $this->assertNotInternalType('array', $record['extra']['hg']['revision']);
     }
 }

--- a/tests/Monolog/Processor/ProcessIdProcessorTest.php
+++ b/tests/Monolog/Processor/ProcessIdProcessorTest.php
@@ -25,6 +25,6 @@ class ProcessIdProcessorTest extends TestCase
         $this->assertArrayHasKey('process_id', $record['extra']);
         $this->assertInternalType('int', $record['extra']['process_id']);
         $this->assertGreaterThan(0, $record['extra']['process_id']);
-        $this->assertEquals(getmypid(), $record['extra']['process_id']);
+        $this->assertSame(getmypid(), $record['extra']['process_id']);
     }
 }

--- a/tests/Monolog/Processor/PsrLogMessageProcessorTest.php
+++ b/tests/Monolog/Processor/PsrLogMessageProcessorTest.php
@@ -24,7 +24,7 @@ class PsrLogMessageProcessorTest extends \PHPUnit\Framework\TestCase
             'message' => '{foo}',
             'context' => ['foo' => $val],
         ]);
-        $this->assertEquals($expected, $message['message']);
+        $this->assertSame($expected, $message['message']);
     }
 
     public function testCustomDateFormat()
@@ -38,7 +38,7 @@ class PsrLogMessageProcessorTest extends \PHPUnit\Framework\TestCase
             'message' => '{foo}',
             'context' => ['foo' => $date],
         ]);
-        $this->assertEquals($date->format($format), $message['message']);
+        $this->assertSame($date->format($format), $message['message']);
     }
 
     public function getPairs()

--- a/tests/Monolog/Processor/TagProcessorTest.php
+++ b/tests/Monolog/Processor/TagProcessorTest.php
@@ -24,7 +24,7 @@ class TagProcessorTest extends TestCase
         $processor = new TagProcessor($tags);
         $record = $processor($this->getRecord());
 
-        $this->assertEquals($tags, $record['extra']['tags']);
+        $this->assertSame($tags, $record['extra']['tags']);
     }
 
     /**
@@ -36,14 +36,14 @@ class TagProcessorTest extends TestCase
         $processor = new TagProcessor($tags);
 
         $record = $processor($this->getRecord());
-        $this->assertEquals($tags, $record['extra']['tags']);
+        $this->assertSame($tags, $record['extra']['tags']);
 
         $processor->setTags(['a', 'b']);
         $record = $processor($this->getRecord());
-        $this->assertEquals(['a', 'b'], $record['extra']['tags']);
+        $this->assertSame(['a', 'b'], $record['extra']['tags']);
 
         $processor->addTags(['a', 'c', 'foo' => 'bar']);
         $record = $processor($this->getRecord());
-        $this->assertEquals(['a', 'b', 'a', 'c', 'foo' => 'bar'], $record['extra']['tags']);
+        $this->assertSame(['a', 'b', 'a', 'c', 'foo' => 'bar'], $record['extra']['tags']);
     }
 }

--- a/tests/Monolog/Processor/UidProcessorTest.php
+++ b/tests/Monolog/Processor/UidProcessorTest.php
@@ -28,6 +28,6 @@ class UidProcessorTest extends TestCase
     public function testGetUid()
     {
         $processor = new UidProcessor(10);
-        $this->assertEquals(10, strlen($processor->getUid()));
+        $this->assertSame(10, strlen($processor->getUid()));
     }
 }

--- a/tests/Monolog/Processor/WebProcessorTest.php
+++ b/tests/Monolog/Processor/WebProcessorTest.php
@@ -28,12 +28,12 @@ class WebProcessorTest extends TestCase
 
         $processor = new WebProcessor($server);
         $record = $processor($this->getRecord());
-        $this->assertEquals($server['REQUEST_URI'], $record['extra']['url']);
-        $this->assertEquals($server['REMOTE_ADDR'], $record['extra']['ip']);
-        $this->assertEquals($server['REQUEST_METHOD'], $record['extra']['http_method']);
-        $this->assertEquals($server['HTTP_REFERER'], $record['extra']['referrer']);
-        $this->assertEquals($server['SERVER_NAME'], $record['extra']['server']);
-        $this->assertEquals($server['UNIQUE_ID'], $record['extra']['unique_id']);
+        $this->assertSame($server['REQUEST_URI'], $record['extra']['url']);
+        $this->assertSame($server['REMOTE_ADDR'], $record['extra']['ip']);
+        $this->assertSame($server['REQUEST_METHOD'], $record['extra']['http_method']);
+        $this->assertSame($server['HTTP_REFERER'], $record['extra']['referrer']);
+        $this->assertSame($server['SERVER_NAME'], $record['extra']['server']);
+        $this->assertSame($server['UNIQUE_ID'], $record['extra']['unique_id']);
     }
 
     public function testProcessorDoNothingIfNoRequestUri()
@@ -70,7 +70,7 @@ class WebProcessorTest extends TestCase
         ];
         $processor = new WebProcessor($server);
         $record = $processor($this->getRecord());
-        $this->assertFalse(isset($record['extra']['unique_id']));
+        $this->assertArrayNotHasKey('unique_id', $record['extra']);
     }
 
     public function testProcessorAddsOnlyRequestedExtraFields()


### PR DESCRIPTION
I've made a little improvement to our assertions:
- use dedicated PHPUnit assertion method when possible;
- use `assertSame` (`===`) on top of `assertEquals` (`==`)
- respect PHPUnit assertion method order of arguments: `$expected` them `$actual`