### PR TITLE
Optional possibility to filter log records on logger level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 .DS_Store
 .php_cs.cache
 .hg
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ composer.lock
 .DS_Store
 .php_cs.cache
 .hg
-.idea

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -721,11 +721,12 @@ class Logger implements LoggerInterface
      *
      * @param string $level
      */
-    public function setLevel($level) {
+    public function setLevel($level)
+    {
         $level = strtoupper($level);
 
-        if (!in_array($level, self::$levels, TRUE)) {
-            throw new InvalidArgumentException('Level "'.$level.'" is not defined, use one of: '.implode(', ', array_keys(array_flip(self::$levels))));
+        if (!in_array($level, self::$levels, true)) {
+            throw new InvalidArgumentException('Level "'.$level.'" is not defined, use one of: '.implode(', ', array_values(self::$levels)));
         }
 
         $this->level = array_search($level, self::$levels);
@@ -736,7 +737,8 @@ class Logger implements LoggerInterface
      *
      * @return int
      */
-    public function getLevel() {
+    public function getLevel()
+    {
         return $this->level;
     }
 }

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -725,7 +725,7 @@ class Logger implements LoggerInterface
     {
         $level = strtoupper($level);
 
-        if (!in_array($level, self::$levels, true)) {
+        if (!in_array($level, self::$levels)) {
             throw new InvalidArgumentException('Level "'.$level.'" is not defined, use one of: '.implode(', ', array_values(self::$levels)));
         }
 

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -15,6 +15,7 @@ use Monolog\Handler\HandlerInterface;
 use Monolog\Handler\StreamHandler;
 use Psr\Log\LoggerInterface;
 use Psr\Log\InvalidArgumentException;
+use Psr\Log\LogLevel;
 
 /**
  * Monolog log channel
@@ -94,22 +95,6 @@ class Logger implements LoggerInterface
     protected $level = self::DEBUG;
 
     /**
-     * Logging levels to syslog protocol defined in RFC 5424
-     *
-     * @var array
-     */
-    protected static $levelMapping = array(
-        'DEBUG'     => self::DEBUG,
-        'INFO'      => self::INFO,
-        'NOTICE'    => self::NOTICE,
-        'WARNING'   => self::WARNING,
-        'ERROR'     => self::ERROR,
-        'CRITICAL'  => self::CRITICAL,
-        'ALERT'     => self::ALERT,
-        'EMERGENCY' => self::EMERGENCY,
-    );
-
-    /**
      * Logging levels from syslog protocol defined in RFC 5424
      *
      * @var array $levels Logging levels
@@ -160,9 +145,9 @@ class Logger implements LoggerInterface
      * @param string             $name       The logging channel
      * @param HandlerInterface[] $handlers   Optional stack of handlers, the first one in the array is called first, etc.
      * @param callable[]         $processors Optional array of processors
-     * @param string             $level Minimal level to log
+     * @param string             $level      Minimal level to log
      */
-    public function __construct($name, array $handlers = array(), array $processors = array(), $level = 'DEBUG')
+    public function __construct($name, array $handlers = array(), array $processors = array(), $level = LogLevel::DEBUG)
     {
         $this->name = $name;
         $this->handlers = $handlers;
@@ -737,11 +722,13 @@ class Logger implements LoggerInterface
      * @param string $level
      */
     public function setLevel($level) {
-        if (!isset(static::$levelMapping[strtoupper($level)])) {
-            throw new InvalidArgumentException('Level "'.$level.'" is not defined, use one of: '.implode(', ', array_keys(static::$levelMapping)));
+        $level = strtoupper($level);
+
+        if (!in_array($level, self::$levels, TRUE)) {
+            throw new InvalidArgumentException('Level "'.$level.'" is not defined, use one of: '.implode(', ', array_keys(array_flip(self::$levels))));
         }
 
-        $this->level = self::$levelMapping[strtoupper($level)];
+        $this->level = array_search($level, self::$levels);
     }
 
     /**

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -725,7 +725,7 @@ class Logger implements LoggerInterface
     {
         $level = strtoupper($level);
 
-        if (!in_array($level, self::$levels)) {
+        if (!in_array($level, self::$levels, true)) {
             throw new InvalidArgumentException('Level "'.$level.'" is not defined, use one of: '.implode(', ', array_values(self::$levels)));
         }
 

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -545,4 +545,162 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
             'without microseconds' => array(false, PHP_VERSION_ID >= 70100 ? 'assertNotSame' : 'assertSame'),
         );
     }
+
+    /**
+     * @covers Monolog\Logger::setlevel()
+     * @covers Monolog\Logger::__construct
+     *
+     * @expectedException InvalidArgumentException
+     */
+    public function testSetLoggerUnExistingLevelName()
+    {
+        $logger = new Logger(__METHOD__);
+        $logger->setLevel('test_level');
+    }
+
+    /**
+     * @covers Monolog\Logger::addRecord
+     * @covers Monolog\Logger::__construct
+     */
+    public function testLoggerLogLevelDebug()
+    {
+        $logger = new Logger(__METHOD__);
+        $logger->pushHandler(new TestHandler());
+
+        $this->assertTrue($logger->debug('test'));
+        $this->assertTrue($logger->info('test'));
+        $this->assertTrue($logger->notice('test'));
+        $this->assertTrue($logger->warning('test'));
+        $this->assertTrue($logger->error('test'));
+        $this->assertTrue($logger->critical('test'));
+        $this->assertTrue($logger->alert('test'));
+        $this->assertTrue($logger->emergency('test'));
+    }
+
+    /**
+     * @covers Monolog\Logger::addRecord
+     * @covers Monolog\Logger::__construct
+     */
+    public function testLoggerLogLevelInfo()
+    {
+        $logger = new Logger(__METHOD__, array(new TestHandler()), array(), 'info');
+
+        $this->assertFalse($logger->debug('test'));
+        $this->assertTrue($logger->info('test'));
+        $this->assertTrue($logger->notice('test'));
+        $this->assertTrue($logger->warning('test'));
+        $this->assertTrue($logger->error('test'));
+        $this->assertTrue($logger->critical('test'));
+        $this->assertTrue($logger->alert('test'));
+        $this->assertTrue($logger->emergency('test'));
+    }
+
+    /**
+     * @covers Monolog\Logger::addRecord
+     * @covers Monolog\Logger::__construct
+     */
+    public function testLoggerLogLevelNotice()
+    {
+        $logger = new Logger(__METHOD__, array(new TestHandler()), array(), 'notice');
+
+        $this->assertFalse($logger->debug('test'));
+        $this->assertFalse($logger->info('test'));
+        $this->assertTrue($logger->notice('test'));
+        $this->assertTrue($logger->warning('test'));
+        $this->assertTrue($logger->error('test'));
+        $this->assertTrue($logger->critical('test'));
+        $this->assertTrue($logger->alert('test'));
+        $this->assertTrue($logger->emergency('test'));
+    }
+
+    /**
+     * @covers Monolog\Logger::addRecord
+     * @covers Monolog\Logger::__construct
+     */
+    public function testLoggerLogLevelWarning()
+    {
+        $logger = new Logger(__METHOD__, array(new TestHandler()), array(), 'warning');
+
+        $this->assertFalse($logger->debug('test'));
+        $this->assertFalse($logger->info('test'));
+        $this->assertFalse($logger->notice('test'));
+        $this->assertTrue($logger->warning('test'));
+        $this->assertTrue($logger->error('test'));
+        $this->assertTrue($logger->critical('test'));
+        $this->assertTrue($logger->alert('test'));
+        $this->assertTrue($logger->emergency('test'));
+    }
+
+    /**
+     * @covers Monolog\Logger::addRecord
+     * @covers Monolog\Logger::__construct
+     */
+    public function testLoggerLogLevelError()
+    {
+        $logger = new Logger(__METHOD__, array(new TestHandler()), array(), 'error');
+
+        $this->assertFalse($logger->debug('test'));
+        $this->assertFalse($logger->info('test'));
+        $this->assertFalse($logger->notice('test'));
+        $this->assertFalse($logger->warning('test'));
+        $this->assertTrue($logger->error('test'));
+        $this->assertTrue($logger->critical('test'));
+        $this->assertTrue($logger->alert('test'));
+        $this->assertTrue($logger->emergency('test'));
+    }
+
+    /**
+     * @covers Monolog\Logger::addRecord
+     * @covers Monolog\Logger::__construct
+     */
+    public function testLoggerLogLevelCritical()
+    {
+        $logger = new Logger(__METHOD__, array(new TestHandler()), array(), 'critical');
+
+        $this->assertFalse($logger->debug('test'));
+        $this->assertFalse($logger->info('test'));
+        $this->assertFalse($logger->notice('test'));
+        $this->assertFalse($logger->warning('test'));
+        $this->assertFalse($logger->error('test'));
+        $this->assertTrue($logger->critical('test'));
+        $this->assertTrue($logger->alert('test'));
+        $this->assertTrue($logger->emergency('test'));
+    }
+
+    /**
+     * @covers Monolog\Logger::addRecord
+     * @covers Monolog\Logger::__construct
+     */
+    public function testLoggerLogLevelAlert()
+    {
+        $logger = new Logger(__METHOD__, array(new TestHandler()), array(), 'alert');
+
+        $this->assertFalse($logger->debug('test'));
+        $this->assertFalse($logger->info('test'));
+        $this->assertFalse($logger->notice('test'));
+        $this->assertFalse($logger->warning('test'));
+        $this->assertFalse($logger->error('test'));
+        $this->assertFalse($logger->critical('test'));
+        $this->assertTrue($logger->alert('test'));
+        $this->assertTrue($logger->emergency('test'));
+    }
+
+    /**
+     * @covers Monolog\Logger::addRecord
+     * @covers Monolog\Logger::__construct
+     */
+    public function testLoggerLogLevelEmergency()
+    {
+        $logger = new Logger(__METHOD__, array(new TestHandler()), array(), 'emergency');
+
+        $this->assertFalse($logger->debug('test'));
+        $this->assertFalse($logger->info('test'));
+        $this->assertFalse($logger->notice('test'));
+        $this->assertFalse($logger->warning('test'));
+        $this->assertFalse($logger->error('test'));
+        $this->assertFalse($logger->critical('test'));
+        $this->assertFalse($logger->alert('test'));
+        $this->assertTrue($logger->emergency('test'));
+    }
+
 }


### PR DESCRIPTION
### Motivation
It might be quite useful to have a possibility to filter log records on logger level, not only on handler level. For example, I want to log events from different parts of my application into the same location and I want to control log level of records for each defined logger as well. For now, it looks like:
```
$logger1 = new Logger('logger1');
$logger1->pushHandler(new StreamHandler('test.log', Logger::INFO)); // Logs records with level >= info.

$logger2 = new Logger('logger2');
$logger2->pushHandler(new StreamHandler('test.log', Logger::ALERT)); // Logs records with level >= alert.

...
```
Where `test.log` is the same target file *for all of the handlers*. Thus I have to create as many *same handlers* as loggers. It becomes a mess when you use pure `monolog` library and define all the loggers & handlers in `*.yml` file. I propose next approach (which doesn't break any previous approaches with handler level filtering):
```
$handler = new StreamHandler('test.log');

$logger1 = new Logger('logger1', [$handler], [...], 'info'); // Logs records with level >= info.
$logger2 = new Logger('logger2', [$handler], [...], 'alert'); // Logs records with level >= alert.
...
```
It's not necessary to pass log level directly to the constructor. It can be set up with `Logger::setLevel()` method.

### Benefit
We don't need to create many same handlers for different loggers, we can create one, share it with loggers and control log level on logger side.

### Backward compatibility
This patch doesn't break anything. You still can filter log records at handler level.

### Modified files
* `src/Monolog/Logger.ph`
* `tests/Monolog/LoggerTest.php`