### PR TITLE
Fix mkdir concurrency creating

### DIFF
--- a/src/Monolog/Handler/StreamHandler.php
+++ b/src/Monolog/Handler/StreamHandler.php
@@ -169,7 +169,7 @@ class StreamHandler extends AbstractProcessingHandler
             set_error_handler([$this, 'customErrorHandler']);
             $status = mkdir($dir, 0777, true);
             restore_error_handler();
-            if (false === $status) {
+            if (false === $status && !is_dir($dir)) {
                 throw new \UnexpectedValueException(sprintf('There is no existing directory at "%s" and its not buildable: '.$this->errorMessage, $dir));
             }
         }


### PR DESCRIPTION
Issue:
Two PHP processes try to create directory concurrently.
Both process successfully pass  `if (null !== $dir && !is_dir($dir)) {` condition, but only one process successfully creates directory and second process will throw Exception, but directory is created.

`clearstatcache()` is not required due to PHP documentation http://php.net/manual/en/function.clearstatcache.php

> You should also note that PHP doesn't cache information about non-existent files. So, if you call file_exists() on a file that doesn't exist, it will return FALSE until you create the file.

Same for `is_dir()`

Please also check https://github.com/kalessil/phpinspectionsea/blob/master/docs/probable-bugs.md#mkdir-race-condition