### PR TITLE
ErrorLogHandler: use strict comparison

### DIFF
--- a/src/Monolog/Handler/ErrorLogHandler.php
+++ b/src/Monolog/Handler/ErrorLogHandler.php
@@ -38,7 +38,7 @@ class ErrorLogHandler extends AbstractProcessingHandler
     {
         parent::__construct($level, $bubble);
 
-        if (false === in_array($messageType, self::getAvailableTypes())) {
+        if (false === in_array($messageType, self::getAvailableTypes(), true)) {
             $message = sprintf('The given message type "%s" is not supported', print_r($messageType, true));
             throw new \InvalidArgumentException($message);
         }


### PR DESCRIPTION
otherwise `null` and `false` get accepted as valid types:

```php
$handler = new Handler\ErrorLogHandler(null, $level);
```

note: this is somewhat backward incompatible, as previously `null` and `false` and `""` would be converted to `0`, but now they are rejected.

also, maybe it would make sense to allow `null` to be "use default value `self::OPERATING_SYSTEM`"?