### PR TITLE
Prevent to call newrelic functions when app and transaction names are…

### DIFF
--- a/src/Monolog/Handler/NewRelicHandler.php
+++ b/src/Monolog/Handler/NewRelicHandler.php
@@ -167,7 +167,8 @@ class NewRelicHandler extends AbstractProcessingHandler
      */
     protected function setNewRelicAppName($appName)
     {
-        newrelic_set_appname($appName);
+        if (!empty($appName))
+            newrelic_set_appname($appName);
     }
 
     /**
@@ -177,7 +178,8 @@ class NewRelicHandler extends AbstractProcessingHandler
      */
     protected function setNewRelicTransactionName($transactionName)
     {
-        newrelic_name_transaction($transactionName);
+        if (!empty($transactionName))
+            newrelic_name_transaction($transactionName);
     }
 
     /**


### PR DESCRIPTION
… empty

The handler shouldn't set the app and transaction names when they are not been passed in the constructor or provided through the context. If the value returned by `getAppName()` or `getTransactionName()` is null or an empty string, the correspondent New Relic API shouldn't be called because the user might have called them in another part of the code. And anyway it doesn't make any sense call `newrelic_set_appname()` and `newrelic_name_transaction()` passing an empty string or null.