### PR TITLE
Newrelic handler with line formatter

### DIFF
--- a/src/Monolog/Handler/NewRelicHandler.php
+++ b/src/Monolog/Handler/NewRelicHandler.php
@@ -82,18 +82,19 @@ class NewRelicHandler extends AbstractProcessingHandler
 
         if ($transactionName = $this->getTransactionName($record['context'])) {
             $this->setNewRelicTransactionName($transactionName);
-            unset($record['formatted']['context']['transaction_name']);
+            unset($record['context']['transaction_name']);
         }
 
+        $message = isset($record['formatted']) ? $record['formatted'] : $record['message'];
         if (isset($record['context']['exception']) && $record['context']['exception'] instanceof \Exception) {
-            newrelic_notice_error($record['message'], $record['context']['exception']);
-            unset($record['formatted']['context']['exception']);
+            newrelic_notice_error($message, $record['context']['exception']);
+            unset($record['context']['exception']);
         } else {
-            newrelic_notice_error($record['message']);
+            newrelic_notice_error($message);
         }
 
-        if (isset($record['formatted']['context']) && is_array($record['formatted']['context'])) {
-            foreach ($record['formatted']['context'] as $key => $parameter) {
+        if (isset($record['context']) && is_array($record['context'])) {
+            foreach ($record['context'] as $key => $parameter) {
                 if (is_array($parameter) && $this->explodeArrays) {
                     foreach ($parameter as $paramKey => $paramValue) {
                         $this->setNewRelicParameter('context_' . $key . '_' . $paramKey, $paramValue);
@@ -104,8 +105,8 @@ class NewRelicHandler extends AbstractProcessingHandler
             }
         }
 
-        if (isset($record['formatted']['extra']) && is_array($record['formatted']['extra'])) {
-            foreach ($record['formatted']['extra'] as $key => $parameter) {
+        if (isset($record['extra']) && is_array($record['extra'])) {
+            foreach ($record['extra'] as $key => $parameter) {
                 if (is_array($parameter) && $this->explodeArrays) {
                     foreach ($parameter as $paramKey => $paramValue) {
                         $this->setNewRelicParameter('extra_' . $key . '_' . $paramKey, $paramValue);

--- a/tests/Monolog/Handler/NewRelicHandlerTest.php
+++ b/tests/Monolog/Handler/NewRelicHandlerTest.php
@@ -20,12 +20,14 @@ class NewRelicHandlerTest extends TestCase
     public static $appname;
     public static $customParameters;
     public static $transactionName;
+    public static $loggedMessage;
 
     public function setUp()
     {
         self::$appname = null;
         self::$customParameters = [];
         self::$transactionName = null;
+        self::$loggedMessage = null;
     }
 
     /**
@@ -108,8 +110,10 @@ class NewRelicHandlerTest extends TestCase
     public function testThehandlerCanHandleTheRecordsFormattedUsingTheLineFormatter()
     {
         $handler = new StubNewRelicHandler();
-        $handler->setFormatter(new LineFormatter());
-        $handler->handle($this->getRecord(Logger::ERROR));
+        $handler->setFormatter(new LineFormatter('message: %message%'));
+        $handler->handle($this->getRecord(Logger::ERROR, 'test message'));
+
+        $this->assertEquals('message: test message', self::$loggedMessage);
     }
 
     public function testTheAppNameIsNullByDefault()
@@ -177,9 +181,9 @@ class StubNewRelicHandler extends NewRelicHandler
     }
 }
 
-function newrelic_notice_error()
+function newrelic_notice_error($loggedMessage)
 {
-    return true;
+    NewRelicHandlerTest::$loggedMessage = $loggedMessage;
 }
 
 function newrelic_set_appname($appname)

--- a/tests/Monolog/Handler/NewRelicHandlerTest.php
+++ b/tests/Monolog/Handler/NewRelicHandlerTest.php
@@ -163,6 +163,14 @@ class NewRelicHandlerTest extends TestCase
 
         $this->assertEquals('logTransactName', self::$transactionName);
     }
+
+    public function testTheContextIsNormalizedByDefault()
+    {
+        $handler = new StubNewRelicHandler(Logger::DEBUG, false, null, false, 'myTransaction');
+        $handler->handle($this->getRecord(Logger::ERROR, 'log message', ['nan' => NAN]));
+
+        $this->assertEquals(['context_nan' => 'NaN'], self::$customParameters);
+    }
 }
 
 class StubNewRelicHandlerWithoutExtension extends NewRelicHandler


### PR DESCRIPTION
The New Relic Handler will crash when using the LineFormatter.

The current implementation tries to use `$record['formatted']` as an array, but it should be a string.