### PR TITLE
Add a record with an object as context

### DIFF
--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -137,7 +137,6 @@ class SlackRecord
                 $attachment['fields'][] = $this->generateAttachmentField('Level', $record['level_name']);
             }
 
-
             if ($this->includeContextAndExtra) {
                 foreach (array('extra', 'context') as $key) {
                     if (empty($record[$key])) {
@@ -230,7 +229,7 @@ class SlackRecord
      * Generates attachment field
      *
      * @param string $title
-     * @param string|array $value\
+     * @param string|array $value
      *
      * @return array
      */
@@ -257,8 +256,17 @@ class SlackRecord
     private function generateAttachmentFields(array $data)
     {
         $fields = array();
-        foreach ($data as $key => $value) {
-            $fields[] = $this->generateAttachmentField($key, $value);
+        $normalized = $this->normalizerFormatter->format($data);
+        foreach ($normalized as $key => $value) {
+            if (is_array($value)) {
+                $value = sprintf('```%s```', $this->stringify($value));
+            }
+
+            $fields[] = array(
+                'title' => $key,
+                'value' => $value,
+                'short' => false,
+            );
         }
 
         return $fields;

--- a/tests/Monolog/Handler/Slack/SlackRecordTest.php
+++ b/tests/Monolog/Handler/Slack/SlackRecordTest.php
@@ -353,6 +353,14 @@ class SlackRecordTest extends TestCase
         $this->assertSame($record['datetime']->getTimestamp(), $attachment['ts']);
     }
 
+    public function testContextHasException()
+    {
+        $record = $this->getRecord(Logger::CRITICAL, 'This is a critical message.', array('exception' => new \Exception()));
+        $slackRecord = new SlackRecord(null, null, true, null, false, true);
+        $data = $slackRecord->getSlackData($record);
+        $this->assertInternalType('string', $data['attachments'][0]['fields'][1]['value']);
+    }
+
     public function testExcludeExtraAndContextFields()
     {
         $record = $this->getRecord(


### PR DESCRIPTION
I have added a test case where the record contains in it's context an object and in this case an Exception.

As we can see below the test fails because value for slack must always be a string but objects are not formatted to strings.

This results in slack displaying the field with no value inside of it.

If you like I can proceed with a fix on this PR but the only solution that I have is adding a Custom Formatter for slack. Would you accept this solution?