### PR TITLE
Improve table row output in HtmlFormatter

### DIFF
--- a/src/Monolog/Formatter/HtmlFormatter.php
+++ b/src/Monolog/Formatter/HtmlFormatter.php
@@ -59,7 +59,7 @@ class HtmlFormatter extends NormalizerFormatter
             $td = '<pre>'.htmlspecialchars($td, ENT_NOQUOTES, 'UTF-8').'</pre>';
         }
 
-        return "<tr style=\"padding: 4px;spacing: 0;text-align: left;\">\n<th style=\"background: #cccccc\" width=\"100px\">$th:</th>\n<td style=\"padding: 4px;spacing: 0;text-align: left;background: #eeeeee\">".$td."</td>\n</tr>";
+        return "<tr style=\"padding: 4px;text-align: left;\">\n<th style=\"vertical-align: top;background: #cccccc\" width=\"100\">$th:</th>\n<td style=\"padding: 4px;text-align: left;vertical-align: top;background: #eeeeee\">".$td."</td>\n</tr>";
     }
 
     /**


### PR DESCRIPTION
* Makes table cells vertical-aligned top (otherwise you have to scroll a lot if you have large data in your extra fields for example)
* `width` HTML attribute should be used without "px" suffix
* Removes non existing `spacing` CSS attribute (and is obsolete, because table already has `spacing="1"`)