### PR TITLE
Allow setting stream chunk size in SocketHandler

### DIFF
--- a/src/Monolog/Handler/SocketHandler.php
+++ b/src/Monolog/Handler/SocketHandler.php
@@ -27,7 +27,7 @@ class SocketHandler extends AbstractProcessingHandler
     private $timeout = 0;
     private $writingTimeout = 10;
     private $lastSentBytes = null;
-    private $chunkSize = 8192;
+    private $chunkSize = null;
     private $persistent = false;
     private $errno;
     private $errstr;
@@ -324,7 +324,7 @@ class SocketHandler extends AbstractProcessingHandler
 
     private function setStreamChunkSize()
     {
-        if (!$this->streamSetChunkSize()) {
+        if ($this->chunkSize && !$this->streamSetChunkSize()) {
             throw new \UnexpectedValueException("Failed setting chunk size with stream_set_chunk_size()");
         }
     }

--- a/tests/Monolog/Handler/SocketHandlerTest.php
+++ b/tests/Monolog/Handler/SocketHandlerTest.php
@@ -77,6 +77,13 @@ class SocketHandlerTest extends TestCase
         $this->assertEquals(10.25, $this->handler->getWritingTimeout());
     }
 
+    public function testSetChunkSize()
+    {
+        $this->createHandler('localhost:1234');
+        $this->handler->setChunkSize(1025);
+        $this->assertEquals(1025, $this->handler->getChunkSize());
+    }
+
     public function testSetConnectionString()
     {
         $this->createHandler('tcp://localhost:9090');
@@ -116,6 +123,18 @@ class SocketHandlerTest extends TestCase
         $this->setMockHandler(array('streamSetTimeout'));
         $this->handler->expects($this->once())
             ->method('streamSetTimeout')
+            ->will($this->returnValue(false));
+        $this->writeRecord('Hello world');
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     */
+    public function testExceptionIsThrownIfCannotSetChunkSize()
+    {
+        $this->setMockHandler(array('streamSetChunkSize'));
+        $this->handler->expects($this->once())
+            ->method('streamSetChunkSize')
             ->will($this->returnValue(false));
         $this->writeRecord('Hello world');
     }
@@ -302,6 +321,12 @@ class SocketHandlerTest extends TestCase
             $this->handler->expects($this->any())
                 ->method('streamSetTimeout')
                 ->will($this->returnValue(true));
+        }
+
+        if (!in_array('streamSetChunkSize', $methods)) {
+            $this->handler->expects($this->any())
+                ->method('streamSetChunkSize')
+                ->will($this->returnValue(8192));
         }
 
         $this->handler->setFormatter($this->getIdentityFormatter());

--- a/tests/Monolog/Handler/SocketHandlerTest.php
+++ b/tests/Monolog/Handler/SocketHandlerTest.php
@@ -133,6 +133,7 @@ class SocketHandlerTest extends TestCase
     public function testExceptionIsThrownIfCannotSetChunkSize()
     {
         $this->setMockHandler(array('streamSetChunkSize'));
+        $this->handler->setChunkSize(8192);
         $this->handler->expects($this->once())
             ->method('streamSetChunkSize')
             ->will($this->returnValue(false));


### PR DESCRIPTION
This pull requests adds an option to the SocketHandler to set the desired stream chunk size via `stream_set_chunk_size`.

The main problem this pull request solves is logging larger messages via UDP using SocketHandler. The default chunk size set by PHP appears to be 8192 and any larger UDP messages get split into multiple packets and result in multiple log entries. When used with logstash (and similar processors) those messages are therefore not parsed correctly.

Since the UDP protocol allows for much larger packets (https://en.wikipedia.org/wiki/User_Datagram_Protocol#Packet_structure), this problem can be solved by simply using a larger chunk size.