### PR TITLE
Make Logger::setHandlers() consistent with Logger::__construct

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -168,7 +168,7 @@ class Logger implements LoggerInterface
     /**
      * Pushes a handler on to the stack.
      */
-    public function pushHandler(HandlerInterface $handler): self
+    public function pushHandler(?HandlerInterface $handler): self
     {
         array_unshift($this->handlers, $handler);
 

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -167,8 +167,10 @@ class Logger implements LoggerInterface
 
     /**
      * Pushes a handler on to the stack.
+     *
+     * @param HandlerInterface|null $handler
      */
-    public function pushHandler(?HandlerInterface $handler): self
+    public function pushHandler($handler): self
     {
         array_unshift($this->handlers, $handler);
 


### PR DESCRIPTION
At the moment, the constructor supports having null in the handler array. This pull request makes it so that `setHandlers` also supports this.

Closes #1131