### PR TITLE
Compatible to phpunit6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "psr/log": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^6.5",
         "graylog2/gelf-php": "^1.4.2",
         "sentry/sentry": "^0.13",
         "ruflin/elastica": ">=0.90 <3.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="tests/bootstrap.php" colors="true">
+<phpunit bootstrap="tests/bootstrap.php" colors="true" beStrictAboutTestsThatDoNotTestAnything="false">
     <testsuites>
         <testsuite name="Monolog Test Suite">
             <directory>tests/Monolog/</directory>

--- a/tests/Monolog/Formatter/LogstashFormatterTest.php
+++ b/tests/Monolog/Formatter/LogstashFormatterTest.php
@@ -17,7 +17,7 @@ class LogstashFormatterTest extends \PHPUnit\Framework\TestCase
 {
     public function tearDown()
     {
-        \PHPUnit_Framework_Error_Warning::$enabled = true;
+        \PHPUnit\Framework\Error\Warning::$enabled = true;
 
         return parent::tearDown();
     }

--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -18,7 +18,7 @@ class NormalizerFormatterTest extends \PHPUnit\Framework\TestCase
 {
     public function tearDown()
     {
-        \PHPUnit_Framework_Error_Warning::$enabled = true;
+        \PHPUnit\Framework\Error\Warning::$enabled = true;
 
         return parent::tearDown();
     }

--- a/tests/Monolog/Handler/ProcessHandlerTest.php
+++ b/tests/Monolog/Handler/ProcessHandlerTest.php
@@ -77,7 +77,7 @@ class ProcessHandlerTest extends TestCase
      */
     public function testConstructWithInvalidCommandThrowsInvalidArgumentException($invalidCommand, $expectedExcep)
     {
-        $this->setExpectedException($expectedExcep);
+        $this->expectException($expectedExcep);
         new ProcessHandler($invalidCommand, Logger::DEBUG);
     }
 
@@ -102,7 +102,7 @@ class ProcessHandlerTest extends TestCase
      */
     public function testConstructWithInvalidCwdThrowsInvalidArgumentException($invalidCwd, $expectedExcep)
     {
-        $this->setExpectedException($expectedExcep);
+        $this->expectException($expectedExcep);
         new ProcessHandler(self::DUMMY_COMMAND, Logger::DEBUG, true, $invalidCwd);
     }
 
@@ -135,7 +135,7 @@ class ProcessHandlerTest extends TestCase
             ->method('selectErrorStream')
             ->will($this->returnValue(false));
 
-        $this->setExpectedException('\UnexpectedValueException');
+        $this->expectException('\UnexpectedValueException');
         /** @var ProcessHandler $handler */
         $handler->handle($this->getRecord(Logger::WARNING, 'stream failing, whoops'));
     }
@@ -147,7 +147,7 @@ class ProcessHandlerTest extends TestCase
     public function testStartupWithErrorsThrowsUnexpectedValueException()
     {
         $handler = new ProcessHandler('>&2 echo "some fake error message"');
-        $this->setExpectedException('\UnexpectedValueException');
+        $this->expectException('\UnexpectedValueException');
         $handler->handle($this->getRecord(Logger::WARNING, 'some warning in the house'));
     }
 
@@ -167,7 +167,7 @@ class ProcessHandlerTest extends TestCase
             ->method('readProcessErrors')
             ->willReturnOnConsecutiveCalls('', $this->returnValue('some fake error message here'));
 
-        $this->setExpectedException('\UnexpectedValueException');
+        $this->expectException('\UnexpectedValueException');
         /** @var ProcessHandler $handler */
         $handler->handle($this->getRecord(Logger::WARNING, 'some test stuff'));
     }

--- a/tests/Monolog/Handler/RotatingFileHandlerTest.php
+++ b/tests/Monolog/Handler/RotatingFileHandlerTest.php
@@ -134,7 +134,8 @@ class RotatingFileHandlerTest extends TestCase
     {
         $handler = new RotatingFileHandler(__DIR__.'/Fixtures/foo.rot', 2);
         if (!$valid) {
-            $this->setExpectedExceptionRegExp(InvalidArgumentException::class, '~^Invalid date format~');
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessageRegExp('~^Invalid date format~');
         }
         $handler->setFilenameFormat('{filename}-{date}', $dateFormat);
         $this->assertTrue(true);
@@ -174,7 +175,8 @@ class RotatingFileHandlerTest extends TestCase
     {
         $handler = new RotatingFileHandler(__DIR__.'/Fixtures/foo.rot', 2);
         if (!$valid) {
-            $this->setExpectedExceptionRegExp(InvalidArgumentException::class, '~^Invalid filename format~');
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessageRegExp('~^Invalid filename format~');
         }
 
         $handler->setFilenameFormat($filenameFormat, RotatingFileHandler::FILE_PER_DAY);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,3 +12,9 @@
 date_default_timezone_set('UTC');
 
 require __DIR__.'/../vendor/autoload.php';
+
+// B.C. for PSR Log's old inheritance
+// see https://github.com/php-fig/log/pull/52
+if (!class_exists('\\PHPUnit_Framework_TestCase', true)) {
+    class_alias('\\PHPUnit\\Framework\\TestCase', '\\PHPUnit_Framework_TestCase');
+}


### PR DESCRIPTION
* PHPUnit 5 is already out of support https://phpunit.de/
* When we require php7, we can use PHPUnit6.

