### PR TITLE
Remove conditional php version check for debug_backtrace legacy support

### DIFF
--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -51,12 +51,7 @@ class IntrospectionProcessor
             return $record;
         }
 
-        /*
-        * http://php.net/manual/en/function.debug-backtrace.php
-        * As of 5.3.6, DEBUG_BACKTRACE_IGNORE_ARGS option was added.
-        * Any version less than 5.3.6 must use the DEBUG_BACKTRACE_IGNORE_ARGS constant value '2'.
-        */
-        $trace = debug_backtrace((PHP_VERSION_ID < 50306) ? 2 : DEBUG_BACKTRACE_IGNORE_ARGS);
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 
         // skip first since it's always the current method
         array_shift($trace);


### PR DESCRIPTION
Given we will now only be supporting PHP 7.0 and greater, we can do away with this conditional which offered backwards compatible support to PHP versions less than 5.3.6.