### PR TITLE
Adjust visibility of some properties to protected for extend slack handlers

### DIFF
--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -27,13 +27,13 @@ class SlackHandler extends SocketHandler
      * Slack API token
      * @var string
      */
-    protected $token;
+    private $token;
 
     /**
      * Instance of the SlackRecord util class preparing data for Slack API.
      * @var SlackRecord
      */
-    protected $slackRecord;
+    private $slackRecord;
 
     /**
      * @param  string                    $token                  Slack API token
@@ -73,6 +73,11 @@ class SlackHandler extends SocketHandler
     public function getSlackRecord()
     {
         return $this->slackRecord;
+    }
+
+    public function getToken()
+    {
+        return $this->token;
     }
 
     /**

--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -27,13 +27,13 @@ class SlackHandler extends SocketHandler
      * Slack API token
      * @var string
      */
-    private $token;
+    protected $token;
 
     /**
      * Instance of the SlackRecord util class preparing data for Slack API.
      * @var SlackRecord
      */
-    private $slackRecord;
+    protected $slackRecord;
 
     /**
      * @param  string                    $token                  Slack API token

--- a/src/Monolog/Handler/SlackWebhookHandler.php
+++ b/src/Monolog/Handler/SlackWebhookHandler.php
@@ -27,13 +27,13 @@ class SlackWebhookHandler extends AbstractProcessingHandler
      * Slack Webhook token
      * @var string
      */
-    private $webhookUrl;
+    protected $webhookUrl;
 
     /**
      * Instance of the SlackRecord util class preparing data for Slack API.
      * @var SlackRecord
      */
-    private $slackRecord;
+    protected $slackRecord;
 
     /**
      * @param  string      $webhookUrl             Slack Webhook URL

--- a/src/Monolog/Handler/SlackWebhookHandler.php
+++ b/src/Monolog/Handler/SlackWebhookHandler.php
@@ -27,13 +27,13 @@ class SlackWebhookHandler extends AbstractProcessingHandler
      * Slack Webhook token
      * @var string
      */
-    protected $webhookUrl;
+    private $webhookUrl;
 
     /**
      * Instance of the SlackRecord util class preparing data for Slack API.
      * @var SlackRecord
      */
-    protected $slackRecord;
+    private $slackRecord;
 
     /**
      * @param  string      $webhookUrl             Slack Webhook URL
@@ -68,6 +68,11 @@ class SlackWebhookHandler extends AbstractProcessingHandler
     public function getSlackRecord()
     {
         return $this->slackRecord;
+    }
+
+    public function getWebhookUrl()
+    {
+        return $this->webhookUrl;
     }
 
     /**


### PR DESCRIPTION
We must use another property to store the `private` properties at parent class.

> See an example: https://github.com/104corp/monolog-extensions/blob/master/src/Handlers/ProxyableSlackWebhookHandler.php#L27

It's not a good idea. Please use `protected` visibility so that we can extend slack handlers easily.