### PR TITLE
Update LineFormatter.php replaceNewlines {

### DIFF
--- a/src/Monolog/Formatter/LineFormatter.php
+++ b/src/Monolog/Formatter/LineFormatter.php
@@ -157,7 +157,7 @@ class LineFormatter extends NormalizerFormatter
     protected function replaceNewlines(string $str): string
     {
         if ($this->allowInlineLineBreaks) {
-            if (0 === strpos($str, '{')) {
+            if (false === strpos($str, '{')) {
                 return str_replace(array('\r', '\n'), array("\r", "\n"), $str);
             }
 


### PR DESCRIPTION
Hello,

When enabling allowInlineLineBreaks and there is no { in the string, it returns a FALSE instead of a 0 so the function will not get triggered. I have filled in { in the first character of my string to fix this but i think it must be:

```
if (false === strpos($str, '{')) {
```
Instead of 
```
if (0 === strpos($str, '{')) {
```

or am i mistaken?