### PR TITLE
Make TestHandler::hasRecord assert context, not only message

### DIFF
--- a/src/Monolog/Handler/TestHandler.php
+++ b/src/Monolog/Handler/TestHandler.php
@@ -86,18 +86,16 @@ class TestHandler extends AbstractProcessingHandler
 
     public function hasRecord($record, $level)
     {
+        if (is_string($record)) {
+            $record = ['message' => $record];
+        }
+
         return $this->hasRecordThatPasses(function ($rec) use ($record) {
-            if (is_array($record)) {
-                if ($rec['message'] !== $record['message']) {
-                    return false;
-                }
-                if ($rec['context'] !== $record['context']) {
-                    return false;
-                }
-            } else {
-                if ($rec['message'] !== $record) {
-                    return false;
-                }
+            if ($rec['message'] !== $record['message']) {
+                return false;
+            }
+            if (isset($record['context']) && $rec['context'] !== $record['context']) {
+                return false;
             }
             return true;
         }, $level);

--- a/src/Monolog/Handler/TestHandler.php
+++ b/src/Monolog/Handler/TestHandler.php
@@ -86,12 +86,20 @@ class TestHandler extends AbstractProcessingHandler
 
     public function hasRecord($record, $level)
     {
-        if (is_array($record)) {
-            $record = $record['message'];
-        }
-
         return $this->hasRecordThatPasses(function ($rec) use ($record) {
-            return $rec['message'] === $record;
+            if (is_array($record)) {
+                if ($rec['message'] !== $record['message']) {
+                    return false;
+                }
+                if ($rec['context'] !== $record['context']) {
+                    return false;
+                }
+            } else {
+                if ($rec['message'] !== $record) {
+                    return false;
+                }
+            }
+            return true;
         }, $level);
     }
 

--- a/tests/Monolog/Handler/TestHandlerTest.php
+++ b/tests/Monolog/Handler/TestHandlerTest.php
@@ -54,6 +54,52 @@ class TestHandlerTest extends TestCase
         $this->assertEquals([$record], $records);
     }
 
+    public function testHandlerAssertEmptyContext() {
+        $handler = new TestHandler;
+        $record  = $this->getRecord(Logger::WARNING, 'test', []);
+        $this->assertFalse($handler->hasWarning([
+            'message' => 'test',
+            'context' => [],
+        ]));
+
+        $handler->handle($record);
+
+        $this->assertTrue($handler->hasWarning([
+            'message' => 'test',
+            'context' => [],
+        ]));
+        $this->assertFalse($handler->hasWarning([
+            'message' => 'test',
+            'context' => [
+                'foo' => 'bar'
+            ],
+        ]));
+    }
+
+    public function testHandlerAssertNonEmptyContext() {
+        $handler = new TestHandler;
+        $record  = $this->getRecord(Logger::WARNING, 'test', ['foo' => 'bar']);
+        $this->assertFalse($handler->hasWarning([
+            'message' => 'test',
+            'context' => [
+                'foo' => 'bar'
+            ],
+        ]));
+
+        $handler->handle($record);
+
+        $this->assertTrue($handler->hasWarning([
+            'message' => 'test',
+            'context' => [
+                'foo' => 'bar'
+            ],
+        ]));
+        $this->assertFalse($handler->hasWarning([
+            'message' => 'test',
+            'context' => [],
+        ]));
+    }
+
     public function methodProvider()
     {
         return [


### PR DESCRIPTION
The current implementation of hasRecord in the TestHandler only checks that the message is correct, not the context. This has also been reported in issue #1002 .

In this pull request, I'm changing the hasRecord method to also verify the context. However, I'm not sure if the hasRecordThatContains should also be modified, and if so, what that should actually mean.

I'm also adding two new tests to verify this behaviour.