### PR TITLE
Use late static bindings in BrowserConsoleHandler

### DIFF
--- a/src/Monolog/Handler/BrowserConsoleHandler.php
+++ b/src/Monolog/Handler/BrowserConsoleHandler.php
@@ -43,11 +43,11 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
     protected function write(array $record)
     {
         // Accumulate records
-        self::$records[] = $record;
+        static::$records[] = $record;
 
         // Register shutdown handler if not already done
-        if (!self::$initialized) {
-            self::$initialized = true;
+        if (!static::$initialized) {
+            static::$initialized = true;
             $this->registerShutdownFunction();
         }
     }
@@ -58,18 +58,18 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
      */
     public static function send()
     {
-        $format = self::getResponseFormat();
+        $format = static::getResponseFormat();
         if ($format === 'unknown') {
             return;
         }
 
-        if (count(self::$records)) {
+        if (count(static::$records)) {
             if ($format === 'html') {
-                self::writeOutput('<script>' . self::generateScript() . '</script>');
+                static::writeOutput('<script>' . static::generateScript() . '</script>');
             } elseif ($format === 'js') {
-                self::writeOutput(self::generateScript());
+                static::writeOutput(static::generateScript());
             }
-            self::reset();
+            static::reset();
         }
     }
 
@@ -78,7 +78,7 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
      */
     public static function reset()
     {
-        self::$records = array();
+        static::$records = array();
     }
 
     /**
@@ -133,18 +133,18 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
     private static function generateScript()
     {
         $script = array();
-        foreach (self::$records as $record) {
-            $context = self::dump('Context', $record['context']);
-            $extra = self::dump('Extra', $record['extra']);
+        foreach (static::$records as $record) {
+            $context = static::dump('Context', $record['context']);
+            $extra = static::dump('Extra', $record['extra']);
 
             if (empty($context) && empty($extra)) {
-                $script[] = self::call_array('log', self::handleStyles($record['formatted']));
+                $script[] = static::call_array('log', static::handleStyles($record['formatted']));
             } else {
                 $script = array_merge($script,
-                    array(self::call_array('groupCollapsed', self::handleStyles($record['formatted']))),
+                    array(static::call_array('groupCollapsed', static::handleStyles($record['formatted']))),
                     $context,
                     $extra,
-                    array(self::call('groupEnd'))
+                    array(static::call('groupEnd'))
                 );
             }
         }
@@ -154,19 +154,19 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
 
     private static function handleStyles($formatted)
     {
-        $args = array(self::quote('font-weight: normal'));
+        $args = array(static::quote('font-weight: normal'));
         $format = '%c' . $formatted;
         preg_match_all('/\[\[(.*?)\]\]\{([^}]*)\}/s', $format, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
 
         foreach (array_reverse($matches) as $match) {
-            $args[] = self::quote(self::handleCustomStyles($match[2][0], $match[1][0]));
+            $args[] = static::quote(static::handleCustomStyles($match[2][0], $match[1][0]));
             $args[] = '"font-weight: normal"';
 
             $pos = $match[0][1];
             $format = substr($format, 0, $pos) . '%c' . $match[1][0] . '%c' . substr($format, $pos + strlen($match[0][0]));
         }
 
-        array_unshift($args, self::quote($format));
+        array_unshift($args, static::quote($format));
 
         return $args;
     }
@@ -198,13 +198,13 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
         if (empty($dict)) {
             return $script;
         }
-        $script[] = self::call('log', self::quote('%c%s'), self::quote('font-weight: bold'), self::quote($title));
+        $script[] = static::call('log', static::quote('%c%s'), static::quote('font-weight: bold'), static::quote($title));
         foreach ($dict as $key => $value) {
             $value = json_encode($value);
             if (empty($value)) {
-                $value = self::quote('');
+                $value = static::quote('');
             }
-            $script[] = self::call('log', self::quote('%s: %o'), self::quote($key), $value);
+            $script[] = static::call('log', static::quote('%s: %o'), static::quote($key), $value);
         }
 
         return $script;
@@ -220,7 +220,7 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
         $args = func_get_args();
         $method = array_shift($args);
 
-        return self::call_array($method, $args);
+        return static::call_array($method, $args);
     }
 
     private static function call_array($method, array $args)


### PR DESCRIPTION
Ref https://github.com/symfony/monolog-bundle/issues/152

TL;DR
BrowserConsoleHandler in a current state cannot be overridden because it is using `self::` instead of `static::` to access its members.