### PR TITLE
Remove from slack handler on constructing the SlackRecord to pass the Formatte

### DIFF
--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -63,8 +63,7 @@ class SlackHandler extends SocketHandler
             $iconEmoji,
             $useShortAttachment,
             $includeContextAndExtra,
-            $excludeFields,
-            $this->formatter
+            $excludeFields
         );
 
         $this->token = $token;

--- a/src/Monolog/Handler/SlackWebhookHandler.php
+++ b/src/Monolog/Handler/SlackWebhookHandler.php
@@ -60,8 +60,7 @@ class SlackWebhookHandler extends AbstractProcessingHandler
             $iconEmoji,
             $useShortAttachment,
             $includeContextAndExtra,
-            $excludeFields,
-            $this->formatter
+            $excludeFields
         );
     }
 


### PR DESCRIPTION
During constructiong the SlackHandler a Formatter has not been set.

So it does not make sense passing the Formatter as an argument to SlackRecord. It is just confusing and makes people wonder where this has been set?