### PR TITLE
A getter for SwiftMailerHandler's subject formatter

### DIFF
--- a/src/Monolog/Handler/SwiftMailerHandler.php
+++ b/src/Monolog/Handler/SwiftMailerHandler.php
@@ -12,6 +12,7 @@
 namespace Monolog\Handler;
 
 use Monolog\Logger;
+use Monolog\Formatter\FormatterInterface;
 use Monolog\Formatter\LineFormatter;
 use Swift_Message;
 use Swift;
@@ -49,6 +50,16 @@ class SwiftMailerHandler extends MailHandler
     }
 
     /**
+     * Gets the formatter for the Swift_Message subject.
+     *
+     * @param  string             $format The format of the subject
+     * @return FormatterInterface
+     */
+    protected function getSubjectFormatter(string $format): FormatterInterface
+    {
+        return new LineFormatter($format);
+    }
+    /**
      * Creates instance of Swift_Message to be sent
      *
      * @param  string        $content formatted email body to be sent
@@ -70,7 +81,7 @@ class SwiftMailerHandler extends MailHandler
         }
 
         if ($records) {
-            $subjectFormatter = new LineFormatter($message->getSubject());
+            $subjectFormatter = $this->getSubjectFormatter($message->getSubject());
             $message->setSubject($subjectFormatter->format($this->getHighestRecord($records)));
         }
 

--- a/tests/Monolog/Handler/InsightOpsHandlerTest.php
+++ b/tests/Monolog/Handler/InsightOpsHandlerTest.php
@@ -11,7 +11,7 @@
 
  namespace Monolog\Handler;
  
- use Monolog\TestCase;
+ use Monolog\Test\TestCase;
  use Monolog\Logger;
 
 /**
@@ -38,7 +38,7 @@ class InsightOpsHandlerTest extends TestCase
         fseek($this->resource, 0);
         $content = fread($this->resource, 1024);
 
-        $this->assertRegexp('/testToken \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] test.CRITICAL: Critical write test/', $content);
+        $this->assertRegexp('/testToken \[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}\+00:00\] test.CRITICAL: Critical write test/', $content);
     }
 
     public function testWriteBatchContent()
@@ -49,7 +49,7 @@ class InsightOpsHandlerTest extends TestCase
         fseek($this->resource, 0);
         $content = fread($this->resource, 1024);
 
-        $this->assertRegexp('/(testToken \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] .* \[\] \[\]\n){3}/', $content);
+        $this->assertRegexp('/(testToken \[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}\+00:00\] .* \[\] \[\]\n){3}/', $content);
     }
 
     private function createHandler()
@@ -57,11 +57,11 @@ class InsightOpsHandlerTest extends TestCase
         $useSSL = extension_loaded('openssl');
         $args = array('testToken', 'us', $useSSL, Logger::DEBUG, true);
         $this->resource = fopen('php://memory', 'a');
-        $this->handler = $this->getMock(
-            '\Monolog\Handler\InsightOpsHandler',
-            array('fsockopen', 'streamSetTimeout', 'closeSocket'),
-            $args
-        );
+        $this->handler = $this->getMockBuilder(InsightOpsHandler::class)
+            ->setMethods(array('fsockopen', 'streamSetTimeout', 'closeSocket'))
+            ->setConstructorArgs($args)
+            ->getMock();
+
 
         $reflectionProperty = new \ReflectionProperty('\Monolog\Handler\SocketHandler', 'connectionString');
         $reflectionProperty->setAccessible(true);


### PR DESCRIPTION
https://github.com/Seldaek/monolog/issues/1105

This PR moves an instance creation of SwiftMailerHandler's subject formatter to a getter. 

Motivation: to get LineFormatter usage to be overwritable. 
Pretty minor change, still, can be useful.

I think there is no reason to cover this getter with a unit test but let me know if you'd like to.

P.S.
Why do I want to avoid LineFormatter usage? Rare cases, but for instance: to avoid calling this __toString() https://github.com/Seldaek/monolog/blob/master/src/Monolog/Formatter/NormalizerFormatter.php#L138 of this zf1 class https://github.com/zendframework/zf1/blob/master/library/Zend/Controller/Response/Abstract.php#L32 who thinks that __toString() method call is a reason to send headers
https://github.com/zendframework/zf1/blob/master/library/Zend/Controller/Response/Abstract.php#L768,%20L794