### PR TITLE
Include stacktraces for "previous" excpetions in LineFormatter

### DIFF
--- a/src/Monolog/Formatter/LineFormatter.php
+++ b/src/Monolog/Formatter/LineFormatter.php
@@ -126,16 +126,12 @@ class LineFormatter extends NormalizerFormatter
 
     protected function normalizeException(\Throwable $e, int $depth = 0): string
     {
-        $previousText = '';
+        $str = $this->formatException($e);
+
         if ($previous = $e->getPrevious()) {
             do {
-                $previousText .= ', '.get_class($previous).'(code: '.$previous->getCode().'): '.$previous->getMessage().' at '.$previous->getFile().':'.$previous->getLine();
+                $str .= "\n[previous exception] " . $this->formatException($previous);
             } while ($previous = $previous->getPrevious());
-        }
-
-        $str = '[object] ('.get_class($e).'(code: '.$e->getCode().'): '.$e->getMessage().' at '.$e->getFile().':'.$e->getLine().$previousText.')';
-        if ($this->includeStacktraces) {
-            $str .= "\n[stacktrace]\n".$e->getTraceAsString()."\n";
         }
 
         return $str;
@@ -165,5 +161,15 @@ class LineFormatter extends NormalizerFormatter
         }
 
         return str_replace(["\r\n", "\r", "\n"], ' ', $str);
+    }
+
+    private function formatException(\Throwable $e): string
+    {
+        $str = '[object] (' . get_class($e) . '(code: ' . $e->getCode() . '): ' . $e->getMessage() . ' at ' . $e->getFile() . ':' . $e->getLine() . ')';
+        if ($this->includeStacktraces) {
+            $str .= "\n[stacktrace]\n" . $e->getTraceAsString() . "\n";
+        }
+
+        return $str;
     }
 }

--- a/tests/Monolog/Formatter/LineFormatterTest.php
+++ b/tests/Monolog/Formatter/LineFormatterTest.php
@@ -170,7 +170,7 @@ class LineFormatterTest extends \PHPUnit\Framework\TestCase
 
         $path = str_replace('\\/', '/', json_encode(__FILE__));
 
-        $this->assertEquals('['.date('Y-m-d').'] core.CRITICAL: foobar {"exception":"[object] (RuntimeException(code: 0): Foo at '.substr($path, 1, -1).':'.(__LINE__ - 8).', LogicException(code: 0): Wut? at '.substr($path, 1, -1).':'.(__LINE__ - 12).')"} []'."\n", $message);
+        $this->assertEquals('['.date('Y-m-d').'] core.CRITICAL: foobar {"exception":"[object] (RuntimeException(code: 0): Foo at '.substr($path, 1, -1).':'.(__LINE__ - 8).')\n[previous exception] [object] (LogicException(code: 0): Wut? at '.substr($path, 1, -1).':'.(__LINE__ - 12).')"} []'."\n", $message);
     }
 
     public function testBatchFormat()


### PR DESCRIPTION
Fixes #1086.