### PR TITLE
Updated constructor params

### DIFF
--- a/src/Monolog/Handler/LogEntriesHandler.php
+++ b/src/Monolog/Handler/LogEntriesHandler.php
@@ -31,7 +31,7 @@ class LogEntriesHandler extends SocketHandler
      *
      * @throws MissingExtensionException If SSL encryption is set to true and OpenSSL is missing
      */
-    public function __construct($token, $host = 'data.logentries.com', $useSSL = true, $level = Logger::DEBUG, $bubble = true)
+    public function __construct($token, $useSSL = true, $level = Logger::DEBUG, $bubble = true, $host = 'data.logentries.com')
     {
         if ($useSSL && !extension_loaded('openssl')) {
             throw new MissingExtensionException('The OpenSSL PHP plugin is required to use SSL encrypted connection for LogEntriesHandler');

--- a/src/Monolog/Handler/LogEntriesHandler.php
+++ b/src/Monolog/Handler/LogEntriesHandler.php
@@ -31,13 +31,13 @@ class LogEntriesHandler extends SocketHandler
      *
      * @throws MissingExtensionException If SSL encryption is set to true and OpenSSL is missing
      */
-    public function __construct($token, $useSSL = true, $level = Logger::DEBUG, $bubble = true)
+    public function __construct($token, $host = 'data.logentries.com', $useSSL = true, $level = Logger::DEBUG, $bubble = true)
     {
         if ($useSSL && !extension_loaded('openssl')) {
             throw new MissingExtensionException('The OpenSSL PHP plugin is required to use SSL encrypted connection for LogEntriesHandler');
         }
 
-        $endpoint = $useSSL ? 'ssl://data.logentries.com:443' : 'data.logentries.com:80';
+        $endpoint = $useSSL ? 'ssl://' . $host . ':443' : $host . ':80';
         parent::__construct($endpoint, $level, $bubble);
         $this->logToken = $token;
     }


### PR DESCRIPTION
Resolves #1173 

Added ability to pass in host parameter. This is needed for new Logentries accounts which are now on a different domain (rapid7.com).

_Note: You also need to pass in `$useSSL` as `false` because it seems port 443 is not an option on the new domain, but I left it in for backwards compatibility._