### PR TITLE
Add support for browser and OS proper recognition

### DIFF
--- a/src/Monolog/Handler/RavenHandler.php
+++ b/src/Monolog/Handler/RavenHandler.php
@@ -173,6 +173,11 @@ class RavenHandler extends AbstractProcessingHandler
                 unset($options['extra']['context']['user']);
             }
         }
+
+        if (!empty($record['contexts'])) {
+            $options['contexts'] = $record['contexts'];
+        }
+
         if (!empty($record['extra'])) {
             $options['extra']['extra'] = $record['extra'];
         }


### PR DESCRIPTION
By default, browser and OS are not properly recognized in sentry when logging from Monolog, even if proper http-agent data is provided. Only runtime options are visible:
![image](https://user-images.githubusercontent.com/3474636/43001144-739af93a-8c24-11e8-8014-f9bfaf5b2b9e.png)
With this simple fix, when we provide additional data ([using processor](https://symfony.com/doc/current/logging/processors.html)) under `contexts` index (same as in JSON generated from JS SDK) we have it :)
![image](https://user-images.githubusercontent.com/3474636/43001259-ea617896-8c24-11e8-97df-a9069d4b9e0c.png)


