### PR TITLE
Cast slack value to string

### DIFF
--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -228,7 +228,7 @@ class SlackRecord
 
         return array(
             'title' => ucfirst($title),
-            'value' => (string) $value,
+            'value' => is_object($value) ? (string) $value : $value,
             'short' => false,
         );
     }

--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -228,7 +228,7 @@ class SlackRecord
 
         return array(
             'title' => ucfirst($title),
-            'value' => $value,
+            'value' => (string) $value,
             'short' => false,
         );
     }


### PR DESCRIPTION
Make sure the value is a string. Eg. for an Exception object.