### PR TITLE
Updated @see URL for GELF formatter.

### DIFF
--- a/src/Monolog/Formatter/GelfMessageFormatter.php
+++ b/src/Monolog/Formatter/GelfMessageFormatter.php
@@ -16,7 +16,7 @@ use Gelf\Message;
 
 /**
  * Serializes a log message to GELF
- * @see http://www.graylog2.org/about/gelf
+ * @see http://docs.graylog.org/en/latest/pages/gelf.html
  *
  * @author Matt Lehner <mlehner@gmail.com>
  */


### PR DESCRIPTION
The @see URL for GELF was broken so I found the new URL and updated it in the PHPDoc.