### PR TITLE
Add ProcessorInterface, an optional one to allow labelling Monolog processors

### DIFF
--- a/src/Monolog/Processor/GitProcessor.php
+++ b/src/Monolog/Processor/GitProcessor.php
@@ -19,7 +19,7 @@ use Monolog\Logger;
  * @author Nick Otter
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-class GitProcessor
+class GitProcessor implements ProcessorInterface
 {
     private $level;
     private static $cache;

--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -24,7 +24,7 @@ use Monolog\Logger;
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-class IntrospectionProcessor
+class IntrospectionProcessor implements ProcessorInterface
 {
     private $level;
 

--- a/src/Monolog/Processor/MemoryProcessor.php
+++ b/src/Monolog/Processor/MemoryProcessor.php
@@ -16,7 +16,7 @@ namespace Monolog\Processor;
  *
  * @author Rob Jensen
  */
-abstract class MemoryProcessor
+abstract class MemoryProcessor implements ProcessorInterface
 {
     /**
      * @var bool If true, get the real size of memory allocated from system. Else, only the memory used by emalloc() is reported.

--- a/src/Monolog/Processor/MercurialProcessor.php
+++ b/src/Monolog/Processor/MercurialProcessor.php
@@ -18,7 +18,7 @@ use Monolog\Logger;
  *
  * @author Jonathan A. Schweder <jonathanschweder@gmail.com>
  */
-class MercurialProcessor
+class MercurialProcessor implements ProcessorInterface
 {
     private $level;
     private static $cache;

--- a/src/Monolog/Processor/ProcessIdProcessor.php
+++ b/src/Monolog/Processor/ProcessIdProcessor.php
@@ -16,7 +16,7 @@ namespace Monolog\Processor;
  *
  * @author Andreas Hörnicke
  */
-class ProcessIdProcessor
+class ProcessIdProcessor implements ProcessorInterface
 {
     /**
      * @param  array $record

--- a/src/Monolog/Processor/ProcessorInterface.php
+++ b/src/Monolog/Processor/ProcessorInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+/**
+ * An optional interface to allow labelling Monolog processors.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+interface ProcessorInterface
+{
+    /**
+     * @return array The processed records
+     */
+    public function __invoke(array $records);
+}

--- a/src/Monolog/Processor/PsrLogMessageProcessor.php
+++ b/src/Monolog/Processor/PsrLogMessageProcessor.php
@@ -18,7 +18,7 @@ namespace Monolog\Processor;
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-class PsrLogMessageProcessor
+class PsrLogMessageProcessor implements ProcessorInterface
 {
     /**
      * @param  array $record

--- a/src/Monolog/Processor/TagProcessor.php
+++ b/src/Monolog/Processor/TagProcessor.php
@@ -16,7 +16,7 @@ namespace Monolog\Processor;
  *
  * @author Martijn Riemers
  */
-class TagProcessor
+class TagProcessor implements ProcessorInterface
 {
     private $tags;
 

--- a/src/Monolog/Processor/UidProcessor.php
+++ b/src/Monolog/Processor/UidProcessor.php
@@ -16,7 +16,7 @@ namespace Monolog\Processor;
  *
  * @author Simon Mönch <sm@webfactory.de>
  */
-class UidProcessor
+class UidProcessor implements ProcessorInterface
 {
     private $uid;
 

--- a/src/Monolog/Processor/WebProcessor.php
+++ b/src/Monolog/Processor/WebProcessor.php
@@ -16,7 +16,7 @@ namespace Monolog\Processor;
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-class WebProcessor
+class WebProcessor implements ProcessorInterface
 {
     /**
      * @var array|\ArrayAccess


### PR DESCRIPTION
Would replace https://github.com/symfony/symfony/pull/27801, as an interface better belongs to its original package than to a bridge.