### PR TITLE
[RavenHandler] Change private vars to protected

### DIFF
--- a/src/Monolog/Handler/RavenHandler.php
+++ b/src/Monolog/Handler/RavenHandler.php
@@ -27,7 +27,7 @@ class RavenHandler extends AbstractProcessingHandler
     /**
      * Translates Monolog log levels to Raven log levels.
      */
-    private $logLevels = [
+    protected $logLevels = [
         Logger::DEBUG     => Raven_Client::DEBUG,
         Logger::INFO      => Raven_Client::INFO,
         Logger::NOTICE    => Raven_Client::INFO,
@@ -42,7 +42,7 @@ class RavenHandler extends AbstractProcessingHandler
      * @var string should represent the current version of the calling
      *             software. Can be any string (git commit, version number)
      */
-    private $release;
+    protected $release;
 
     /**
      * @var Raven_Client the client object that sends the message to the server


### PR DESCRIPTION
The class uses `private` vars while it's not necessary. It makes it difficult to extend this class. This PR changes `private` vars into `protected`.