### PR TITLE
[RavenHandler] Add support for contexts

### DIFF
--- a/src/Monolog/Handler/RavenHandler.php
+++ b/src/Monolog/Handler/RavenHandler.php
@@ -182,10 +182,12 @@ class RavenHandler extends AbstractProcessingHandler
             unset($record['contexts']);
         }
         if (!empty($record['extra']['contexts'])) {
-            if (!empty($options['contexts']))
+            if (!empty($options['contexts'])) {
                 $options['contexts'] = array_merge($options['contexts'], $record['extra']['contexts']);
-            else
+            }
+            else {
                 $options['contexts'] = $record['extra']['contexts'];
+            }
             unset($record['extra']['contexts']);
         }
 

--- a/src/Monolog/Handler/RavenHandler.php
+++ b/src/Monolog/Handler/RavenHandler.php
@@ -177,6 +177,18 @@ class RavenHandler extends AbstractProcessingHandler
             $options['extra']['extra'] = $record['extra'];
         }
 
+        if (!empty($record['contexts'])) {
+            $options['contexts'] = $record['contexts'];
+            unset($record['contexts']);
+        }
+        if (!empty($record['extra']['contexts'])) {
+            if (!empty($options['contexts']))
+                $options['contexts'] = array_merge($options['contexts'], $record['extra']['contexts']);
+            else
+                $options['contexts'] = $record['extra']['contexts'];
+            unset($record['extra']['contexts']);
+        }
+
         if (!empty($this->release) && !isset($options['release'])) {
             $options['release'] = $this->release;
         }


### PR DESCRIPTION
Originates from #1179, and problem discussion is available at [Sentry](https://github.com/getsentry/sentry/issues/8555).

Sentry provides [contexts](https://docs.sentry.io/clientdev/interfaces/contexts/) to add extra data to the log. But it's not supported in current release of RavenHandler. As a result, in Sentry we see empty info like this:

![image](https://user-images.githubusercontent.com/16267156/47886660-7bc21d80-de4c-11e8-858e-4abacb262e3d.png)

This PR fixes this, so that user can pass `contexts` field in the record, as a result we will see something like this:

![image](https://user-images.githubusercontent.com/16267156/47886686-ac09bc00-de4c-11e8-8800-d1705096f23e.png)

Users can pass information to Sentry like this:

```php
$logger = new Monolog\Logger('YOUR_LOG_NAME');
$client = new Raven_Client('YOUR_SECRET_KEY');
$stream = new RavenHandler($client);
$log->addNotice('Some information', [
    'contexts' => [
        'os' => [
            'name' => 'Windows',
            'version' => '10'
        ]
    ]
]);
```

It's also possible to pass the `contexts` using [processors](https://github.com/Seldaek/monolog/blob/master/doc/02-handlers-formatters-processors.md#processors). Example:

```php
$log->pushProcessor(function ($record) {
    $record['contexts'] = [
        'os' => [
            'name' => 'Windows',
            'version' => '10'
        ]
    ];
    return $record;
});
```