### PR TITLE
Add newrelic_end_transcation() at the end of the write method

### DIFF
--- a/src/Monolog/Handler/NewRelicHandler.php
+++ b/src/Monolog/Handler/NewRelicHandler.php
@@ -117,6 +117,8 @@ class NewRelicHandler extends AbstractProcessingHandler
                 }
             }
         }
+
+        newrelic_end_transaction();
     }
 
     /**


### PR DESCRIPTION
Calling `newrelic_end_transaction()` is required for every transaction.