### PR TITLE
We do not need to close the socket manually

### DIFF
--- a/src/Monolog/Handler/SyslogUdpHandler.php
+++ b/src/Monolog/Handler/SyslogUdpHandler.php
@@ -52,11 +52,6 @@ class SyslogUdpHandler extends AbstractSyslogHandler
         }
     }
 
-    public function close(): void
-    {
-        $this->socket->close();
-    }
-
     private function splitMessageIntoLines($message): array
     {
         if (is_array($message)) {


### PR DESCRIPTION
The motivation for this pr: 
We've had some issues with this error in our logs: "The UdpSocket to syslog.cbxone:514 has been closed and can not be written to anymore". The problem seems to be that that send is being called after the socket has been closed. This lead us down the rabbit hole of "when is an object destructed. My colleague who did the deep dive wrote:

PHP docs say this about __destruct(): "The destructor method will be called as
soon as there are no other references to a particular object, or in any order
during the shutdown sequence.". Monolog will attempt to close the socket via
AbstractHandler::__destruct() but if this occurs during the PHP "shutdown
sequence", it seems a send() may actually come after this which triggers an
error: "The UdpSocket to syslog.cbxone:514 has been closed and can not be
written to anymore".

Using strace I have verified that PHP closes the socket itself during shutdown,
even with FPM (which reuses PHP processes), so the __destruct behavior is
entirely unnecessary

Thank you so much for an awesome library! :)