### PR TITLE
Exclude files and folder from release archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
-.gitattributes export-ignore
-.gitignore export-ignore
-.travis.yml export-ignore
+/doc export-ignore
+/tests export-ignore
+/.* export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
Hi,

Let's not publish all those file.
`.gitattributes` can be used to exclude files from final archive that is downloaded by composer.

This file content is same as `master` branch now.

Thanks.