### PR TITLE
Add visibility to constants

### DIFF
--- a/src/Monolog/Formatter/GelfMessageFormatter.php
+++ b/src/Monolog/Formatter/GelfMessageFormatter.php
@@ -22,7 +22,7 @@ use Gelf\Message;
  */
 class GelfMessageFormatter extends NormalizerFormatter
 {
-    const DEFAULT_MAX_LENGTH = 32766;
+    public const DEFAULT_MAX_LENGTH = 32766;
 
     /**
      * @var string the name of the system for the Gelf log message

--- a/src/Monolog/Formatter/JsonFormatter.php
+++ b/src/Monolog/Formatter/JsonFormatter.php
@@ -23,8 +23,8 @@ use Throwable;
  */
 class JsonFormatter extends NormalizerFormatter
 {
-    const BATCH_MODE_JSON = 1;
-    const BATCH_MODE_NEWLINES = 2;
+    public const BATCH_MODE_JSON = 1;
+    public const BATCH_MODE_NEWLINES = 2;
 
     protected $batchMode;
     protected $appendNewline;

--- a/src/Monolog/Formatter/LineFormatter.php
+++ b/src/Monolog/Formatter/LineFormatter.php
@@ -23,7 +23,7 @@ use Monolog\Utils;
  */
 class LineFormatter extends NormalizerFormatter
 {
-    const SIMPLE_FORMAT = "[%datetime%] %channel%.%level_name%: %message% %context% %extra%\n";
+    public const SIMPLE_FORMAT = "[%datetime%] %channel%.%level_name%: %message% %context% %extra%\n";
 
     protected $format;
     protected $allowInlineLineBreaks;

--- a/src/Monolog/Formatter/LogmaticFormatter.php
+++ b/src/Monolog/Formatter/LogmaticFormatter.php
@@ -18,7 +18,7 @@ namespace Monolog\Formatter;
  */
 class LogmaticFormatter extends JsonFormatter
 {
-    const MARKERS = ["sourcecode", "php"];
+    public const MARKERS = ["sourcecode", "php"];
 
     /**
      * @var string

--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -22,7 +22,7 @@ use Monolog\Utils;
  */
 class NormalizerFormatter implements FormatterInterface
 {
-    const SIMPLE_DATE = "Y-m-d\TH:i:sP";
+    public const SIMPLE_DATE = "Y-m-d\TH:i:sP";
 
     protected $dateFormat;
     protected $maxNormalizeDepth = 9;

--- a/src/Monolog/Formatter/WildfireFormatter.php
+++ b/src/Monolog/Formatter/WildfireFormatter.php
@@ -22,7 +22,7 @@ use Monolog\Logger;
  */
 class WildfireFormatter extends NormalizerFormatter
 {
-    const TABLE = 'table';
+    public const TABLE = 'table';
 
     /**
      * Translates Monolog log levels to Wildfire levels.

--- a/src/Monolog/Handler/ChromePHPHandler.php
+++ b/src/Monolog/Handler/ChromePHPHandler.php
@@ -29,17 +29,17 @@ class ChromePHPHandler extends AbstractProcessingHandler
     /**
      * Version of the extension
      */
-    const VERSION = '4.0';
+    public const VERSION = '4.0';
 
     /**
      * Header name
      */
-    const HEADER_NAME = 'X-ChromeLogger-Data';
+    public const HEADER_NAME = 'X-ChromeLogger-Data';
 
     /**
      * Regular expression to detect supported browsers (matches any Chrome, or Firefox 43+)
      */
-    const USER_AGENT_REGEX = '{\b(?:Chrome/\d+(?:\.\d+)*|HeadlessChrome|Firefox/(?:4[3-9]|[5-9]\d|\d{3,})(?:\.\d)*)\b}';
+    public const USER_AGENT_REGEX = '{\b(?:Chrome/\d+(?:\.\d+)*|HeadlessChrome|Firefox/(?:4[3-9]|[5-9]\d|\d{3,})(?:\.\d)*)\b}';
 
     protected static $initialized = false;
 

--- a/src/Monolog/Handler/DynamoDbHandler.php
+++ b/src/Monolog/Handler/DynamoDbHandler.php
@@ -26,7 +26,7 @@ use Monolog\Logger;
  */
 class DynamoDbHandler extends AbstractProcessingHandler
 {
-    const DATE_FORMAT = 'Y-m-d\TH:i:s.uO';
+    public const DATE_FORMAT = 'Y-m-d\TH:i:s.uO';
 
     /**
      * @var DynamoDbClient

--- a/src/Monolog/Handler/ErrorLogHandler.php
+++ b/src/Monolog/Handler/ErrorLogHandler.php
@@ -22,8 +22,8 @@ use Monolog\Logger;
  */
 class ErrorLogHandler extends AbstractProcessingHandler
 {
-    const OPERATING_SYSTEM = 0;
-    const SAPI = 4;
+    public const OPERATING_SYSTEM = 0;
+    public const SAPI = 4;
 
     protected $messageType;
     protected $expandNewlines;

--- a/src/Monolog/Handler/FirePHPHandler.php
+++ b/src/Monolog/Handler/FirePHPHandler.php
@@ -26,22 +26,22 @@ class FirePHPHandler extends AbstractProcessingHandler
     /**
      * WildFire JSON header message format
      */
-    const PROTOCOL_URI = 'http://meta.wildfirehq.org/Protocol/JsonStream/0.2';
+    public const PROTOCOL_URI = 'http://meta.wildfirehq.org/Protocol/JsonStream/0.2';
 
     /**
      * FirePHP structure for parsing messages & their presentation
      */
-    const STRUCTURE_URI = 'http://meta.firephp.org/Wildfire/Structure/FirePHP/FirebugConsole/0.1';
+    public const STRUCTURE_URI = 'http://meta.firephp.org/Wildfire/Structure/FirePHP/FirebugConsole/0.1';
 
     /**
      * Must reference a "known" plugin, otherwise headers won't display in FirePHP
      */
-    const PLUGIN_URI = 'http://meta.firephp.org/Wildfire/Plugin/FirePHP/Library-FirePHPCore/0.3';
+    public const PLUGIN_URI = 'http://meta.firephp.org/Wildfire/Plugin/FirePHP/Library-FirePHPCore/0.3';
 
     /**
      * Header prefix for Wildfire to recognize & parse headers
      */
-    const HEADER_PREFIX = 'X-Wf';
+    public const HEADER_PREFIX = 'X-Wf';
 
     /**
      * Whether or not Wildfire vendor-specific headers have been generated & sent yet

--- a/src/Monolog/Handler/FleepHookHandler.php
+++ b/src/Monolog/Handler/FleepHookHandler.php
@@ -25,9 +25,9 @@ use Monolog\Logger;
  */
 class FleepHookHandler extends SocketHandler
 {
-    const FLEEP_HOST = 'fleep.io';
+    public const FLEEP_HOST = 'fleep.io';
 
-    const FLEEP_HOOK_URI = '/hook/';
+    public const FLEEP_HOOK_URI = '/hook/';
 
     /**
      * @var string Webhook token (specifies the conversation where logs are sent)

--- a/src/Monolog/Handler/HipChatHandler.php
+++ b/src/Monolog/Handler/HipChatHandler.php
@@ -32,12 +32,12 @@ class HipChatHandler extends SocketHandler
     /**
      * The maximum allowed length for the name used in the "from" field.
      */
-    const MAXIMUM_NAME_LENGTH = 15;
+    public const MAXIMUM_NAME_LENGTH = 15;
 
     /**
      * The maximum allowed length for the message.
      */
-    const MAXIMUM_MESSAGE_LENGTH = 9500;
+    public const MAXIMUM_MESSAGE_LENGTH = 9500;
 
     /**
      * @var string

--- a/src/Monolog/Handler/LogglyHandler.php
+++ b/src/Monolog/Handler/LogglyHandler.php
@@ -24,9 +24,9 @@ use Monolog\Formatter\LogglyFormatter;
  */
 class LogglyHandler extends AbstractProcessingHandler
 {
-    const HOST = 'logs-01.loggly.com';
-    const ENDPOINT_SINGLE = 'inputs';
-    const ENDPOINT_BATCH = 'bulk';
+    public const HOST = 'logs-01.loggly.com';
+    public const ENDPOINT_SINGLE = 'inputs';
+    public const ENDPOINT_BATCH = 'bulk';
 
     protected $token;
 

--- a/src/Monolog/Handler/ProcessHandler.php
+++ b/src/Monolog/Handler/ProcessHandler.php
@@ -51,7 +51,7 @@ class ProcessHandler extends AbstractProcessingHandler
     /**
      * @var array
      */
-    const DESCRIPTOR_SPEC = [
+    public const DESCRIPTOR_SPEC = [
         0 => ['pipe', 'r'],  // STDIN is a pipe that the child will read from
         1 => ['pipe', 'w'],  // STDOUT is a pipe that the child will write to
         2 => ['pipe', 'w'],  // STDERR is a pipe to catch the any errors

--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -25,9 +25,9 @@ use Monolog\Logger;
  */
 class RotatingFileHandler extends StreamHandler
 {
-    const FILE_PER_DAY = 'Y-m-d';
-    const FILE_PER_MONTH = 'Y-m';
-    const FILE_PER_YEAR = 'Y';
+    public const FILE_PER_DAY = 'Y-m-d';
+    public const FILE_PER_MONTH = 'Y-m';
+    public const FILE_PER_YEAR = 'Y';
 
     protected $filename;
     protected $maxFiles;

--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -25,13 +25,13 @@ use Monolog\Formatter\FormatterInterface;
  */
 class SlackRecord
 {
-    const COLOR_DANGER = 'danger';
+    public const COLOR_DANGER = 'danger';
 
-    const COLOR_WARNING = 'warning';
+    public const COLOR_WARNING = 'warning';
 
-    const COLOR_GOOD = 'good';
+    public const COLOR_GOOD = 'good';
 
-    const COLOR_DEFAULT = '#e3e4e6';
+    public const COLOR_DEFAULT = '#e3e4e6';
 
     /**
      * Slack channel (encoded ID or name)

--- a/src/Monolog/Handler/SqsHandler.php
+++ b/src/Monolog/Handler/SqsHandler.php
@@ -22,9 +22,9 @@ use Monolog\Logger;
 class SqsHandler extends AbstractProcessingHandler
 {
     /** 256 KB in bytes - maximum message size in SQS */
-    const MAX_MESSAGE_SIZE = 262144;
+    public const MAX_MESSAGE_SIZE = 262144;
     /** 100 KB in bytes - head message size for new error log */
-    const HEAD_MESSAGE_SIZE = 102400;
+    public const HEAD_MESSAGE_SIZE = 102400;
 
     /** @var SqsClient */
     private $client;

--- a/src/Monolog/Handler/SyslogUdp/UdpSocket.php
+++ b/src/Monolog/Handler/SyslogUdp/UdpSocket.php
@@ -13,7 +13,7 @@ namespace Monolog\Handler\SyslogUdp;
 
 class UdpSocket
 {
-    const DATAGRAM_MAX_LENGTH = 65023;
+    public const DATAGRAM_MAX_LENGTH = 65023;
 
     /** @var string */
     protected $ip;

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -30,19 +30,19 @@ class Logger implements LoggerInterface, ResettableInterface
     /**
      * Detailed debug information
      */
-    const DEBUG = 100;
+    public const DEBUG = 100;
 
     /**
      * Interesting events
      *
      * Examples: User logs in, SQL logs.
      */
-    const INFO = 200;
+    public const INFO = 200;
 
     /**
      * Uncommon events
      */
-    const NOTICE = 250;
+    public const NOTICE = 250;
 
     /**
      * Exceptional occurrences that are not errors
@@ -50,19 +50,19 @@ class Logger implements LoggerInterface, ResettableInterface
      * Examples: Use of deprecated APIs, poor use of an API,
      * undesirable things that are not necessarily wrong.
      */
-    const WARNING = 300;
+    public const WARNING = 300;
 
     /**
      * Runtime errors
      */
-    const ERROR = 400;
+    public const ERROR = 400;
 
     /**
      * Critical conditions
      *
      * Example: Application component unavailable, unexpected exception.
      */
-    const CRITICAL = 500;
+    public const CRITICAL = 500;
 
     /**
      * Action must be taken immediately
@@ -70,12 +70,12 @@ class Logger implements LoggerInterface, ResettableInterface
      * Example: Entire website down, database unavailable, etc.
      * This should trigger the SMS alerts and wake you up.
      */
-    const ALERT = 550;
+    public const ALERT = 550;
 
     /**
      * Urgent alert.
      */
-    const EMERGENCY = 600;
+    public const EMERGENCY = 600;
 
     /**
      * Monolog API version
@@ -85,7 +85,7 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * @var int
      */
-    const API = 2;
+    public const API = 2;
 
     /**
      * This is a static variable and not a constant to serve as an extension point for custom levels

--- a/src/Monolog/Processor/PsrLogMessageProcessor.php
+++ b/src/Monolog/Processor/PsrLogMessageProcessor.php
@@ -22,7 +22,7 @@ use Monolog\Utils;
  */
 class PsrLogMessageProcessor implements ProcessorInterface
 {
-    const SIMPLE_DATE = "Y-m-d\TH:i:s.uP";
+    public const SIMPLE_DATE = "Y-m-d\TH:i:s.uP";
 
     /** @var ?string */
     private $dateFormat;


### PR DESCRIPTION
[PSR-12](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md) Just for reference if it gets accepted: 

> Visibility MUST be declared on all constants if your project PHP minimum version supports constant visibilities (PHP 7.1 or later).

Personally I like it also this way better. Maybe you should revise some of them if they should be public but this would be a BC. Since you are moving to v2.0 it's a good chance.