### PR TITLE
Added a test logger

### DIFF
--- a/src/Monolog/TestLogger.php
+++ b/src/Monolog/TestLogger.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Monolog;
+
+use Psr\Log\AbstractLogger;
+
+/**
+ * Used for testing purposes.
+ *
+ * It records all records and gives you access to them for verification.
+ *
+ * @method bool hasEmergency($record)
+ * @method bool hasAlert($record)
+ * @method bool hasCritical($record)
+ * @method bool hasError($record)
+ * @method bool hasWarning($record)
+ * @method bool hasNotice($record)
+ * @method bool hasInfo($record)
+ * @method bool hasDebug($record)
+ *
+ * @method bool hasEmergencyRecords()
+ * @method bool hasAlertRecords()
+ * @method bool hasCriticalRecords()
+ * @method bool hasErrorRecords()
+ * @method bool hasWarningRecords()
+ * @method bool hasNoticeRecords()
+ * @method bool hasInfoRecords()
+ * @method bool hasDebugRecords()
+ *
+ * @method bool hasEmergencyThatContains($message)
+ * @method bool hasAlertThatContains($message)
+ * @method bool hasCriticalThatContains($message)
+ * @method bool hasErrorThatContains($message)
+ * @method bool hasWarningThatContains($message)
+ * @method bool hasNoticeThatContains($message)
+ * @method bool hasInfoThatContains($message)
+ * @method bool hasDebugThatContains($message)
+ *
+ * @method bool hasEmergencyThatMatches($message)
+ * @method bool hasAlertThatMatches($message)
+ * @method bool hasCriticalThatMatches($message)
+ * @method bool hasErrorThatMatches($message)
+ * @method bool hasWarningThatMatches($message)
+ * @method bool hasNoticeThatMatches($message)
+ * @method bool hasInfoThatMatches($message)
+ * @method bool hasDebugThatMatches($message)
+ *
+ * @method bool hasEmergencyThatPasses($message)
+ * @method bool hasAlertThatPasses($message)
+ * @method bool hasCriticalThatPasses($message)
+ * @method bool hasErrorThatPasses($message)
+ * @method bool hasWarningThatPasses($message)
+ * @method bool hasNoticeThatPasses($message)
+ * @method bool hasInfoThatPasses($message)
+ * @method bool hasDebugThatPasses($message)
+ */
+final class TestLogger extends AbstractLogger implements ResettableInterface
+{
+    /**
+     * @var array
+     */
+    public $records = [];
+
+    public $recordsByLevel = [];
+
+    /**
+     * @inheritdoc
+     */
+    public function log($level, $message, array $context = [])
+    {
+        $record = [
+            'level' => $level,
+            'message' => $message,
+            'context' => $context,
+        ];
+
+        $this->recordsByLevel[$record['level']][] = $record;
+        $this->records[] = $record;
+    }
+
+    public function hasRecords($level)
+    {
+        return isset($this->recordsByLevel[$level]);
+    }
+
+    public function hasRecord($record, $level)
+    {
+        if (is_string($record)) {
+            $record = ['message' => $record];
+        }
+        return $this->hasRecordThatPasses(function ($rec) use ($record) {
+            if ($rec['message'] !== $record['message']) {
+                return false;
+            }
+            if (isset($record['context']) && $rec['context'] !== $record['context']) {
+                return false;
+            }
+            return true;
+        }, $level);
+    }
+
+    public function hasRecordThatContains($message, $level)
+    {
+        return $this->hasRecordThatPasses(function ($rec) use ($message) {
+            return strpos($rec['message'], $message) !== false;
+        }, $level);
+    }
+
+    public function hasRecordThatMatches($regex, $level)
+    {
+        return $this->hasRecordThatPasses(function ($rec) use ($regex) {
+            return preg_match($regex, $rec['message']) > 0;
+        }, $level);
+    }
+
+    public function hasRecordThatPasses(callable $predicate, $level)
+    {
+        if (!isset($this->recordsByLevel[$level])) {
+            return false;
+        }
+        foreach ($this->recordsByLevel[$level] as $i => $rec) {
+            if (call_user_func($predicate, $rec, $i)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function write(array $record): void
+    {
+        $this->recordsByLevel[$record['level']][] = $record;
+        $this->records[] = $record;
+    }
+
+    public function __call($method, $args)
+    {
+        if (preg_match('/(.*)(Debug|Info|Notice|Warning|Error|Critical|Alert|Emergency)(.*)/', $method, $matches) > 0) {
+            $genericMethod = $matches[1] . ('Records' !== $matches[3] ? 'Record' : '') . $matches[3];
+            $level = strtolower($matches[2]);
+            if (method_exists($this, $genericMethod)) {
+                $args[] = $level;
+                return call_user_func_array([$this, $genericMethod], $args);
+            }
+        }
+        throw new \BadMethodCallException('Call to undefined method ' . get_class($this) . '::' . $method . '()');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function reset()
+    {
+        $this->records = [];
+    }
+}

--- a/src/Monolog/TestLogger.php
+++ b/src/Monolog/TestLogger.php
@@ -126,15 +126,6 @@ final class TestLogger extends AbstractLogger implements ResettableInterface
         return false;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function write(array $record): void
-    {
-        $this->recordsByLevel[$record['level']][] = $record;
-        $this->records[] = $record;
-    }
-
     public function __call($method, $args)
     {
         if (preg_match('/(.*)(Debug|Info|Notice|Warning|Error|Critical|Alert|Emergency)(.*)/', $method, $matches) > 0) {

--- a/tests/Monolog/TestLoggerTest.php
+++ b/tests/Monolog/TestLoggerTest.php
@@ -1,0 +1,115 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog;
+
+use Monolog\Test\TestCase;
+
+/**
+ * @covers \Monolog\TestLogger
+ */
+class TestLoggerTest extends TestCase
+{
+    /**
+     * @dataProvider methodProvider
+     */
+    public function testHandler($method)
+    {
+        $handler = new TestLogger();
+        $level = strtolower($method);
+        $record = ['level' => $level, 'message' => 'test' . $method, 'context' => []];
+        $this->assertFalse($handler->hasRecords($level));
+        $this->assertFalse($handler->hasRecord($record, $level));
+        $this->assertFalse($handler->{'has'.$method}($record), 'has'.$method);
+        $this->assertFalse($handler->{'has'.$method.'ThatContains'}('test'), 'has'.$method.'ThatContains');
+        $this->assertFalse($handler->{'has'.$method.'ThatPasses'}(function ($rec) {
+            return true;
+        }), 'has'.$method.'ThatPasses');
+        $this->assertFalse($handler->{'has'.$method.'ThatMatches'}('/test\w+/'));
+        $this->assertFalse($handler->{'has'.$method.'Records'}(), 'has'.$method.'Records');
+        $handler->log($level, 'test'.$method);
+
+        $this->assertFalse($handler->{'has'.$method}('bar'), 'has'.$method);
+        $this->assertTrue($handler->hasRecords($level));
+        $this->assertTrue($handler->hasRecord($record, $level));
+        $this->assertTrue($handler->{'has'.$method}($record), 'has'.$method);
+        $this->assertTrue($handler->{'has'.$method}('test'.$method), 'has'.$method);
+        $this->assertTrue($handler->{'has'.$method.'ThatContains'}('test'), 'has'.$method.'ThatContains');
+        $this->assertTrue($handler->{'has'.$method.'ThatPasses'}(function ($rec) {
+            return true;
+        }), 'has'.$method.'ThatPasses');
+        $this->assertTrue($handler->{'has'.$method.'ThatMatches'}('/test\w+/'));
+        $this->assertTrue($handler->{'has'.$method.'Records'}(), 'has'.$method.'Records');
+
+        $records = $handler->records;
+        $this->assertEquals([$record], $records);
+    }
+
+    public function testHandlerAssertEmptyContext()
+    {
+        $logger = new TestLogger();
+        $this->assertFalse($logger->hasWarning([
+            'message' => 'test',
+            'context' => [],
+        ]));
+
+        $logger->warning('test');
+
+        $this->assertTrue($logger->hasWarning([
+            'message' => 'test',
+            'context' => [],
+        ]));
+        $this->assertFalse($logger->hasWarning([
+            'message' => 'test',
+            'context' => [
+                'foo' => 'bar',
+            ],
+        ]));
+    }
+
+    public function testHandlerAssertNonEmptyContext()
+    {
+        $handler = new TestLogger;
+        $this->assertFalse($handler->hasWarning([
+            'message' => 'test',
+            'context' => [
+                'foo' => 'bar',
+            ],
+        ]));
+
+        $handler->warning('test', ['foo' => 'bar']);
+
+        $this->assertTrue($handler->hasWarning([
+            'message' => 'test',
+            'context' => [
+                'foo' => 'bar',
+            ],
+        ]));
+        $this->assertFalse($handler->hasWarning([
+            'message' => 'test',
+            'context' => [],
+        ]));
+    }
+
+    public function methodProvider()
+    {
+        return [
+            ['Emergency'],
+            ['Alert'],
+            ['Critical'],
+            ['Error'],
+            ['Warning'],
+            ['Info'],
+            ['Notice'],
+            ['Debug'],
+        ];
+    }
+}


### PR DESCRIPTION
Hello,

I have created a TestLogger. I hope that you feel that this fits inside your package. I know that Monolog has a `TestHandler` but I believe this is better for the following reasons:

- Simpler initialization of Logger inside tests. At the moment in order to perform my tests I need to initialize a `Logger` and then a `TestHandler`.. More properties that I have to maintain inside my code... etc etc.
- Faster tests since it does minimal work. It skips all the extra work that it is made by `Logger` class.
- Inside the TestHandler you have the `getRecords` function. Even if I retrieve all the records when I need to do simple asserts I can not.. Check this:

```
$this->assertSame(['level' => 'warning', 'message' => 'that', ['context' => []], $records[0]];
```

The record contains a lot of extra information that in my case they are not needed.

Even in your tests you had to [do unset](https://github.com/Seldaek/monolog/blob/master/tests/Monolog/Handler/TestHandlerTest.php#L53). So I don't need to have all these information like `formatted` etc etc.

All I need to test is that the API of the `LoggerInterface` class is called correctly.