### PR TITLE
Make CURL util final and internal

### DIFF
--- a/src/Monolog/Handler/Curl/Util.php
+++ b/src/Monolog/Handler/Curl/Util.php
@@ -11,7 +11,12 @@
 
 namespace Monolog\Handler\Curl;
 
-class Util
+/**
+ * This class is marked as internal and it is not under the BC promise of the package.
+ *
+ * @internal
+ */
+final class Util
 {
     private static $retriableErrorCodes = [
         CURLE_COULDNT_RESOLVE_HOST,

--- a/src/Monolog/Utils.php
+++ b/src/Monolog/Utils.php
@@ -11,7 +11,7 @@
 
 namespace Monolog;
 
-class Utils
+final class Utils
 {
     /**
      * @internal


### PR DESCRIPTION
Hello,

Should these be final and internal to avoid BC changes in the future.

I am not sure if you would be willing to accept a change like this... 

Also I have one more suggestion to make.. how would you feel about removing the Curl Util and moving to a solution like HTTPlug now that PSR-18 is accepted?