### PR TITLE
Suggest JSON extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
         "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
         "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+        "ext-json": "Allow encoding messages to a JSON format.",
         "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
         "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
         "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",


### PR DESCRIPTION
I believe that this extension should be in the required ones...  🤔 

Although as a counter argument someone might say that he wants to use Monolog without using Handlers/Formatters that JSON encode messages that's why I added it at `suggest` for now.. 

Let me know where do you believe it belongs...