### PR TITLE
Error handler strict comparison fix

### DIFF
--- a/src/Monolog/ErrorHandler.php
+++ b/src/Monolog/ErrorHandler.php
@@ -58,9 +58,6 @@ class ErrorHandler
      */
     public static function register(LoggerInterface $logger, $errorLevelMap = [], $exceptionLevelMap = [], $fatalLevel = null): self
     {
-        //Forces the autoloader to run for LogLevel. Fixes an autoload issue at compile-time on PHP5.3. See https://github.com/Seldaek/monolog/pull/929
-        class_exists('\\Psr\\Log\\LogLevel', true);
-
         $handler = new static($logger);
         if ($errorLevelMap !== false) {
             $handler->registerErrorHandler($errorLevelMap);
@@ -150,6 +147,7 @@ class ErrorHandler
 
     /**
      * @private
+     * @param \Exception $e
      */
     public function handleException($e)
     {
@@ -171,7 +169,7 @@ class ErrorHandler
             call_user_func($this->previousExceptionHandler, $e);
         }
 
-        if (!headers_sent() && ini_get('display_errors') === 0) {
+        if (!headers_sent() && !ini_get('display_errors')) {
             http_response_code(500);
         }
 


### PR DESCRIPTION
According to official PHP documentation 

> Returns the value of the configuration option as a string on success, or an empty string for null values. Returns FALSE if the configuration option doesn't exist. 

This change seems kinda big... and I don't know how to test it