### PR TITLE
Parameter formatter was never set.. would cause fatal

### DIFF
--- a/src/Monolog/Handler/HandlerWrapper.php
+++ b/src/Monolog/Handler/HandlerWrapper.php
@@ -119,7 +119,7 @@ class HandlerWrapper implements HandlerInterface, ProcessableHandlerInterface, F
     public function getFormatter(): FormatterInterface
     {
         if ($this->handler instanceof FormattableHandlerInterface) {
-            return $this->handler->getFormatter($formatter);
+            return $this->handler->getFormatter();
         }
 
         throw new \LogicException('The wrapped handler does not implement ' . FormattableHandlerInterface::class);


### PR DESCRIPTION
The parameter `$formatter` was never set and most probably it would have caused a fatal error.