### PR TITLE
Update README link of Python Logbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,5 +98,5 @@ Monolog is licensed under the MIT License - see the `LICENSE` file for details
 
 ### Acknowledgements
 
-This library is heavily inspired by Python's [Logbook](http://packages.python.org/Logbook/)
+This library is heavily inspired by Python's [Logbook](https://logbook.readthedocs.io/en/stable/)
 library, although most concepts have been adjusted to fit to the PHP world.


### PR DESCRIPTION
The old URL is no longer in use, serving "Logbook's documentation is maintained elsewhere." and a redirect.

Convieniently also converts the URL to HTTPS.