### PR TITLE
Use object as message on docblock for PSR functions

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -458,9 +458,9 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * This method allows for compatibility with common interfaces.
      *
-     * @param mixed  $level   The log level
-     * @param string $message The log message
-     * @param array  $context The log context
+     * @param mixed         $level   The log level
+     * @param string|object $message The log message
+     * @param array         $context The log context
      */
     public function log($level, $message, array $context = [])
     {
@@ -474,8 +474,8 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * This method allows for compatibility with common interfaces.
      *
-     * @param string $message The log message
-     * @param array  $context The log context
+     * @param string|object $message The log message
+     * @param array         $context The log context
      */
     public function debug($message, array $context = [])
     {
@@ -487,8 +487,8 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * This method allows for compatibility with common interfaces.
      *
-     * @param string $message The log message
-     * @param array  $context The log context
+     * @param string|object $message The log message
+     * @param array         $context The log context
      */
     public function info($message, array $context = [])
     {
@@ -500,8 +500,8 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * This method allows for compatibility with common interfaces.
      *
-     * @param string $message The log message
-     * @param array  $context The log context
+     * @param string|object $message The log message
+     * @param array         $context The log context
      */
     public function notice($message, array $context = [])
     {
@@ -513,8 +513,8 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * This method allows for compatibility with common interfaces.
      *
-     * @param string $message The log message
-     * @param array  $context The log context
+     * @param string|object $message The log message
+     * @param array         $context The log context
      */
     public function warning($message, array $context = [])
     {
@@ -526,8 +526,8 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * This method allows for compatibility with common interfaces.
      *
-     * @param string $message The log message
-     * @param array  $context The log context
+     * @param string|object $message The log message
+     * @param array         $context The log context
      */
     public function error($message, array $context = [])
     {
@@ -539,8 +539,8 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * This method allows for compatibility with common interfaces.
      *
-     * @param string $message The log message
-     * @param array  $context The log context
+     * @param string|object $message The log message
+     * @param array         $context The log context
      */
     public function critical($message, array $context = [])
     {
@@ -552,8 +552,8 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * This method allows for compatibility with common interfaces.
      *
-     * @param string $message The log message
-     * @param array  $context The log context
+     * @param string|object $message The log message
+     * @param array         $context The log context
      */
     public function alert($message, array $context = [])
     {
@@ -565,8 +565,8 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * This method allows for compatibility with common interfaces.
      *
-     * @param string $message The log message
-     * @param array  $context The log context
+     * @param string|object $message The log message
+     * @param array         $context The log context
      */
     public function emergency($message, array $context = [])
     {


### PR DESCRIPTION
Driven by this: https://github.com/Seldaek/monolog/pull/1260

I looked at the PSR-3 to see if custom levels are allowed.. and yes they are... but on the next lines I saw this:

> Every method accepts a string as the message, or an object with a __toString() method. Implementors MAY have special handling for the passed objects. If that is not the case, implementors MUST cast it to a string

An alternative could be to get rid of the docblocks on these methods and depend on the docblocks of PSR.