### PR TITLE
Support indexed context arrays

### DIFF
--- a/src/Monolog/Formatter/LineFormatter.php
+++ b/src/Monolog/Formatter/LineFormatter.php
@@ -29,6 +29,7 @@ class LineFormatter extends NormalizerFormatter
     protected $allowInlineLineBreaks;
     protected $ignoreEmptyContextAndExtra;
     protected $includeStacktraces;
+    protected $isAssoc;
 
     /**
      * @param string|null $format                     The format of the message
@@ -62,6 +63,11 @@ class LineFormatter extends NormalizerFormatter
         $this->ignoreEmptyContextAndExtra = $ignore;
     }
 
+    public function isAssoc(array $record)
+    {
+        $this->isAssoc = count(array_filter(array_keys($record), 'is_string')) > 0;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -78,10 +84,12 @@ class LineFormatter extends NormalizerFormatter
             }
         }
 
-        foreach ($vars['context'] as $var => $val) {
-            if (false !== strpos($output, '%context.'.$var.'%')) {
-                $output = str_replace('%context.'.$var.'%', $this->stringify($val), $output);
-                unset($vars['context'][$var]);
+        if ($this->isAssoc) {
+            foreach ($vars['context'] as $var => $val) {
+                if (false !== strpos($output, '%context.'.$var.'%')) {
+                    $output = str_replace('%context.'.$var.'%', $this->stringify($val), $output);
+                    unset($vars['context'][$var]);
+                }
             }
         }
 


### PR DESCRIPTION
To provide some context, I am trying to create a means of passing a method's classname into my logs as I find it quite handy. My aim was to make this as visually clean as I could in my code, so I don't want to use `sprintf()` or any other means of formatting the message. To start, here's what im passing as my log arguments:

`$this->logger->info("Hey there! I'm just testing!", [__CLASS__]);`

To those unfamiliar, `__CLASS__` is a magic constant that returns the classname, including the namespace.

By default, Monolog will stringify the `context` array. This produces a log record which looks like this:
_(note: i've custom formatted the log message so that the context appears before the message)_

`[2019-01-02 02:06:12] INFO: [["LFLAPI\\Services\\Ecom\\SomeService"]] Hey there! I'm just testing!`

I don't like how this appears in my logs, so I opted to make use of the `pushHandler()` to pull out just the first element, which is the string by itself.

```php
$logger->pushProcessor(function ($record) {
    $record['context'] = $record['context'][0];
    return $record;
});
```

This produces the log results im after:

`[2019-01-02 02:09:02] INFO: [LFLAPI\Services\Ecom\SomeService] Hey there! I'm just testing!`

But it also triggers a warning:

`PHP Warning:  Invalid argument supplied for foreach() in /var/www/api/vendor/monolog/monolog/src/Monolog/Formatter/LineFormatter.php on line 81`

If I've analyzed this correctly, it occurs because Monolog expects an associative array, whereas I am passing an indexed array. I would like to propose including support for indexed arrays by including a function that can determine if an array is indexed, or associative:

```php
protected $isAssoc;

public function isAssoc(array $record)
{
    $this->isAssoc = count(array_filter(array_keys($record), 'is_string')) > 0;
}

if ($this->isAssoc) {
    foreach ($vars['context'] as $var => $val) {
        if (false !== strpos($output, '%context.'.$var.'%')) {
            $output = str_replace('%context.'.$var.'%', $this->stringify($val), $output);
            unset($vars['context'][$var]);
        }
    }
}
```

I feel this adds value to Monolog by allowing for more customization, and ultimately, cleaner user-code. Here's a quick side-by-side comparison of what I was aiming to avoid:

```php
$this->logger->info("Hey there! I'm just testing!", [__CLASS__]);
$this->logger->info(sprintf("[%s] Hey there! I'm just testing!", __CLASS__));

$this->logger->info("Hey there! I'm just testing!", [$var]);
$this->logger->info(sprintf("[%s] Hey there! I'm just testing!", $var));
```