### PR TITLE
Fix create duplicate records in *GroupHandler 1.x

### DIFF
--- a/src/Monolog/Handler/GroupHandler.php
+++ b/src/Monolog/Handler/GroupHandler.php
@@ -80,8 +80,9 @@ class GroupHandler extends AbstractHandler
             $processed = array();
             foreach ($records as $record) {
                 foreach ($this->processors as $processor) {
-                    $processed[] = call_user_func($processor, $record);
+                    $record = call_user_func($processor, $record);
                 }
+                $processed[] = $record;
             }
             $records = $processed;
         }

--- a/src/Monolog/Handler/WhatFailureGroupHandler.php
+++ b/src/Monolog/Handler/WhatFailureGroupHandler.php
@@ -52,8 +52,9 @@ class WhatFailureGroupHandler extends GroupHandler
             $processed = array();
             foreach ($records as $record) {
                 foreach ($this->processors as $processor) {
-                    $processed[] = call_user_func($processor, $record);
+                    $record = call_user_func($processor, $record);
                 }
+                $processed[] = $record;
             }
             $records = $processed;
         }

--- a/tests/Monolog/Handler/GroupHandlerTest.php
+++ b/tests/Monolog/Handler/GroupHandlerTest.php
@@ -99,6 +99,11 @@ class GroupHandlerTest extends TestCase
 
             return $record;
         });
+        $handler->pushProcessor(function ($record) {
+            $record['extra']['foo2'] = true;
+
+            return $record;
+        });
         $handler->handleBatch(array($this->getRecord(Logger::DEBUG), $this->getRecord(Logger::INFO)));
         foreach ($testHandlers as $test) {
             $this->assertTrue($test->hasDebugRecords());
@@ -107,6 +112,8 @@ class GroupHandlerTest extends TestCase
             $records = $test->getRecords();
             $this->assertTrue($records[0]['extra']['foo']);
             $this->assertTrue($records[1]['extra']['foo']);
+            $this->assertTrue($records[0]['extra']['foo2']);
+            $this->assertTrue($records[1]['extra']['foo2']);
         }
     }
 }

--- a/tests/Monolog/Handler/WhatFailureGroupHandlerTest.php
+++ b/tests/Monolog/Handler/WhatFailureGroupHandlerTest.php
@@ -99,6 +99,11 @@ class WhatFailureGroupHandlerTest extends TestCase
 
             return $record;
         });
+        $handler->pushProcessor(function ($record) {
+            $record['extra']['foo2'] = true;
+
+            return $record;
+        });
         $handler->handleBatch(array($this->getRecord(Logger::DEBUG), $this->getRecord(Logger::INFO)));
         foreach ($testHandlers as $test) {
             $this->assertTrue($test->hasDebugRecords());
@@ -107,6 +112,8 @@ class WhatFailureGroupHandlerTest extends TestCase
             $records = $test->getRecords();
             $this->assertTrue($records[0]['extra']['foo']);
             $this->assertTrue($records[1]['extra']['foo']);
+            $this->assertTrue($records[0]['extra']['foo2']);
+            $this->assertTrue($records[1]['extra']['foo2']);
         }
     }
 


### PR DESCRIPTION
Fix create duplicate records in *GroupHandler when there is more than one Processor.