### PR TITLE
optimize MemoryUsage processors

### DIFF
--- a/src/Monolog/Processor/MemoryPeakUsageProcessor.php
+++ b/src/Monolog/Processor/MemoryPeakUsageProcessor.php
@@ -21,10 +21,13 @@ class MemoryPeakUsageProcessor extends MemoryProcessor
 {
     public function __invoke(array $record): array
     {
-        $bytes = memory_get_peak_usage($this->realUsage);
-        $formatted = $this->formatBytes($bytes);
+        $usage = memory_get_peak_usage($this->realUsage);
 
-        $record['extra']['memory_peak_usage'] = $formatted;
+        if ($this->useFormatting) {
+            $usage = $this->formatBytes($usage);
+        }
+
+        $record['extra']['memory_peak_usage'] = $usage;
 
         return $record;
     }

--- a/src/Monolog/Processor/MemoryUsageProcessor.php
+++ b/src/Monolog/Processor/MemoryUsageProcessor.php
@@ -21,10 +21,13 @@ class MemoryUsageProcessor extends MemoryProcessor
 {
     public function __invoke(array $record): array
     {
-        $bytes = memory_get_usage($this->realUsage);
-        $formatted = $this->formatBytes($bytes);
+        $usage = memory_get_usage($this->realUsage);
 
-        $record['extra']['memory_usage'] = $formatted;
+        if ($this->useFormatting) {
+            $usage = $this->formatBytes($usage);
+        }
+
+        $record['extra']['memory_usage'] = $usage;
 
         return $record;
     }


### PR DESCRIPTION
Determining accurate memory usage should be an optimized process, not introducing any extra overhead. This pull request uses just a single variable and avoids a function call, if it's not needed.

1. Combine `$bytes` and `$formatted` into single `$usage` variable.
2. Check to see if formatting is needed before calling `formatBytes()`.

