### PR TITLE
Replace logrotate link with alternative page

### DIFF
--- a/doc/02-handlers-formatters-processors.md
+++ b/doc/02-handlers-formatters-processors.md
@@ -18,7 +18,7 @@
 - [_StreamHandler_](../src/Monolog/Handler/StreamHandler.php): Logs records into any PHP stream, use this for log files.
 - [_RotatingFileHandler_](../src/Monolog/Handler/RotatingFileHandler.php): Logs records to a file and creates one logfile per day.
   It will also delete files older than `$maxFiles`. You should use
-  [logrotate](http://linuxcommand.org/man_pages/logrotate8.html) for high profile
+  [logrotate](https://linux.die.net/man/8/logrotate) for high profile
   setups though, this is just meant as a quick and dirty solution.
 - [_SyslogHandler_](../src/Monolog/Handler/SyslogHandler.php): Logs records to the syslog.
 - [_ErrorLogHandler_](../src/Monolog/Handler/ErrorLogHandler.php): Logs records to PHP's


### PR DESCRIPTION
The current link no longer exists so this is the most extensive and popular page for the logrotate command.