### PR TITLE
Check and reject duplicate handlers in the logger.

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -174,7 +174,8 @@ class Logger implements LoggerInterface, ResettableInterface
      */
     public function pushHandler(HandlerInterface $handler): self
     {
-        array_unshift($this->handlers, $handler);
+        if (! in_array($handler, $this->handlers))
+            array_unshift($this->handlers, $handler);
 
         return $this;
     }


### PR DESCRIPTION
Stop the duplication of log entries in the same log.

Tested:  Locally for a couple of weeks.  

See Issue [#1293](https://github.com/Seldaek/monolog/issues/1293)