### PR TITLE
support two digit years

### DIFF
--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -81,7 +81,7 @@ class RotatingFileHandler extends StreamHandler
 
     public function setFilenameFormat(string $filenameFormat, string $dateFormat): self
     {
-        if (!preg_match('{^Y(([/_.-]?m)([/_.-]?d)?)?$}', $dateFormat)) {
+        if (!preg_match('{^[Yy](([/_.-]?m)([/_.-]?d)?)?$}', $dateFormat)) {
             throw new InvalidArgumentException(
                 'Invalid date format - format must be one of '.
                 'RotatingFileHandler::FILE_PER_DAY ("Y-m-d"), RotatingFileHandler::FILE_PER_MONTH ("Y-m") '.


### PR DESCRIPTION
With this change you can use two digit years, i.e. $fileHandler->setFilenameFormat('{date}_{filename}', 'y-m-d'); for 19-03-21