### PR TITLE
Enable adding/removing options to json_encode()

### DIFF
--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -375,4 +375,14 @@ class NormalizerFormatter implements FormatterInterface
 
         return $date->format($this->dateFormat);
     }
+    
+    protected function addJsonEncodeOption($option)
+    {
+        $this->jsonEncodeOptions |= $option;
+    }
+    
+    protected function removeJsonEncodeOption($option)
+    {
+        $this->jsonEncodeOptions ^= $option;
+    }
 }


### PR DESCRIPTION
Sometimes you want to add some options. In my case I wanted to encode the data using JSON_FORCE_OBJECT, but there was no way to do it