### PR TITLE
Check for JsonSerializable in normalizeException

### DIFF
--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -182,6 +182,10 @@ class NormalizerFormatter implements FormatterInterface
      */
     protected function normalizeException(Throwable $e, int $depth = 0)
     {
+        if ($e instanceof \JsonSerializable) {
+            return (array) $e->jsonSerialize();
+        }
+
         $data = [
             'class' => Utils::getClass($e),
             'message' => $e->getMessage(),


### PR DESCRIPTION
I needed this change because I have exceptions that I want to handle how they get json serialized.