### PR TITLE
Dont use more than 2000 chars for slack attachments field

### DIFF
--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -223,7 +223,7 @@ class SlackRecord
     private function generateAttachmentField(string $title, $value): array
     {
         $value = is_array($value)
-            ? sprintf('```%s```', $this->stringify($value))
+            ? sprintf('```%s```', substr($this->stringify($value), 0, 1990))
             : $value;
 
         return array(


### PR DESCRIPTION
See docs here: https://api.slack.com/docs/interactive-message-field-guide

Slack will automatically limit this for us, but it will remove the last 3 back ticks so long messages is not properly formatted. 