### PR TITLE
For when the date changes during a long process.

### DIFF
--- a/src/Monolog/Handler/StreamHandler.php
+++ b/src/Monolog/Handler/StreamHandler.php
@@ -65,6 +65,7 @@ class StreamHandler extends AbstractProcessingHandler
             fclose($this->stream);
         }
         $this->stream = null;
+        $this->dirCreated = null;
     }
 
     /**


### PR DESCRIPTION
Laravel uses an instance of Handler in one process.

When using "RotatingFileHandler", if the date changes in one process, the error "Could not be opened: failed to open stream: No such file or directory in" is occured.

The date is checked with the "write" function of "RotatingFileHandler". If the date has changed, closing the file. However, "$dirCreated" of "StreamHandler" remains True. Therefore, a new directory can not be created and an error occurs.

Fixed "$dirCreated" to its initial value when closing a file.