### PR TITLE
fix ProcessorInterface

### DIFF
--- a/src/Monolog/Processor/ProcessorInterface.php
+++ b/src/Monolog/Processor/ProcessorInterface.php
@@ -19,7 +19,7 @@ namespace Monolog\Processor;
 interface ProcessorInterface
 {
     /**
-     * @return array The processed records
+     * @return array The processed record
      */
-    public function __invoke(array $records);
+    public function __invoke(array $record);
 }


### PR DESCRIPTION
Every single processor that implements `ProcessorInterface` has only single record as argument. This is true even when I test the code in my project.

Having the ProcessorInterface argument for multiple records is seriously confusing and untrue.