### PR TITLE
Added ElasticsearchLogstashHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.25.0 (xxxx-xx-xx)
+
+  * Added ElasticsearchLogstashHandler
+
 ### 1.24.0 (2018-11-05)
 
   * BC Notice: If you are extending any of the Monolog's Formatters' `normalize` method, make sure you add the new `$depth = 0` argument to your function signature to avoid strict PHP warnings.

--- a/src/Monolog/Formatter/ElasticsearchLogstashHandler.php
+++ b/src/Monolog/Formatter/ElasticsearchLogstashHandler.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace AppBundle\Monitoring\Monolog\Handler;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\LogstashFormatter;
+use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Logger;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Push logs directly to Elasticsearch and format them according to Logstash specification
+ *
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class ElasticsearchLogstashHandler extends AbstractProcessingHandler
+{
+    private $endpoint;
+    private $index;
+    private $client;
+    private $responses;
+
+    public function __construct($endpoint = 'http://elasticsearch:9200', $index = 'monolog', HttpClientInterface $client = null, $level = Logger::DEBUG, $bubble = true)
+    {
+        if (!class_exists(HttpClientInterface::class)) {
+            throw new \LogicException(sprintf('%s handler needs symfony/http-client, please run `composer require symfony/http-client`.', __CLASS__));
+        }
+
+        parent::__construct($level, $bubble);
+        $this->endpoint = $endpoint;
+        $this->index = $index;
+        $this->client = $client ?: HttpClient::create();
+        $this->responses = new \SplObjectStorage();
+    }
+
+    protected function write(array $record)
+    {
+        $this->sendToElasticsearch(array($record));
+    }
+
+    protected function getDefaultFormatter()
+    {
+        return new LogstashFormatter('application', null, null, 'ctxt_', LogstashFormatter::V1);
+    }
+
+    private function sendToElasticsearch(array $documents)
+    {
+        $body = '';
+        foreach ($documents as $document) {
+            $body .= json_encode([
+                'index' => [
+                    '_index' => $this->index,
+                    '_type' => '_doc',
+                ],
+            ]);
+            $body .= "\n";
+            $body .= $document['formatted'];
+            $body .= "\n";
+        }
+
+        $response = $this->client->request('POST', $this->endpoint.'/_bulk', [
+            'body' => $body,
+            'headers' => [
+                'Content-Type' => 'application/json',
+            ],
+        ]);
+
+        $this->responses->attach($response);
+
+        foreach ($this->client->stream($this->responses, 0) as $response => $chunk) {
+            if (!$chunk->isTimeout() && $chunk->isFirst()) {
+                $this->responses->detach($response);
+            }
+        }
+    }
+}


### PR DESCRIPTION
ATM, there are few options to push log to Elastic Stack in order to play with them:

* install logstash and use a Gelf handler. It works but you have to install logstash and configure it. Not an easy task. More over, it need an extra PHP package
* use the ES handler: It does not play well with context and extra: Kibana is not able to filter on nested object. And this handler is tightly coupled to the ElasticaFormatter formater. More over, it need an extra PHP package
* use something to parse file logs. This is really a bad idea since it involves a parsing... More over a daemon is needed to do that (file beat / logstash / you name it)

This is why I'm introducing a new Handler.

* There is not need to install anything (expect ES, of course)
* It play very well with Kibana, as it uses the Logstash format
* It requires symfony/http-client, but in a modern PHP application (SF 4.3) this dependency is already present 
* It slow down a bit the application since it trigger an HTTP request for each logs. But symfony/http-client is non-blocking. If you want to use it in production, I recommend to wrap this handler in a buffer handler or a cross-finger handle to have only one HTTP call.

**Note: This handler is not aimed to be used in production**

---

This is what you can expect **out of the box**
![image](https://user-images.githubusercontent.com/408368/59916122-9b7b7580-941e-11e9-9a22-f56bc1d1a288.png)
