### PR TITLE
Change Curl\Util for return response from cURL request.

### DIFF
--- a/src/Monolog/Handler/Curl/Util.php
+++ b/src/Monolog/Handler/Curl/Util.php
@@ -31,13 +31,16 @@ final class Util
     /**
      * Executes a CURL request with optional retries and exception on failure
      *
-     * @param  resource          $ch curl handler
-     * @throws \RuntimeException
+     * @param resource $ch curl handler
+     * @param int $retries
+     * @param bool $closeAfterDone
+     * @return bool|string @see curl_exec
      */
-    public static function execute($ch, int $retries = 5, bool $closeAfterDone = true): void
+    public static function execute($ch, int $retries = 5, bool $closeAfterDone = true)
     {
         while ($retries--) {
-            if (curl_exec($ch) === false) {
+            $curlResponse = curl_exec($ch);
+            if ($curlResponse === false) {
                 $curlErrno = curl_errno($ch);
 
                 if (false === in_array($curlErrno, self::$retriableErrorCodes, true) || !$retries) {
@@ -56,7 +59,10 @@ final class Util
             if ($closeAfterDone) {
                 curl_close($ch);
             }
-            break;
+
+            return $curlResponse;
         }
+
+        return false;
     }
 }


### PR DESCRIPTION
Simply rework `Curl\Util::execute()` method. So now this method returns HTTP response from the request.

Moreover, because this method returns nothing - these changes do not break anything.