### PR TITLE
Fix for SyslogUdpHandler timezone issue

### DIFF
--- a/src/Monolog/Handler/SyslogUdpHandler.php
+++ b/src/Monolog/Handler/SyslogUdpHandler.php
@@ -11,6 +11,7 @@
 
 namespace Monolog\Handler;
 
+use Monolog\DateTimeImmutable;
 use Monolog\Logger;
 use Monolog\Handler\SyslogUdp\UdpSocket;
 
@@ -57,7 +58,7 @@ class SyslogUdpHandler extends AbstractSyslogHandler
     {
         $lines = $this->splitMessageIntoLines($record['formatted']);
 
-        $header = $this->makeCommonSyslogHeader($this->logLevels[$record['level']]);
+        $header = $this->makeCommonSyslogHeader($this->logLevels[$record['level']], $record['datetime']);
 
         foreach ($lines as $line) {
             $this->socket->write($line, $header);
@@ -81,7 +82,7 @@ class SyslogUdpHandler extends AbstractSyslogHandler
     /**
      * Make common syslog header (see rfc5424 or rfc3164)
      */
-    protected function makeCommonSyslogHeader(int $severity): string
+    protected function makeCommonSyslogHeader(int $severity, DateTimeImmutable $datetime): string
     {
         $priority = $severity + $this->facility;
 
@@ -93,10 +94,13 @@ class SyslogUdpHandler extends AbstractSyslogHandler
             $hostname = '-';
         }
 
-        $date = $this->getDateTime();
-
         if ($this->rfc === self::RFC3164) {
-            return "<$priority>" .
+	    	$datetime->setTimezone(new \DateTimeZone('UTC'));
+	    }
+		$date = $datetime->format($this->dateFormats[$this->rfc]);
+
+	    if ($this->rfc === self::RFC3164) {
+        	return "<$priority>" .
                 $date . " " .
                 $hostname . " " .
                 $this->ident . "[" . $pid . "]: ";

--- a/src/Monolog/Handler/SyslogUdpHandler.php
+++ b/src/Monolog/Handler/SyslogUdpHandler.php
@@ -11,7 +11,7 @@
 
 namespace Monolog\Handler;
 
-use Monolog\DateTimeImmutable;
+use DateTimeInterface;
 use Monolog\Logger;
 use Monolog\Handler\SyslogUdp\UdpSocket;
 
@@ -95,11 +95,11 @@ class SyslogUdpHandler extends AbstractSyslogHandler
         }
 
         if ($this->rfc === self::RFC3164) {
-	    $datetime->setTimezone(new \DateTimeZone('UTC'));
-	}
-	$date = $datetime->format($this->dateFormats[$this->rfc]);
+            $datetime->setTimezone(new \DateTimeZone('UTC'));
+        }
+        $date = $datetime->format($this->dateFormats[$this->rfc]);
 
-	if ($this->rfc === self::RFC3164) {
+        if ($this->rfc === self::RFC3164) {
             return "<$priority>" .
                 $date . " " .
                 $hostname . " " .

--- a/src/Monolog/Handler/SyslogUdpHandler.php
+++ b/src/Monolog/Handler/SyslogUdpHandler.php
@@ -82,7 +82,7 @@ class SyslogUdpHandler extends AbstractSyslogHandler
     /**
      * Make common syslog header (see rfc5424 or rfc3164)
      */
-    protected function makeCommonSyslogHeader(int $severity, DateTimeImmutable $datetime): string
+    protected function makeCommonSyslogHeader(int $severity, DateTimeInterface $datetime): string
     {
         $priority = $severity + $this->facility;
 
@@ -95,12 +95,12 @@ class SyslogUdpHandler extends AbstractSyslogHandler
         }
 
         if ($this->rfc === self::RFC3164) {
-	    	$datetime->setTimezone(new \DateTimeZone('UTC'));
-	    }
-		$date = $datetime->format($this->dateFormats[$this->rfc]);
+	    $datetime->setTimezone(new \DateTimeZone('UTC'));
+	}
+	$date = $datetime->format($this->dateFormats[$this->rfc]);
 
-	    if ($this->rfc === self::RFC3164) {
-        	return "<$priority>" .
+	if ($this->rfc === self::RFC3164) {
+            return "<$priority>" .
                 $date . " " .
                 $hostname . " " .
                 $this->ident . "[" . $pid . "]: ";
@@ -111,11 +111,6 @@ class SyslogUdpHandler extends AbstractSyslogHandler
                 $this->ident . " " .
                 $pid . " - - ";
         }
-    }
-
-    protected function getDateTime(): string
-    {
-        return date($this->dateFormats[$this->rfc]);
     }
 
     /**


### PR DESCRIPTION
Hello!
As described in [this issue](https://github.com/Seldaek/monolog/issues/1350), SyslogUdpHandler doesn't respect `Logger` timezone setting for IETF (RFC-5424) syslog format.
This PR is a fix for this issue.