### PR TITLE
Fix error_handler return type declaration

### DIFF
--- a/src/Monolog/ErrorHandler.php
+++ b/src/Monolog/ErrorHandler.php
@@ -200,6 +200,8 @@ class ErrorHandler
         } elseif ($this->previousErrorHandler) {
             return call_user_func($this->previousErrorHandler, $code, $message, $file, $line, $context);
         }
+
+        return true;
     }
 
     /**

--- a/src/Monolog/Handler/StreamHandler.php
+++ b/src/Monolog/Handler/StreamHandler.php
@@ -134,9 +134,11 @@ class StreamHandler extends AbstractProcessingHandler
         fwrite($stream, (string) $record['formatted']);
     }
 
-    private function customErrorHandler($code, $msg): void
+    private function customErrorHandler($code, $msg): bool
     {
         $this->errorMessage = preg_replace('{^(fopen|mkdir)\(.*?\): }', '', $msg);
+
+        return true;
     }
 
     private function getDirFromStream(string $stream): ?string

--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -182,6 +182,8 @@ class NormalizerFormatterTest extends \PHPUnit\Framework\TestCase
                 restore_error_handler();
                 $that->fail("$message should not be raised");
             }
+
+            return true;
         });
 
         $formatter = new NormalizerFormatter();
@@ -215,6 +217,8 @@ class NormalizerFormatterTest extends \PHPUnit\Framework\TestCase
                 restore_error_handler();
                 $that->fail("$message should not be raised");
             }
+
+            return true;
         });
 
         $formatter = new NormalizerFormatter();

--- a/tests/Monolog/Handler/RotatingFileHandlerTest.php
+++ b/tests/Monolog/Handler/RotatingFileHandlerTest.php
@@ -34,6 +34,8 @@ class RotatingFileHandlerTest extends TestCase
                 'code' => $code,
                 'message' => $message,
             ];
+
+            return true;
         });
     }
 


### PR DESCRIPTION
Hi,

Small patch to fix error handler function return type.
From php.net documentation, the error_handler should return a bool and not a void (https://www.php.net/manual/en/function.set-error-handler.php).