### PR TITLE
Support json scalar formatter

### DIFF
--- a/src/Monolog/Formatter/JsonScalarFormatter.php
+++ b/src/Monolog/Formatter/JsonScalarFormatter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Monolog\Formatter;
 

--- a/src/Monolog/Formatter/JsonScalarFormatter.php
+++ b/src/Monolog/Formatter/JsonScalarFormatter.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Monolog\Formatter;
+
+class JsonScalarFormatter
+{
+    /** @var ScalarFormatter */
+    private $scalarFormatter;
+
+    /**
+     * @param ScalarFormatter $scalarFormatter
+     */
+    public function __construct(ScalarFormatter $scalarFormatter)
+    {
+        $this->scalarFormatter = $scalarFormatter;
+    }
+
+    /**
+     * @param array $record
+     * @return string
+     */
+    public function format(array $record): string
+    {
+        $record = $this->scalarFormatter->format($record);
+
+        return json_encode($record);
+    }
+}

--- a/tests/Monolog/Formatter/JsonScalarFormatterTest.php
+++ b/tests/Monolog/Formatter/JsonScalarFormatterTest.php
@@ -1,8 +1,8 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Monolog\Formatter;
 
-class JsonScalarFormatterTest extends \PHPUnit_Framework_TestCase
+class JsonScalarFormatterTest extends \PHPUnit\Framework\TestCase
 {
     private $formatter;
 

--- a/tests/Monolog/Formatter/JsonScalarFormatterTest.php
+++ b/tests/Monolog/Formatter/JsonScalarFormatterTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Monolog\Formatter;
+
+class JsonScalarFormatterTest extends \PHPUnit_Framework_TestCase
+{
+    private $formatter;
+
+    public function setUp()
+    {
+        $this->formatter = new JsonScalarFormatter(new ScalarFormatter());
+    }
+
+    public function testFormat()
+    {
+        $input = [
+            'key' => 'value',
+            'array' => [
+                'array_key' => 'array_value',
+            ],
+        ];
+
+        $expectedOutput = '{"key":"value","array":"{\"array_key\":\"array_value\"}"}';
+
+        $this->assertSame($expectedOutput, $this->formatter->format($input));
+    }
+}


### PR DESCRIPTION
There are cases when logstash doesn't support non-scalar values and json format is necessary as well. This formatter solves this case, as it makes all arrays into scalar values, and encodes the whole record to json afterwards.
I guess this wouldn't be necessary if we could push multiple formatters (i.e. JsonFormatter&ScalarFormatter) to the logger, but that's not possible yet.