### PR TITLE
Backport Interface and Trait from master to 1.X

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -13,6 +13,12 @@ $finder = Symfony\CS\Finder::create()
     ->files()
     ->name('*.php')
     ->exclude('Fixtures')
+    // The next 4 files are here for forward compatibility, and are not used by
+    // Monolog itself
+    ->exclude(__DIR__.'src/Monolog/Handler/FormattableHandlerInterface.php')
+    ->exclude(__DIR__.'src/Monolog/Handler/FormattableHandlerTrait.php')
+    ->exclude(__DIR__.'src/Monolog/Handler/ProcessableHandlerInterface.php')
+    ->exclude(__DIR__.'src/Monolog/Handler/ProcessableHandlerTrait.php')
     ->in(__DIR__.'/src')
     ->in(__DIR__.'/tests')
 ;

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     },
     "scripts": {
         "test": [
-            "parallel-lint . --exclude vendor",
+            "parallel-lint . --exclude vendor --exclude src/Monolog/Handler/FormattableHandlerInterface.php  --exclude src/Monolog/Handler/FormattableHandlerTrait.php --exclude src/Monolog/Handler/ProcessableHandlerInterface.php --exclude src/Monolog/Handler/ProcessableHandlerTrait.php",
             "phpunit"
         ]
     }

--- a/src/Monolog/Handler/FormattableHandlerInterface.php
+++ b/src/Monolog/Handler/FormattableHandlerInterface.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Formatter\FormatterInterface;
+
+/**
+ * Interface to describe loggers that have a formatter
+ *
+ * @internal This interface is present in monolog 1.x to ease forward compatibility.
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+interface FormattableHandlerInterface
+{
+    /**
+     * Sets the formatter.
+     *
+     * @param  FormatterInterface $formatter
+     * @return HandlerInterface   self
+     */
+    public function setFormatter(FormatterInterface $formatter): HandlerInterface;
+
+    /**
+     * Gets the formatter.
+     *
+     * @return FormatterInterface
+     */
+    public function getFormatter(): FormatterInterface;
+}

--- a/src/Monolog/Handler/FormattableHandlerTrait.php
+++ b/src/Monolog/Handler/FormattableHandlerTrait.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\LineFormatter;
+
+/**
+ * Helper trait for implementing FormattableInterface
+ *
+ * @internal This interface is present in monolog 1.x to ease forward compatibility.
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+trait FormattableHandlerTrait
+{
+    /**
+     * @var FormatterInterface
+     */
+    protected $formatter;
+
+    /**
+     * {@inheritdoc}
+     * @suppress PhanTypeMismatchReturn
+     */
+    public function setFormatter(FormatterInterface $formatter): HandlerInterface
+    {
+        $this->formatter = $formatter;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFormatter(): FormatterInterface
+    {
+        if (!$this->formatter) {
+            $this->formatter = $this->getDefaultFormatter();
+        }
+
+        return $this->formatter;
+    }
+
+    /**
+     * Gets the default formatter.
+     *
+     * Overwrite this if the LineFormatter is not a good default for your handler.
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new LineFormatter();
+    }
+}

--- a/src/Monolog/Handler/ProcessableHandlerInterface.php
+++ b/src/Monolog/Handler/ProcessableHandlerInterface.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Processor\ProcessorInterface;
+
+/**
+ * Interface to describe loggers that have processors
+ *
+ * @internal This interface is present in monolog 1.x to ease forward compatibility.
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+interface ProcessableHandlerInterface
+{
+    /**
+     * Adds a processor in the stack.
+     *
+     * @param  ProcessorInterface|callable $callback
+     * @return HandlerInterface            self
+     */
+    public function pushProcessor(callable $callback): HandlerInterface;
+
+    /**
+     * Removes the processor on top of the stack and returns it.
+     *
+     * @throws \LogicException In case the processor stack is empty
+     * @return callable
+     */
+    public function popProcessor(): callable;
+}

--- a/src/Monolog/Handler/ProcessableHandlerTrait.php
+++ b/src/Monolog/Handler/ProcessableHandlerTrait.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\ResettableInterface;
+
+/**
+ * Helper trait for implementing ProcessableInterface
+ *
+ * @internal This interface is present in monolog 1.x to ease forward compatibility.
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+trait ProcessableHandlerTrait
+{
+    /**
+     * @var callable[]
+     */
+    protected $processors = [];
+
+    /**
+     * {@inheritdoc}
+     * @suppress PhanTypeMismatchReturn
+     */
+    public function pushProcessor(callable $callback): HandlerInterface
+    {
+        array_unshift($this->processors, $callback);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function popProcessor(): callable
+    {
+        if (!$this->processors) {
+            throw new \LogicException('You tried to pop from an empty processor stack.');
+        }
+
+        return array_shift($this->processors);
+    }
+
+    /**
+     * Processes a record.
+     */
+    protected function processRecord(array $record): array
+    {
+        foreach ($this->processors as $processor) {
+            $record = $processor($record);
+        }
+
+        return $record;
+    }
+
+    protected function resetProcessors(): void
+    {
+        foreach ($this->processors as $processor) {
+            if ($processor instanceof ResettableInterface) {
+                $processor->reset();
+            }
+        }
+    }
+}


### PR DESCRIPTION
New features should have been done on 1.X and 2.X should be for cleanup.
Now it's too late, but we can ease migrations by backporting some
code to 1.X.

This PR will help supporting monolog 1.X and 2.X at the same time.
See https://github.com/symfony/symfony/pull/33241