### PR TITLE
Remove versions from Laravel integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Bugs and feature request are tracked on [GitHub](https://github.com/Seldaek/mono
 - Frameworks and libraries using [PSR-3](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md)
   can be used very easily with Monolog since it implements the interface.
 - [Symfony](http://symfony.com) comes out of the box with Monolog.
-- [Laravel 4 & 5](http://laravel.com/) come out of the box with Monolog.
+- [Laravel](http://laravel.com/) comes out of the box with Monolog.
 - [Lumen](http://lumen.laravel.com/) comes out of the box with Monolog.
 - [PPI](https://github.com/ppi/framework) comes out of the box with Monolog.
 - [CakePHP](http://cakephp.org/) is usable with Monolog via the [cakephp-monolog](https://github.com/jadb/cakephp-monolog) plugin.


### PR DESCRIPTION
We recently released v6.0 so maybe we shouldn't mention the versions anymore. Monolog will probably always remain with the framework.

Thanks for all your work on Monolog and Composer @Seldaek!