### PR TITLE
Fixed forward compatibilty layer

### DIFF
--- a/src/Monolog/Handler/FormattableHandlerInterface.php
+++ b/src/Monolog/Handler/FormattableHandlerInterface.php
@@ -16,7 +16,8 @@ use Monolog\Formatter\FormatterInterface;
 /**
  * Interface to describe loggers that have a formatter
  *
- * @internal This interface is present in monolog 1.x to ease forward compatibility.
+ * This interface is present in monolog 1.x to ease forward compatibility.
+ *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
 interface FormattableHandlerInterface

--- a/src/Monolog/Handler/FormattableHandlerTrait.php
+++ b/src/Monolog/Handler/FormattableHandlerTrait.php
@@ -17,7 +17,8 @@ use Monolog\Formatter\LineFormatter;
 /**
  * Helper trait for implementing FormattableInterface
  *
- * @internal This interface is present in monolog 1.x to ease forward compatibility.
+ * This trait is present in monolog 1.x to ease forward compatibility.
+ *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
 trait FormattableHandlerTrait

--- a/src/Monolog/Handler/ProcessableHandlerInterface.php
+++ b/src/Monolog/Handler/ProcessableHandlerInterface.php
@@ -16,7 +16,8 @@ use Monolog\Processor\ProcessorInterface;
 /**
  * Interface to describe loggers that have processors
  *
- * @internal This interface is present in monolog 1.x to ease forward compatibility.
+ * This interface is present in monolog 1.x to ease forward compatibility.
+ *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
 interface ProcessableHandlerInterface
@@ -27,7 +28,7 @@ interface ProcessableHandlerInterface
      * @param  ProcessorInterface|callable $callback
      * @return HandlerInterface            self
      */
-    public function pushProcessor(callable $callback): HandlerInterface;
+    public function pushProcessor($callback): HandlerInterface;
 
     /**
      * Removes the processor on top of the stack and returns it.

--- a/src/Monolog/Handler/ProcessableHandlerTrait.php
+++ b/src/Monolog/Handler/ProcessableHandlerTrait.php
@@ -16,7 +16,8 @@ use Monolog\ResettableInterface;
 /**
  * Helper trait for implementing ProcessableInterface
  *
- * @internal This interface is present in monolog 1.x to ease forward compatibility.
+ * This trait is present in monolog 1.x to ease forward compatibility.
+ *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
 trait ProcessableHandlerTrait
@@ -30,7 +31,7 @@ trait ProcessableHandlerTrait
      * {@inheritdoc}
      * @suppress PhanTypeMismatchReturn
      */
-    public function pushProcessor(callable $callback): HandlerInterface
+    public function pushProcessor($callback): HandlerInterface
     {
         array_unshift($this->processors, $callback);
 


### PR DESCRIPTION
I'm sorry the extra work. But while working on https://github.com/symfony/symfony/pull/33492 I notice traits were not forward compatible.

So I:

* removed the `@internal ` flag, as the goal of theses traits is to be used.
* fixed the signature, to be compatible with the current signature of `Mono
log\Handler\AbstractHandler::pushProcessor($callback)`

The error was:

```
  1x: The "Monolog\Handler\ProcessableHandlerTrait" trait is considered internal This interface is present in monolog 1.x to ease forward compatibility. It may change wit
hout further notice. You should not use it from "Symfony\Bridge\Monolog\Handler\ElasticsearchLogstashHandler".                                                            
    1x in DeprecationErrorHandler::shutdown from Symfony\Bridge\PhpUnit                                                                                                   
                                                                                                                                                                          
  1x: The "Monolog\Handler\FormattableHandlerTrait" trait is considered internal This interface is present in monolog 1.x to ease forward compatibility. It may change wit
hout further notice. You should not use it from "Symfony\Bridge\Monolog\Handler\ElasticsearchLogstashHandler".                                                            
    1x in DeprecationErrorHandler::shutdown from Symfony\Bridge\PhpUnit                                                                                                   
```