### PR TITLE
JsonFormatter: Don't even try to attempt normalizing iterators or generators in context

### DIFF
--- a/src/Monolog/Formatter/JsonFormatter.php
+++ b/src/Monolog/Formatter/JsonFormatter.php
@@ -145,7 +145,7 @@ class JsonFormatter extends NormalizerFormatter
             return 'Over 9 levels deep, aborting normalization';
         }
 
-        if (is_array($data) || $data instanceof \Traversable) {
+        if (is_array($data)) {
             $normalized = array();
 
             $count = 1;


### PR DESCRIPTION
Iterators and Generators may not be rewindable, so foreach is not safe
to use on them.

Iterators and especially Generators may trigger irreversible actions on
calling next(), so iterating over all values can potentially cause harm,
e.g. imagine an iterator over a set of HTTP POST requests that are sent
when the next value is requested . The only sufficiently safe thing to
iterate and include here are primitive arrays.

similar fix is applied to `NormalizerFormatter`: https://github.com/Seldaek/monolog/pull/891/files

It throws `Exception : Cannot traverse an already closed generator vendor/monolog/monolog/src/Monolog/Formatter/JsonFormatter.php:152`:
```php
    public function getGenerator(): \Generator
    {
        yield 111;
        yield 222;
    }

    public function testNormalizeClosedGenerator()
    {
        $formatter = new JsonFormatter();

        $generator = $this->getGenerator();
        foreach ($generator as $i) {
            // Consume generator...
        }

        $res = $formatter->format(array(
            'level_name' => 'CRITICAL',
            'channel' => 'test',
            'message' => 'bar',
            'context' => array($generator),
            'datetime' => new \DateTime,
            'extra' => array(),
        ));
    }
```