### PR TITLE
Fix BrowserConsoleHandler formatting

### DIFF
--- a/src/Monolog/Handler/BrowserConsoleHandler.php
+++ b/src/Monolog/Handler/BrowserConsoleHandler.php
@@ -167,21 +167,22 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
 
     private static function handleStyles(string $formatted): array
     {
-        $args = [static::quote('font-weight: normal')];
+        $args = [];
         $format = '%c' . $formatted;
         preg_match_all('/\[\[(.*?)\]\]\{([^}]*)\}/s', $format, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
 
         foreach (array_reverse($matches) as $match) {
-            $args[] = static::quote(static::handleCustomStyles($match[2][0], $match[1][0]));
             $args[] = '"font-weight: normal"';
+            $args[] = static::quote(static::handleCustomStyles($match[2][0], $match[1][0]));
 
             $pos = $match[0][1];
             $format = Utils::substr($format, 0, $pos) . '%c' . $match[1][0] . '%c' . Utils::substr($format, $pos + strlen($match[0][0]));
         }
 
-        array_unshift($args, static::quote($format));
+        $args[] = static::quote('font-weight: normal');
+        $args[] = static::quote($format);
 
-        return $args;
+        return array_reverse($args);
     }
 
     private static function handleCustomStyles(string $style, string $string): string

--- a/tests/Monolog/Handler/BrowserConsoleHandlerTest.php
+++ b/tests/Monolog/Handler/BrowserConsoleHandlerTest.php
@@ -48,6 +48,22 @@ EOF;
         $this->assertEquals($expected, $this->generateScript());
     }
 
+    public function testStylingMultiple()
+    {
+        $handler = new BrowserConsoleHandler();
+        $handler->setFormatter($this->getIdentityFormatter());
+
+        $handler->handle($this->getRecord(Logger::DEBUG, 'foo[[bar]]{color: red}[[baz]]{color: blue}'));
+
+        $expected = <<<EOF
+(function (c) {if (c && c.groupCollapsed) {
+c.log("%cfoo%cbar%c%cbaz%c", "font-weight: normal", "color: red", "font-weight: normal", "color: blue", "font-weight: normal");
+}})(console);
+EOF;
+
+        $this->assertEquals($expected, $this->generateScript());
+    }
+
     public function testEscaping()
     {
         $handler = new BrowserConsoleHandler();


### PR DESCRIPTION
This resolves an issue whereby all styles would be applied in reverse order to the formatting markers.

### Reproduction code
```
$logger = new Logger('test');
$handler = new BrowserConsoleHandler();
$handler->setFormatter(new LineFormatter(
	'[[blue text]]{color: blue} or [[green background]]{background-color: green; color: white}'
));
$logger->setHandlers([$handler]);
$logger->info('woo');
```

### Before
![Selection_593](https://user-images.githubusercontent.com/367121/66646917-71dd9880-ec1f-11e9-9ad2-8332a1f320c6.png)
```
<script>(function (c) {if (c && c.groupCollapsed) {
c.log("%c%cblue text%c or %cgreen background%c", "font-weight: normal", "background-color: green; color: white", "font-weight: normal", "color: blue", "font-weight: normal");
}})(console);</script>
```

### After
![Selection_592](https://user-images.githubusercontent.com/367121/66646928-75711f80-ec1f-11e9-88b3-c1ffbe168022.png)
```
<script>(function (c) {if (c && c.groupCollapsed) {
c.log("%c%cblue text%c or %cgreen background%c", "font-weight: normal", "color: blue", "font-weight: normal", "background-color: green; color: white", "font-weight: normal");
}})(console);</script>
```