### PR TITLE
github: implement newer version of issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,0 @@
-I am using Monolog version 1|2
-
-... the problem/suggestion/question here ...

--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -1,0 +1,9 @@
+---
+name: Bug Report
+about: Create a bug report
+labels: Bug
+---
+
+Monolog version 1|2
+
+Write your bug report here.

--- a/.github/ISSUE_TEMPLATE/Feature.md
+++ b/.github/ISSUE_TEMPLATE/Feature.md
@@ -1,0 +1,7 @@
+---
+name: Feature
+about: Suggest a new feature or enhancement
+labels: Feature
+---
+
+Write your suggestion here.

--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -1,0 +1,9 @@
+---
+name: Question
+about: Ask a question regarding software usage
+labels: Support
+---
+
+Monolog version 1|2
+
+Write your question here.


### PR DESCRIPTION
Moves away from the older version of GitHub issue templates, includes
automatic labelling.

more reading:
https://help.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates

see it in action: https://github.com/Zarthus/monolog/issues