### PR TITLE
github: Add security header

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,7 @@
+# Reporting a vulnerability
+
+If you have found any issues that might have security implications,
+please send a report privately to the email associated with the author
+of this repository.
+
+Do not report security reports publicly.


### PR DESCRIPTION
Tying in with #1389, this will add a new section
to the 'create new issue' and also be visible in the
'security' tab on GitHub

It's been left intentionally generic.

examples: 
https://github.com/Zarthus/monolog/security/policy
https://github.com/Zarthus/monolog/issues/new/choose

in an established project: https://github.com/symfony/symfony/issues/new/choose