### PR TITLE
Format exception log for Elasticsearch

### DIFF
--- a/src/Monolog/Formatter/ElasticsearchFormatter.php
+++ b/src/Monolog/Formatter/ElasticsearchFormatter.php
@@ -50,6 +50,10 @@ class ElasticsearchFormatter extends NormalizerFormatter
     {
         $record = parent::format($record);
 
+        if ($this->recordHasContext($record) && $this->contextHasException($record['context'])) {
+            $record['context']['exception'] = $this->getContextException($record['context']['exception']);
+        }
+
         return $this->getDocument($record);
     }
 
@@ -85,5 +89,52 @@ class ElasticsearchFormatter extends NormalizerFormatter
         $record['_type'] = $this->type;
 
         return $record;
+    }
+
+    /**
+     * Returns the entire exception as Elasticsearch format
+     *
+     * @param  array $recordContext
+     *
+     * @return array
+     */
+    protected function getContextException(array $recordContext)
+    {
+        return [
+            'class'     => $recordContext['class'] ?? '',
+            'message'   => $recordContext['message'] ?? '',
+            'code'      => intval($recordContext['code']) ?? '',
+            'file'      => $recordContext['file'] ?? '',
+            'trace'     => $recordContext['trace'] ?? '',
+        ];
+    }
+
+    /**
+     * Identifies the content type of the given $record
+     *
+     * @param  array $record
+     *
+     * @return bool
+     */
+    protected function recordHasContext(array $record): bool
+    {
+        return (
+            array_key_exists('context', $record)
+        );
+    }
+
+    /**
+     * Identifies the content type of the given $context
+     *
+     * @param  mixed $context
+     *
+     * @return bool
+     */
+    protected function contextHasException($context): bool
+    {
+        return (
+            is_array($context)
+            && array_key_exists('exception', $context)
+        );
     }
 }

--- a/src/Monolog/Formatter/ElasticsearchFormatter.php
+++ b/src/Monolog/Formatter/ElasticsearchFormatter.php
@@ -130,7 +130,7 @@ class ElasticsearchFormatter extends NormalizerFormatter
      *
      * @return bool
      */
-    protected function contextHasException($context): bool
+    protected function contextHasException(array $context): bool
     {
         return (
             is_array($context)

--- a/tests/Monolog/Handler/ProcessHandlerTest.php
+++ b/tests/Monolog/Handler/ProcessHandlerTest.php
@@ -48,7 +48,7 @@ class ProcessHandlerTest extends TestCase
 
         $handler->expects($this->exactly(2))
             ->method('writeProcessInput')
-            ->withConsecutive($this->stringContains($fixtures[0]), $this->stringContains($fixtures[1]));
+            ->withConsecutive([$this->stringContains($fixtures[0])], [$this->stringContains($fixtures[1])]);
 
         /** @var ProcessHandler $handler */
         $handler->handle($this->getRecord(Logger::WARNING, $fixtures[0]));


### PR DESCRIPTION
For resolving the issues when working with Laravel

Class Error: `QueryException`

```php
        "status" => 400
        "error" => array:3 [
          "type" => "mapper_parsing_exception"
          "reason" => "failed to parse field [context.exception.code] of type [long] in document with id 'sPh3G24Bss4rAxTOzNRI'"
          "caused_by" => array:2 [
            "type" => "illegal_argument_exception"
            "reason" => "For input string: "42S22""
          ]
        ]
```

Or got the error the message log too long.