### PR TITLE
HtmlFormatter cast key to string in addRow

### DIFF
--- a/src/Monolog/Formatter/HtmlFormatter.php
+++ b/src/Monolog/Formatter/HtmlFormatter.php
@@ -92,7 +92,7 @@ class HtmlFormatter extends NormalizerFormatter
         if ($record['context']) {
             $embeddedTable = '<table cellspacing="1" width="100%">';
             foreach ($record['context'] as $key => $value) {
-                $embeddedTable .= $this->addRow($key, $this->convertToString($value));
+                $embeddedTable .= $this->addRow((string)$key, $this->convertToString($value));
             }
             $embeddedTable .= '</table>';
             $output .= $this->addRow('Context', $embeddedTable, false);
@@ -100,7 +100,7 @@ class HtmlFormatter extends NormalizerFormatter
         if ($record['extra']) {
             $embeddedTable = '<table cellspacing="1" width="100%">';
             foreach ($record['extra'] as $key => $value) {
-                $embeddedTable .= $this->addRow($key, $this->convertToString($value));
+                $embeddedTable .= $this->addRow((string)$key, $this->convertToString($value));
             }
             $embeddedTable .= '</table>';
             $output .= $this->addRow('Extra', $embeddedTable, false);


### PR DESCRIPTION
My case is if you log php trace into `context` it will throw an error
`Argument 1 passed to Monolog\\Formatter\\HtmlFormatter::addRow() must be of the type string, int given`.

The PR fixes the issue