### PR TITLE
Do not escape forwardslashes on slack

### DIFF
--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -212,13 +212,14 @@ class SlackRecord
     {
         $normalized = $this->normalizerFormatter->format($fields);
         $prettyPrintFlag = JSON_PRETTY_PRINT;
+        $commonFlags = JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES;
 
         $hasSecondDimension = count(array_filter($normalized, 'is_array'));
         $hasNonNumericKeys = !count(array_filter(array_keys($normalized), 'is_numeric'));
 
         return $hasSecondDimension || $hasNonNumericKeys
-            ? json_encode($normalized, $prettyPrintFlag|JSON_UNESCAPED_UNICODE)
-            : json_encode($normalized, JSON_UNESCAPED_UNICODE);
+            ? json_encode($normalized, $commonFlags|$prettyPrintFlag)
+            : json_encode($normalized, $commonFlags);
     }
 
     /**

--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -211,7 +211,7 @@ class SlackRecord
     public function stringify(array $fields): string
     {
         $normalized = $this->normalizerFormatter->format($fields);
-        $prettyPrintFlag = defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 128;
+        $prettyPrintFlag = JSON_PRETTY_PRINT;
 
         $hasSecondDimension = count(array_filter($normalized, 'is_array'));
         $hasNonNumericKeys = !count(array_filter(array_keys($normalized), 'is_numeric'));

--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -212,15 +212,13 @@ class SlackRecord
     public function stringify(array $fields): string
     {
         $normalized = $this->normalizerFormatter->format($fields);
-        $prettyPrintFlag = JSON_PRETTY_PRINT;
-        $commonFlags = JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES;
 
         $hasSecondDimension = count(array_filter($normalized, 'is_array'));
         $hasNonNumericKeys = !count(array_filter(array_keys($normalized), 'is_numeric'));
 
         return $hasSecondDimension || $hasNonNumericKeys
-            ? Utils::jsonEncode($normalized, $commonFlags|$prettyPrintFlag)
-            : Utils::jsonEncode($normalized, $commonFlags);
+            ? Utils::jsonEncode($normalized)
+            : Utils::jsonEncode($normalized, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES);
     }
 
     /**

--- a/tests/Monolog/Handler/Slack/SlackRecordTest.php
+++ b/tests/Monolog/Handler/Slack/SlackRecordTest.php
@@ -23,7 +23,7 @@ class SlackRecordTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->jsonPrettyPrintFlag = JSON_PRETTY_PRINT;
+        $this->jsonPrettyPrintFlag = JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES;
     }
 
     public function dataGetAttachmentColor()

--- a/tests/Monolog/Handler/Slack/SlackRecordTest.php
+++ b/tests/Monolog/Handler/Slack/SlackRecordTest.php
@@ -78,16 +78,14 @@ class SlackRecordTest extends TestCase
      */
     public function dataStringify()
     {
-        $jsonPrettyPrintFlag = JSON_PRETTY_PRINT;
-
         $multipleDimensions = array(array(1, 2));
         $numericKeys = array('library' => 'monolog');
         $singleDimension = array(1, 'Hello', 'Jordi');
 
         return array(
             array(array(), '[]'),
-            array($multipleDimensions, json_encode($multipleDimensions, $jsonPrettyPrintFlag)),
-            array($numericKeys, json_encode($numericKeys, $jsonPrettyPrintFlag)),
+            array($multipleDimensions, json_encode($multipleDimensions, $this->jsonPrettyPrintFlag)),
+            array($numericKeys, json_encode($numericKeys, $this->jsonPrettyPrintFlag)),
             array($singleDimension, json_encode($singleDimension)),
         );
     }

--- a/tests/Monolog/Handler/Slack/SlackRecordTest.php
+++ b/tests/Monolog/Handler/Slack/SlackRecordTest.php
@@ -23,7 +23,7 @@ class SlackRecordTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->jsonPrettyPrintFlag = defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 128;
+        $this->jsonPrettyPrintFlag = JSON_PRETTY_PRINT;
     }
 
     public function dataGetAttachmentColor()
@@ -78,7 +78,7 @@ class SlackRecordTest extends TestCase
      */
     public function dataStringify()
     {
-        $jsonPrettyPrintFlag = defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 128;
+        $jsonPrettyPrintFlag = JSON_PRETTY_PRINT;
 
         $multipleDimensions = array(array(1, 2));
         $numericKeys = array('library' => 'monolog');


### PR DESCRIPTION
closes #1396

Goals:
 - don't escape slashes in Slack messages to make them more readable (`\Monolog\Utils::jsonEncode` do it by default)

Side-effects:
 - cleanup: remove code to support old PHP versions
 - improve tests to reuse vars from setUp() method