### PR TITLE
Fix a bug when using string-based loglevels in the `tr_TR` locale

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -527,8 +527,13 @@ class Logger implements LoggerInterface, ResettableInterface
      */
     public static function toMonologLevel($level)
     {
-        if (is_string($level) && defined(__CLASS__.'::'.strtoupper($level))) {
-            return constant(__CLASS__.'::'.strtoupper($level));
+        if (is_string($level)) {
+            // Contains chars of all log levels and avoids using strtoupper() which may have
+            // strange results depending on locale (for example, "i" will become "İ")
+            $upper = strtr($level, 'abcdefgilmnortuwy', 'ABCDEFGILMNORTUWY');
+            if (defined(__CLASS__.'::'.$upper)) {
+                return constant(__CLASS__ . '::' . $upper);
+            }
         }
 
         return $level;


### PR DESCRIPTION
PHP's `strtoupper()` is locale-aware, and `strtoupper('i')` (= `strtoupper(chr(105))`) will not be `I`(= `chr(73)`) but `chr(221)`, the "latin capital letter i with dot above" İ character.
