### PR TITLE
More detailed ElasticsearchHandler exceptions

### DIFF
--- a/src/Monolog/Handler/ElasticsearchHandler.php
+++ b/src/Monolog/Handler/ElasticsearchHandler.php
@@ -11,14 +11,14 @@
 
 namespace Monolog\Handler;
 
-use Elasticsearch\Client;
-use Elasticsearch\Common\Exceptions\RuntimeException as ElasticsearchRuntimeException;
-use InvalidArgumentException;
-use Monolog\Formatter\ElasticsearchFormatter;
-use Monolog\Formatter\FormatterInterface;
-use Monolog\Logger;
-use RuntimeException;
 use Throwable;
+use RuntimeException;
+use Monolog\Logger;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\ElasticsearchFormatter;
+use InvalidArgumentException;
+use Elasticsearch\Common\Exceptions\RuntimeException as ElasticsearchRuntimeException;
+use Elasticsearch\Client;
 
 /**
  * Elasticsearch handler
@@ -148,12 +148,44 @@ class ElasticsearchHandler extends AbstractProcessingHandler
             $responses = $this->client->bulk($params);
 
             if ($responses['errors'] === true) {
-                throw new ElasticsearchRuntimeException('Elasticsearch returned error for one of the records');
+                throw $this->createExceptionFromResponses($responses);
             }
         } catch (Throwable $e) {
             if (! $this->options['ignore_error']) {
                 throw new RuntimeException('Error sending messages to Elasticsearch', 0, $e);
             }
         }
+	}
+	
+	/**
+	 * Creates elasticsearch exception from responses array
+	 * 
+	 * Only the first error is converted into an exception.
+	 * 
+	 * @param array $responses returned by $this->client->bulk()
+	 */
+    protected function createExceptionFromResponses(array $responses): ElasticsearchRuntimeException
+    {
+    	foreach ($responses['items'] ?? [] as $item) {
+    		if (isset($item['index']['error'])) {
+    			return $this->createExceptionFromError($item['index']['error']);
+    		}
+    	}
+
+    	return new ElasticsearchRuntimeException('Elasticsearch failed to index one or more records.');
     }
+
+	/**
+	 * Creates elasticsearch exception from error array
+	 *
+	 * @param array $error
+	 */
+    protected function createExceptionFromError(array $error): ElasticsearchRuntimeException
+    {
+    	$previous = isset($error['caused_by']) ? $this->createExceptionFromError($error['caused_by']) : null;
+
+    	return new ElasticsearchRuntimeException($error['type'] . ': ' . $error['reason'], 0, $previous);
+	}
+	
+	
 }

--- a/src/Monolog/Handler/ElasticsearchHandler.php
+++ b/src/Monolog/Handler/ElasticsearchHandler.php
@@ -164,28 +164,26 @@ class ElasticsearchHandler extends AbstractProcessingHandler
 	 * 
 	 * @param array $responses returned by $this->client->bulk()
 	 */
-    protected function createExceptionFromResponses(array $responses): ElasticsearchRuntimeException
-    {
-    	foreach ($responses['items'] ?? [] as $item) {
-    		if (isset($item['index']['error'])) {
-    			return $this->createExceptionFromError($item['index']['error']);
-    		}
-    	}
+	protected function createExceptionFromResponses(array $responses): ElasticsearchRuntimeException
+	{
+		foreach ($responses['items'] ?? [] as $item) {
+			if (isset($item['index']['error'])) {
+				return $this->createExceptionFromError($item['index']['error']);
+			}
+		}
 
-    	return new ElasticsearchRuntimeException('Elasticsearch failed to index one or more records.');
-    }
+		return new ElasticsearchRuntimeException('Elasticsearch failed to index one or more records.');
+	}
 
 	/**
 	 * Creates elasticsearch exception from error array
 	 *
 	 * @param array $error
 	 */
-    protected function createExceptionFromError(array $error): ElasticsearchRuntimeException
-    {
-    	$previous = isset($error['caused_by']) ? $this->createExceptionFromError($error['caused_by']) : null;
+	protected function createExceptionFromError(array $error): ElasticsearchRuntimeException
+	{
+		$previous = isset($error['caused_by']) ? $this->createExceptionFromError($error['caused_by']) : null;
 
-    	return new ElasticsearchRuntimeException($error['type'] . ': ' . $error['reason'], 0, $previous);
+		return new ElasticsearchRuntimeException($error['type'] . ': ' . $error['reason'], 0, $previous);
 	}
-	
-	
 }


### PR DESCRIPTION
#1405 

Previously exceptions were thrown like this:

	Error sending messages to Elasticsearch
		Elasticsearch returned error for one of the records

After this fix:

	Error sending messages to Elasticsearch	
		mapper_parsing_exception: failed to parse field [ip] of type [text] in document with id '5Fvd324BEf_D0jiFiYl-'` 
			illegal_state_exception: Can't get text on a START_OBJECT at 1:2616

If no useful info is found in the `responses` array, falls back to:

    'Elasticsearch failed to index one or more records.'

Didn't mean to reorder imports, IDE did it automatically.