### PR TITLE
Fix JSON formatting of resource type

### DIFF
--- a/src/Monolog/Formatter/JsonFormatter.php
+++ b/src/Monolog/Formatter/JsonFormatter.php
@@ -157,6 +157,10 @@ class JsonFormatter extends NormalizerFormatter
             return $this->normalizeException($data, $depth);
         }
 
+        if (is_resource($data)) {
+            return parent::normalize($data);
+        }
+
         return $data;
     }
 

--- a/tests/Monolog/Formatter/JsonFormatterTest.php
+++ b/tests/Monolog/Formatter/JsonFormatterTest.php
@@ -144,6 +144,14 @@ class JsonFormatterTest extends TestCase
         $this->assertContextContainsFormattedException($formattedThrowable, $message);
     }
 
+    public function testDefFormatWithResource()
+    {
+        $formatter = new JsonFormatter(JsonFormatter::BATCH_MODE_JSON, false);
+        $record = $this->getRecord();
+        $record['context'] = ['field_resource' => curl_init()];
+        $this->assertEquals('{"message":"test","context":{"field_resource":"[resource(curl)]"},"level":300,"level_name":"WARNING","channel":"test","datetime":"'.$record['datetime']->format('Y-m-d\TH:i:s.uP').'","extra":{}}', $formatter->format($record));
+    }
+
     public function testMaxNormalizeDepth()
     {
         $formatter = new JsonFormatter(JsonFormatter::BATCH_MODE_JSON, true);


### PR DESCRIPTION
I think it is well-known that `json_encode` does not handle variables of `resource` type properly. Easiest example is:

    php -r "var_dump(json_encode(['test' => curl_init()]));" 
    // returns bool(false)

JsonFormatter of Monolog is affected as well, so it returns empty line if there is a resource in "context".

This pull request leverages already existing code from `NormalizerFormatter` to convert resources to `sprintf('[resource(%s)]', get_resource_type($data))`.