### PR TITLE
Set phpredis multi() mode parameter

### DIFF
--- a/src/Monolog/Handler/RedisHandler.php
+++ b/src/Monolog/Handler/RedisHandler.php
@@ -73,7 +73,8 @@ class RedisHandler extends AbstractProcessingHandler
     protected function writeCapped(array $record)
     {
         if ($this->redisClient instanceof \Redis) {
-            $this->redisClient->multi()
+            $mode = defined('\Redis::MULTI') ? \Redis::MULTI : 1;
+            $this->redisClient->multi($mode)
                 ->rpush($this->redisKey, $record["formatted"])
                 ->ltrim($this->redisKey, -$this->capSize, -1)
                 ->exec();


### PR DESCRIPTION
Set the default function parameter to avoid potential issues when a Redis proxy is used instead of the internal class.

This issue has been discussed in https://github.com/phpredis/phpredis/issues/1476#issuecomment-445968070 and https://github.com/snc/SncRedisBundle/issues/442.

This may be Symfony specific, but I'd be happy to hear your thoughts on this issue.