### PR TITLE
Update html color

### DIFF
--- a/src/Monolog/Formatter/HtmlFormatter.php
+++ b/src/Monolog/Formatter/HtmlFormatter.php
@@ -27,13 +27,13 @@ class HtmlFormatter extends NormalizerFormatter
      * Translates Monolog log levels to html color priorities.
      */
     protected $logLevels = [
-        Logger::DEBUG     => '#cccccc',
-        Logger::INFO      => '#468847',
-        Logger::NOTICE    => '#3a87ad',
-        Logger::WARNING   => '#c09853',
-        Logger::ERROR     => '#f0ad4e',
-        Logger::CRITICAL  => '#FF7708',
-        Logger::ALERT     => '#C12A19',
+        Logger::DEBUG     => '#CCCCCC',
+        Logger::INFO      => '#28A745',
+        Logger::NOTICE    => '#17A2B8',
+        Logger::WARNING   => '#FFC107',
+        Logger::ERROR     => '#FD7E14',
+        Logger::CRITICAL  => '#DC3545',
+        Logger::ALERT     => '#821722',
         Logger::EMERGENCY => '#000000',
     ];
 


### PR DESCRIPTION
Hi,

Just a PR that remap new html colors on bootstrap ones, that IMO a lot of developers are visually used to :)
cf https://github.com/twbs/bootstrap/blob/master/site/data/colors.yml
(exepts for the `alert` where  i took the `critical` but darker)

before:
<img width="754" alt="before" src="https://user-images.githubusercontent.com/13205768/71901110-7e5e8800-315f-11ea-9f93-4e561fc092f0.png">

after:
<img width="759" alt="HtmlFormatter_ logLevels_color" src="https://user-images.githubusercontent.com/13205768/71900078-5837e880-315d-11ea-9a40-28a139964b72.png">
