### PR TITLE
Introduce Stackdriver formatter

### DIFF
--- a/src/Monolog/Formatter/StackdriverFormatter.php
+++ b/src/Monolog/Formatter/StackdriverFormatter.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+/**
+ * Encodes message into JSON in a format compatible with Stackdriver.
+ *
+ * @author Dmitry Tarasov <tarasovdyu@gmail.com>
+ */
+class StackdriverFormatter extends JsonFormatter
+{
+    /**
+     * Transforms log level information into Stackdriver 'severity' field.
+     *
+     * @see https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
+     * @see \Monolog\Formatter\JsonFormatter::format()
+     */
+    public function format(array $record): string
+    {
+        $record['severity'] = $record['level_name'];
+        unset($record['level'], $record['level_name']);
+
+        return parent::format($record);
+    }
+}

--- a/tests/Monolog/Formatter/StackdriverFormatterTest.php
+++ b/tests/Monolog/Formatter/StackdriverFormatterTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Monolog\Test\TestCase;
+
+class StackdriverFormatterTest extends TestCase
+{
+    /**
+     * @covers Monolog\Formatter\StackdriverFormatter::format
+     */
+    public function testFormat()
+    {
+        $formatter = new StackdriverFormatter();
+        $record = $this->getRecord();
+        $recordDecoded = json_decode($formatter->format($record), true);
+        $this->assertEquals($record['level_name'], $recordDecoded['severity']);
+        $this->assertArrayNotHasKey('level', $recordDecoded);
+        $this->assertArrayNotHasKey('level_name', $recordDecoded);
+    }
+}


### PR DESCRIPTION
We actively use such formatter in production for a long time, so I decided to propose making it available for the community.

The formatter is useful with the following setup:

- Application is containerized and orchestrated using Google Kubernetes Engine (GKE);
- Application writes logs to stderr/stdout;
- Log entries are collected from stdout/stderr by GKE, then [forwarded to Stackdriver](https://cloud.google.com/monitoring/kubernetes-engine/).

The problem:
Stackdriver uses JSON-structured logs, but does not understand "level" field, therefore it cannot understand the level of log entry. On the other hand, level names match Monolog level names, the difference is just a field name ("severity" instead of "level" or "level_name").

Other references:
People use similar approach for other technical stack as well, for example Python article: https://medium.com/retailmenot-engineering/formatting-python-logs-for-stackdriver-5a5ddd80761c

