### PR TITLE
Fix typehint for AbstractHandler level parameter

### DIFF
--- a/src/Monolog/Handler/AbstractHandler.php
+++ b/src/Monolog/Handler/AbstractHandler.php
@@ -33,8 +33,8 @@ abstract class AbstractHandler implements HandlerInterface, ResettableInterface
     protected $processors = array();
 
     /**
-     * @param int  $level  The minimum logging level at which this handler will be triggered
-     * @param bool $bubble Whether the messages that are handled can bubble up the stack or not
+     * @param int|string $level  The minimum logging level at which this handler will be triggered
+     * @param bool       $bubble Whether the messages that are handled can bubble up the stack or not
      */
     public function __construct($level = Logger::DEBUG, $bubble = true)
     {


### PR DESCRIPTION
The level parameter of the `AbstractHandler` supports also the PSR levels as strings e.g. `\Psr\Log\LogLevel::ERROR` or from a ENV variable `CUSTOM_ERROR_HANDLER_LEVEL=error`.

This will fix issues with phpstan or other static code analyzer when given the level as string.