### PR TITLE
Ensure usage of global curl_* functions

### DIFF
--- a/src/Monolog/Handler/SlackWebhookHandler.php
+++ b/src/Monolog/Handler/SlackWebhookHandler.php
@@ -95,7 +95,7 @@ class SlackWebhookHandler extends AbstractProcessingHandler
         $postData = $this->slackRecord->getSlackData($record);
         $postString = Utils::jsonEncode($postData);
 
-        $ch = curl_init();
+        $ch = \curl_init();
         $options = array(
             CURLOPT_URL => $this->webhookUrl,
             CURLOPT_POST => true,
@@ -107,7 +107,7 @@ class SlackWebhookHandler extends AbstractProcessingHandler
             $options[CURLOPT_SAFE_UPLOAD] = true;
         }
 
-        curl_setopt_array($ch, $options);
+        \curl_setopt_array($ch, $options);
 
         Curl\Util::execute($ch);
     }


### PR DESCRIPTION
Using the Slack Webhook handler broke on our PHP 7.3 install (Ubuntu 18.04) with a `Uncaught PHP Exception Symfony\Component\ErrorHandler\Error\UndefinedFunctionError: "Attempted to call function "curl_init" from namespace "Monolog\Handler"."`. Prefixing the `curl_*` calls with a backslash to ensure the global methods are used fixed it, and as far as I know there's no downsides to being more precise with these things.

Fixes #1444 