### PR TITLE
Registry class not used in ErrorHandler

### DIFF
--- a/src/Monolog/ErrorHandler.php
+++ b/src/Monolog/ErrorHandler.php
@@ -14,7 +14,6 @@ namespace Monolog;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Monolog\Handler\AbstractHandler;
-use Monolog\Registry;
 
 /**
  * Monolog error handler


### PR DESCRIPTION
The use statement `use Monolog\Registry;` was unnecessary in the `ErrorHandler` class.