### PR TITLE
Telegram Handler: support additional API parameters

### DIFF
--- a/src/Monolog/Handler/TelegramBotHandler.php
+++ b/src/Monolog/Handler/TelegramBotHandler.php
@@ -59,19 +59,19 @@ class TelegramBotHandler extends AbstractProcessingHandler
      * The kind of formatting that is used for the message.
      * See available options at https://core.telegram.org/bots/api#formatting-options
      * or in AVAILABLE_PARSE_MODES
-     * @var string
+     * @var string|null
      */
     private $parseMode;
 
     /**
      * Disables link previews for links in the message.
-     * @var bool
+     * @var bool|null
      */
     private $disableWebPagePreview;
 
     /**
      * Sends the message silently. Users will receive a notification with no sound.
-     * @var bool
+     * @var bool|null
      */
     private $disableNotification;
 
@@ -110,13 +110,13 @@ class TelegramBotHandler extends AbstractProcessingHandler
         return $this;
     }
 
-    public function setDisableWebPagePreview(bool $disableWebPagePreview = null): self
+    public function disableWebPagePreview(bool $disableWebPagePreview = null): self
     {
         $this->disableWebPagePreview = $disableWebPagePreview;
         return $this;
     }
 
-    public function setDisableNotification(bool $disableNotification = null): self
+    public function disableNotification(bool $disableNotification = null): self
     {
         $this->disableNotification = $disableNotification;
         return $this;

--- a/src/Monolog/Handler/TelegramBotHandler.php
+++ b/src/Monolog/Handler/TelegramBotHandler.php
@@ -96,8 +96,8 @@ class TelegramBotHandler extends AbstractProcessingHandler
         $this->level = $level;
         $this->bubble = $bubble;
         $this->setParseMode($parseMode);
-        $this->setDisableWebPagePreview($disableWebPagePreview);
-        $this->setDisableNotification($disableNotification);
+        $this->disableWebPagePreview($disableWebPagePreview);
+        $this->disableNotification($disableNotification);
     }
 
     public function setParseMode(string $parseMode = null): self

--- a/src/Monolog/Handler/TelegramBotHandler.php
+++ b/src/Monolog/Handler/TelegramBotHandler.php
@@ -47,6 +47,25 @@ class TelegramBotHandler extends AbstractProcessingHandler
     private $channel;
 
     /**
+     * The kind of formatting that is used for the message.
+     * See available options at https://core.telegram.org/bots/api#formatting-options
+     * @var string
+     */
+    private $parseMode;
+
+    /**
+     * Disables link previews for links in the message.
+     * @var bool
+     */
+    private $disableWebPagePreview;
+
+    /**
+     * Sends the message silently. Users will receive a notification with no sound.
+     * @var bool
+     */
+    private $disableNotification;
+
+    /**
      * @param string $apiKey  Telegram bot access token provided by BotFather
      * @param string $channel Telegram channel name
      * @inheritDoc
@@ -54,6 +73,9 @@ class TelegramBotHandler extends AbstractProcessingHandler
     public function __construct(
         string $apiKey,
         string $channel,
+        string $parseMode = null,
+        bool $disableWebPagePreview = null,
+        bool $disableNotification = null,
         $level = Logger::DEBUG,
         bool $bubble = true
     ) {
@@ -61,6 +83,9 @@ class TelegramBotHandler extends AbstractProcessingHandler
 
         $this->apiKey = $apiKey;
         $this->channel = $channel;
+        $this->parseMode = $parseMode;
+        $this->disableWebPagePreview = $disableWebPagePreview;
+        $this->disableNotification = $disableNotification;
         $this->level = $level;
         $this->bubble = $bubble;
     }
@@ -87,6 +112,9 @@ class TelegramBotHandler extends AbstractProcessingHandler
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
             'text' => $message,
             'chat_id' => $this->channel,
+            'parse_mode' => $this->parseMode,
+            'disable_web_page_preview' => $this->disableWebPagePreview,
+            'disable_notification' => $this->disableNotification,
         ]));
 
         $result = Curl\Util::execute($ch);

--- a/src/Monolog/Handler/TelegramBotHandler.php
+++ b/src/Monolog/Handler/TelegramBotHandler.php
@@ -33,6 +33,15 @@ class TelegramBotHandler extends AbstractProcessingHandler
     private const BOT_API = 'https://api.telegram.org/bot';
 
     /**
+     * @var array AVAILABLE_PARSE_MODES The available values of parseMode according to the Telegram api documentation
+     */
+    private const AVAILABLE_PARSE_MODES = [
+        'HTML',
+        'MarkdownV2',
+        'Markdown' // legacy mode without underline and strikethrough, use MarkdownV2 instead
+    ];
+
+    /**
      * Telegram bot access token provided by BotFather.
      * Create telegram bot with https://telegram.me/BotFather and use access token from it.
      * @var string
@@ -49,6 +58,7 @@ class TelegramBotHandler extends AbstractProcessingHandler
     /**
      * The kind of formatting that is used for the message.
      * See available options at https://core.telegram.org/bots/api#formatting-options
+     * or in AVAILABLE_PARSE_MODES
      * @var string
      */
     private $parseMode;
@@ -85,9 +95,31 @@ class TelegramBotHandler extends AbstractProcessingHandler
         $this->channel = $channel;
         $this->level = $level;
         $this->bubble = $bubble;
+        $this->setParseMode($parseMode);
+        $this->setDisableWebPagePreview($disableWebPagePreview);
+        $this->setDisableNotification($disableNotification);
+    }
+
+    public function setParseMode(string $parseMode = null): self
+    {
+        if ($parseMode !== null && !in_array($parseMode, self::AVAILABLE_PARSE_MODES)) {
+            throw new \InvalidArgumentException('Unknown parseMode, use one of these: ' . implode(', ', self::AVAILABLE_PARSE_MODES) . '.');
+        }
+
         $this->parseMode = $parseMode;
+        return $this;
+    }
+
+    public function setDisableWebPagePreview(bool $disableWebPagePreview = null): self
+    {
         $this->disableWebPagePreview = $disableWebPagePreview;
+        return $this;
+    }
+
+    public function setDisableNotification(bool $disableNotification = null): self
+    {
         $this->disableNotification = $disableNotification;
+        return $this;
     }
 
     /**

--- a/src/Monolog/Handler/TelegramBotHandler.php
+++ b/src/Monolog/Handler/TelegramBotHandler.php
@@ -73,21 +73,21 @@ class TelegramBotHandler extends AbstractProcessingHandler
     public function __construct(
         string $apiKey,
         string $channel,
+        $level = Logger::DEBUG,
+        bool $bubble = true,
         string $parseMode = null,
         bool $disableWebPagePreview = null,
-        bool $disableNotification = null,
-        $level = Logger::DEBUG,
-        bool $bubble = true
+        bool $disableNotification = null
     ) {
         parent::__construct($level, $bubble);
 
         $this->apiKey = $apiKey;
         $this->channel = $channel;
+        $this->level = $level;
+        $this->bubble = $bubble;
         $this->parseMode = $parseMode;
         $this->disableWebPagePreview = $disableWebPagePreview;
         $this->disableNotification = $disableNotification;
-        $this->level = $level;
-        $this->bubble = $bubble;
     }
 
     /**

--- a/tests/Monolog/Handler/TelegramBotHandlerTest.php
+++ b/tests/Monolog/Handler/TelegramBotHandlerTest.php
@@ -53,4 +53,18 @@ class TelegramBotHandlerTest extends TestCase
         $this->handler->expects($this->atLeast(1))
             ->method('send');
     }
+
+    public function testSetInvalidParseMode(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $handler = new TelegramBotHandler('testKey', 'testChannel');
+        $handler->setParseMode('invalid parse mode');
+    }
+
+    public function testSetParseMode(): void
+    {
+        $handler = new TelegramBotHandler('testKey', 'testChannel');
+        $handler->setParseMode('HTML');
+    }
 }

--- a/tests/Monolog/Handler/TelegramBotHandlerTest.php
+++ b/tests/Monolog/Handler/TelegramBotHandlerTest.php
@@ -35,9 +35,15 @@ class TelegramBotHandlerTest extends TestCase
      * @param string $apiKey
      * @param string $channel
      */
-    private function createHandler(string $apiKey = 'testKey', string $channel = 'testChannel'): void
+    private function createHandler(
+        string $apiKey = 'testKey',
+        string $channel = 'testChannel',
+        string $parseMode = 'Markdown',
+        bool $disableWebPagePreview = false,
+        bool $disableNotification = true
+    ): void
     {
-        $constructorArgs = [$apiKey, $channel, Logger::DEBUG, true];
+        $constructorArgs = [$apiKey, $channel, $parseMode, $disableWebPagePreview, $disableNotification, Logger::DEBUG, true];
 
         $this->handler = $this->getMockBuilder(TelegramBotHandler::class)
             ->setConstructorArgs($constructorArgs)

--- a/tests/Monolog/Handler/TelegramBotHandlerTest.php
+++ b/tests/Monolog/Handler/TelegramBotHandlerTest.php
@@ -43,7 +43,7 @@ class TelegramBotHandlerTest extends TestCase
         bool $disableNotification = true
     ): void
     {
-        $constructorArgs = [$apiKey, $channel, $parseMode, $disableWebPagePreview, $disableNotification, Logger::DEBUG, true];
+        $constructorArgs = [$apiKey, $channel, Logger::DEBUG, true, $parseMode, $disableWebPagePreview, $disableNotification];
 
         $this->handler = $this->getMockBuilder(TelegramBotHandler::class)
             ->setConstructorArgs($constructorArgs)


### PR DESCRIPTION
The telegram API for sendMessage supports some additional parameters that where not yet covered with the current implementation. See the API documentation here:

https://core.telegram.org/bots/api#sendmessage

In my use case I'm mostly just interested in the `parse_mode` parameter but I thought that while I'm on it I could also add support for `disable_web_page_preview` and `disable_notification`.

I didn't add support for the other remaining options because in my opinion they will never make sense when using the API for logging. `reply_to_message_id` can only be set for replies, but when logging we're not replying to a message but rather sending independent messages. `reply_markup` lets the bot display an interactive interface for the user receiving the message, but the log handler can't deal with replies anyway.

Something that I'm not sure about whether it's okay like this is the function argument order to the constructor. Should I move the new arguments to the end?