### PR TITLE
Update ErrorLogHandler.php

### DIFF
--- a/src/Monolog/Handler/ErrorLogHandler.php
+++ b/src/Monolog/Handler/ErrorLogHandler.php
@@ -78,7 +78,7 @@ class ErrorLogHandler extends AbstractProcessingHandler
             return;
         }
 
-        $lines = preg_split('{[\r\n]+}', (string) $record['formatted']);
+        $lines = preg_split('{[\r\n]+}', (string) $record['message']);
         foreach ($lines as $line) {
             error_log($line, $this->messageType);
         }


### PR DESCRIPTION
`$record['formatted']` contains no `\r\n` escape sequences but ` $record['message']` does, hence should be the source string for split.