### PR TITLE
Fix array offset access on null in RavenHandler

### DIFF
--- a/src/Monolog/Handler/RavenHandler.php
+++ b/src/Monolog/Handler/RavenHandler.php
@@ -86,7 +86,7 @@ class RavenHandler extends AbstractProcessingHandler
 
         // the record with the highest severity is the "main" one
         $record = array_reduce($records, function ($highest, $record) {
-            if ($record['level'] > $highest['level']) {
+            if (null === $highest || $record['level'] > $highest['level']) {
                 return $record;
             }
 


### PR DESCRIPTION
PHP 7.4 introduces backward incompatible changes and not allow anymore to [access a null variable like an array](https://www.php.net/manual/en/migration74.incompatible.php#migration74.incompatible.core.non-array-access).

The `RavenHandler` use an `array_reduce` with the default initial value that is `null` but acces it like an array which generate a PHP notice.

![before](https://user-images.githubusercontent.com/433926/83811488-33b74c80-a6ba-11ea-89f6-6cf0707115fc.png)
