### PR TITLE
Static analysis improvements

### DIFF
--- a/src/Monolog/Handler/FilterHandler.php
+++ b/src/Monolog/Handler/FilterHandler.php
@@ -49,6 +49,8 @@ class FilterHandler extends Handler implements ProcessableHandlerInterface, Rese
     protected $bubble;
 
     /**
+     * @psalm-param callable(array, HandlerInterface): HandlerInterface|HandlerInterface $handler
+     *
      * @param callable|HandlerInterface $handler        Handler or factory callable($record|null, $filterHandler).
      * @param int|array                 $minLevelOrList A list of levels to accept or a minimum level if maxLevel is provided
      * @param int|string                $maxLevel       Maximum level to accept, only used if $minLevelOrList is not an array

--- a/src/Monolog/Handler/FilterHandler.php
+++ b/src/Monolog/Handler/FilterHandler.php
@@ -49,7 +49,7 @@ class FilterHandler extends Handler implements ProcessableHandlerInterface, Rese
     protected $bubble;
 
     /**
-     * @psalm-param callable(array, HandlerInterface): HandlerInterface|HandlerInterface $handler
+     * @psalm-param HandlerInterface|callable(?array, HandlerInterface): HandlerInterface $handler
      *
      * @param callable|HandlerInterface $handler        Handler or factory callable($record|null, $filterHandler).
      * @param int|array                 $minLevelOrList A list of levels to accept or a minimum level if maxLevel is provided

--- a/src/Monolog/Handler/FingersCrossedHandler.php
+++ b/src/Monolog/Handler/FingersCrossedHandler.php
@@ -47,7 +47,7 @@ class FingersCrossedHandler extends Handler implements ProcessableHandlerInterfa
     protected $bubble;
 
     /**
-     * @psalm-param callable(?array, FingersCrossedHandler): HandlerInterface|HandlerInterface $handler
+     * @psalm-param HandlerInterface|callable(?array, FingersCrossedHandler): HandlerInterface $handler
      *
      * @param callable|HandlerInterface              $handler            Handler or factory callable($record|null, $fingersCrossedHandler).
      * @param int|string|ActivationStrategyInterface $activationStrategy Strategy which determines when this handler takes action, or a level name/value at which the handler is activated

--- a/src/Monolog/Handler/FingersCrossedHandler.php
+++ b/src/Monolog/Handler/FingersCrossedHandler.php
@@ -47,6 +47,8 @@ class FingersCrossedHandler extends Handler implements ProcessableHandlerInterfa
     protected $bubble;
 
     /**
+     * @psalm-param callable(?array, FingersCrossedHandler): HandlerInterface|HandlerInterface $handler
+     *
      * @param callable|HandlerInterface              $handler            Handler or factory callable($record|null, $fingersCrossedHandler).
      * @param int|string|ActivationStrategyInterface $activationStrategy Strategy which determines when this handler takes action, or a level name/value at which the handler is activated
      * @param int                                    $bufferSize         How many entries should be buffered at most, beyond that the oldest items are removed from the buffer.

--- a/src/Monolog/Handler/MandrillHandler.php
+++ b/src/Monolog/Handler/MandrillHandler.php
@@ -25,6 +25,8 @@ class MandrillHandler extends MailHandler
     protected $apiKey;
 
     /**
+     * @psalm-param callable(string, array): Swift_Message|Swift_Message $message
+     *
      * @param string                  $apiKey  A valid Mandrill API key
      * @param callable|\Swift_Message $message An example message for real messages, only the body will be replaced
      * @param string|int              $level   The minimum logging level at which this handler will be triggered

--- a/src/Monolog/Handler/MandrillHandler.php
+++ b/src/Monolog/Handler/MandrillHandler.php
@@ -25,7 +25,7 @@ class MandrillHandler extends MailHandler
     protected $apiKey;
 
     /**
-     * @psalm-param callable(string, array): Swift_Message|Swift_Message $message
+     * @psalm-param Swift_Message|callable(string, array): Swift_Message $message
      *
      * @param string                  $apiKey  A valid Mandrill API key
      * @param callable|\Swift_Message $message An example message for real messages, only the body will be replaced

--- a/src/Monolog/Handler/ProcessableHandlerInterface.php
+++ b/src/Monolog/Handler/ProcessableHandlerInterface.php
@@ -23,6 +23,8 @@ interface ProcessableHandlerInterface
     /**
      * Adds a processor in the stack.
      *
+     * @psalm-param ProcessorInterface|callable(array): array $callback
+     *
      * @param  ProcessorInterface|callable $callback
      * @return HandlerInterface            self
      */
@@ -30,6 +32,8 @@ interface ProcessableHandlerInterface
 
     /**
      * Removes the processor on top of the stack and returns it.
+     *
+     * @psalm-return callable(array): array
      *
      * @throws \LogicException In case the processor stack is empty
      * @return callable

--- a/src/Monolog/Handler/SamplingHandler.php
+++ b/src/Monolog/Handler/SamplingHandler.php
@@ -42,7 +42,7 @@ class SamplingHandler extends AbstractHandler implements ProcessableHandlerInter
     protected $factor;
 
     /**
-     * @psalm-param callable(array, HandlerInterface): HandlerInterface|HandlerInterface $handler
+     * @psalm-param HandlerInterface|callable(array, HandlerInterface): HandlerInterface $handler
      *
      * @param callable|HandlerInterface $handler Handler or factory callable($record|null, $samplingHandler).
      * @param int                       $factor  Sample factor (e.g. 10 means every ~10th record is sampled)

--- a/src/Monolog/Handler/SamplingHandler.php
+++ b/src/Monolog/Handler/SamplingHandler.php
@@ -42,6 +42,8 @@ class SamplingHandler extends AbstractHandler implements ProcessableHandlerInter
     protected $factor;
 
     /**
+     * @psalm-param callable(array, HandlerInterface): HandlerInterface|HandlerInterface $handler
+     *
      * @param callable|HandlerInterface $handler Handler or factory callable($record|null, $samplingHandler).
      * @param int                       $factor  Sample factor (e.g. 10 means every ~10th record is sampled)
      */

--- a/src/Monolog/Handler/SwiftMailerHandler.php
+++ b/src/Monolog/Handler/SwiftMailerHandler.php
@@ -28,6 +28,8 @@ class SwiftMailerHandler extends MailHandler
     private $messageTemplate;
 
     /**
+     * @psalm-param callable(string, array): Swift_Message|Swift_Message $message
+     *
      * @param \Swift_Mailer          $mailer  The mailer to use
      * @param callable|Swift_Message $message An example message for real messages, only the body will be replaced
      * @param string|int             $level   The minimum logging level at which this handler will be triggered

--- a/src/Monolog/Handler/SwiftMailerHandler.php
+++ b/src/Monolog/Handler/SwiftMailerHandler.php
@@ -28,7 +28,7 @@ class SwiftMailerHandler extends MailHandler
     private $messageTemplate;
 
     /**
-     * @psalm-param callable(string, array): Swift_Message|Swift_Message $message
+     * @psalm-param Swift_Message|callable(string, array): Swift_Message $message
      *
      * @param \Swift_Mailer          $mailer  The mailer to use
      * @param callable|Swift_Message $message An example message for real messages, only the body will be replaced

--- a/src/Monolog/Handler/TestHandler.php
+++ b/src/Monolog/Handler/TestHandler.php
@@ -139,13 +139,16 @@ class TestHandler extends AbstractProcessingHandler
      */
     public function hasRecordThatMatches(string $regex, $level): bool
     {
-        return $this->hasRecordThatPasses(function ($rec) use ($regex) {
+        return $this->hasRecordThatPasses(function (array $rec) use ($regex): bool {
             return preg_match($regex, $rec['message']) > 0;
         }, $level);
     }
 
     /**
+     * @psalm-param callable(array, int): mixed $predicate
+     *
      * @param string|int $level Logging level value or name
+     * @return bool
      */
     public function hasRecordThatPasses(callable $predicate, $level)
     {

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -140,6 +140,8 @@ class Logger implements LoggerInterface, ResettableInterface
     protected $exceptionHandler;
 
     /**
+     * @psalm-param array<callable(array): array>
+     *
      * @param string             $name       The logging channel, a simple descriptive name that is attached to all log records
      * @param HandlerInterface[] $handlers   Optional stack of handlers, the first one in the array is called first, etc.
      * @param callable[]         $processors Optional array of processors

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -140,7 +140,7 @@ class Logger implements LoggerInterface, ResettableInterface
     protected $exceptionHandler;
 
     /**
-     * @psalm-param array<callable(array): array>
+     * @psalm-param array<callable(array): array> $processors
      *
      * @param string             $name       The logging channel, a simple descriptive name that is attached to all log records
      * @param HandlerInterface[] $handlers   Optional stack of handlers, the first one in the array is called first, etc.


### PR DESCRIPTION
Hi.. although you are not using static analysis these docblocks can improve static analysis on userland.

- I used `psalm-*` in order for the normal annotations to not mess the IDEs
- The `psalm-*` annotation works both for psalm and phpstan. I think that also psalm reads `phpstan-*` annotations.
- Since you don't use static analysis I only changed the public api.

More things could be done. Like adding to levels something like this:

```php
psalm-param 100|200|300|400|550|600|LogLevel::* $level
```

But it wont be 100% accurate since level can accept `info` and `INFO` and `iNFO` so I believe it's not worth the overhead.