### PR TITLE
🐛 Fix Elastica\Document undefined method

### DIFF
--- a/src/Monolog/Formatter/ElasticaFormatter.php
+++ b/src/Monolog/Formatter/ElasticaFormatter.php
@@ -72,7 +72,7 @@ class ElasticaFormatter extends NormalizerFormatter
     {
         $document = new Document();
         $document->setData($record);
-        $document->setType($this->type);
+        $document->setOpType($this->type);
         $document->setIndex($this->index);
 
         return $document;


### PR DESCRIPTION
Fix undefined method call to `Elastic\Document::setType()` in ElasticaFormatter Class.