### PR TITLE
[Sendgrid] Depend on the time of the first record

### DIFF
--- a/src/Monolog/Handler/SendGridHandler.php
+++ b/src/Monolog/Handler/SendGridHandler.php
@@ -11,6 +11,7 @@
 
 namespace Monolog\Handler;
 
+use Monolog\DateTimeImmutable;
 use Monolog\Logger;
 
 /**
@@ -82,7 +83,10 @@ class SendGridHandler extends MailHandler
             $message['to[]'] = $recipient;
         }
         $message['subject'] = $this->subject;
-        $message['date'] = date('r');
+
+        /** @var DateTimeImmutable $date */
+        $date = $records[0]['datetime'];
+        $message['date'] = $date->format('r');
 
         if ($this->isHtmlBody($content)) {
             $message['html'] = $content;

--- a/src/Monolog/Handler/SendGridHandler.php
+++ b/src/Monolog/Handler/SendGridHandler.php
@@ -84,9 +84,13 @@ class SendGridHandler extends MailHandler
         }
         $message['subject'] = $this->subject;
 
-        /** @var DateTimeImmutable $date */
-        $date = $records[0]['datetime'];
-        $message['date'] = $date->format('r');
+        if ($records) {
+            /** @var DateTimeImmutable $date */
+            $date = reset($records)['datetime'];
+            $message['date'] = $date->format('r');
+        } else {
+            $message['date'] = date('r');
+        }
 
         if ($this->isHtmlBody($content)) {
             $message['html'] = $content;


### PR DESCRIPTION
Shouldn't this time depend on the time of the first record instead?