### PR TITLE
Improve exception message

### DIFF
--- a/src/Monolog/Handler/StreamHandler.php
+++ b/src/Monolog/Handler/StreamHandler.php
@@ -108,7 +108,7 @@ class StreamHandler extends AbstractProcessingHandler
             if (!is_resource($this->stream)) {
                 $this->stream = null;
 
-                throw new \UnexpectedValueException(sprintf('The stream or file "%s" could not be opened: '.$this->errorMessage, $this->url));
+                throw new \UnexpectedValueException(sprintf('The stream or file "%s" could not be opened in append mode: '.$this->errorMessage, $this->url));
             }
         }
 


### PR DESCRIPTION
This exception is commonly thrown in Laravel applications when using Docker.
But it is not clear why the system could not open a file that has read permission
for all users. So, when I came to the code of Monolog, I saw that you try to open it
in append mode, so I think that just adding this information could help a lot other
users.