### PR TITLE
Fixed TelegramBotHandler constructor

### DIFF
--- a/src/Monolog/Handler/TelegramBotHandler.php
+++ b/src/Monolog/Handler/TelegramBotHandler.php
@@ -93,8 +93,6 @@ class TelegramBotHandler extends AbstractProcessingHandler
 
         $this->apiKey = $apiKey;
         $this->channel = $channel;
-        $this->level = $level;
-        $this->bubble = $bubble;
         $this->setParseMode($parseMode);
         $this->disableWebPagePreview($disableWebPagePreview);
         $this->disableNotification($disableNotification);


### PR DESCRIPTION
Parameters `$level` and `$bubble` are already passed to parent constructor, no need to set them again.

Also setting `$level` without `setLevel()` makes it incomparable as it is not converted to int via `Logger::toMonologLevel()`.