### PR TITLE
Adds support for unix sockets

### DIFF
--- a/src/Monolog/Handler/SyslogUdp/UdpSocket.php
+++ b/src/Monolog/Handler/SyslogUdp/UdpSocket.php
@@ -28,7 +28,8 @@ class UdpSocket
     {
         $this->ip = $ip;
         $this->port = $port;
-        $this->socket = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);
+        $domain = $port === 0 ? AF_UNIX : AF_INET;
+        $this->socket = socket_create($domain, SOCK_DGRAM, SOL_UDP);
     }
 
     public function write($line, $header = "")

--- a/src/Monolog/Handler/SyslogUdpHandler.php
+++ b/src/Monolog/Handler/SyslogUdpHandler.php
@@ -51,7 +51,7 @@ class SyslogUdpHandler extends AbstractSyslogHandler
         $this->ident = $ident;
         $this->rfc = $rfc;
 
-        $this->socket = new UdpSocket($host, $port ?: 514);
+        $this->socket = new UdpSocket($host, $port);
     }
 
     protected function write(array $record): void


### PR DESCRIPTION
The SyslogUdpHandler currently hard codes the `AF_INET` socket domain, however we can also easily support local unix sockets with `AF_UNIX`. See https://www.php.net/manual/en/function.socket-create.php

If the port is 0, the we can assume it is a local unix socket.
