### PR TITLE
BUGFIX substr() broke when passing a NULL because of strict type

### DIFF
--- a/src/Monolog/Utils.php
+++ b/src/Monolog/Utils.php
@@ -31,7 +31,7 @@ final class Utils
             return mb_strcut($string, $start, $length);
         }
 
-        return substr($string, $start, $length);
+        return substr($string, $start, $length ?: strlen($string));
     }
 
     /**


### PR DESCRIPTION
If the mb extension was not installed, the Utils::substr method could fail when passed a NULL, because of strict mode.

You would get the following errors:

Uncaught TypeError: substr() expects parameter 3 to be int, null given in vendor/monolog/monolog/src/Monolog/Utils.php on line 34
TypeError: substr() expects parameter 3 to be int, null given in vendor/monolog/monolog/src/Monolog/Utils.php on line 34

This is fixed in this patch.
This is my first contribution to this project, so I hope I played nice. :)