### PR TITLE
Support for extended RFC5424 timestamp format

### DIFF
--- a/src/Monolog/Handler/SyslogUdpHandler.php
+++ b/src/Monolog/Handler/SyslogUdpHandler.php
@@ -25,10 +25,12 @@ class SyslogUdpHandler extends AbstractSyslogHandler
 {
     const RFC3164 = 0;
     const RFC5424 = 1;
+    const RFC5424e = 2;
 
     private $dateFormats = array(
         self::RFC3164 => 'M d H:i:s',
         self::RFC5424 => \DateTime::RFC3339,
+        self::RFC5424e => \DateTime::RFC3339_EXTENDED,
     );
 
     protected $socket;


### PR DESCRIPTION
As described in [RFC5424 Timestamp format](https://tools.ietf.org/html/rfc5424#section-6.2.3), it is allowed to send second fraction as doted mili (3 digits) or micro (6 digits) in syslog messages. I suggest this modest PR to support it.