### PR TITLE
Split SlackRecord into SlackRecord + SlackFormatter

### DIFF
--- a/src/Monolog/Formatter/SlackFormatter.php
+++ b/src/Monolog/Formatter/SlackFormatter.php
@@ -1,0 +1,255 @@
+<?php
+
+
+namespace Monolog\Formatter;
+
+
+use Monolog\Logger;
+use Monolog\Utils;
+
+/**
+ * Formats the message as a Slack message with the schema {@link https://api.slack.com/messaging/composing/layouts}
+ *
+ * @author Tim Finucane <timfinucane@outlook.com>
+ */
+class SlackFormatter extends NormalizerFormatter
+{
+    public const COLOR_DANGER = 'danger';
+
+    public const COLOR_WARNING = 'warning';
+
+    public const COLOR_GOOD = 'good';
+
+    public const COLOR_DEFAULT = '#e3e4e6';
+
+    /**
+     * Whether the message should be added to Slack as attachment (plain text otherwise)
+     * @var bool
+     */
+    private $useAttachment;
+
+    /**
+     * Whether the the context/extra messages added to Slack as attachments are in a short style
+     * @var bool
+     */
+    private $useShortAttachment;
+
+    /**
+     * Whether the attachment should include context and extra data
+     * @var bool
+     */
+    private $includeContextAndExtra;
+
+    /**
+     * Dot separated list of fields to exclude from slack message. E.g. ['context.field1', 'extra.field2']
+     * @var array
+     */
+    private $excludeFields;
+
+    public function __construct(
+        bool $useAttachment = true,
+        bool $useShortAttachment = false,
+        bool $includeContextAndExtra = false,
+        array $excludeFields = array(),
+        ?string $dateFormat = null
+    ) {
+        parent::__construct($dateFormat);
+
+        $this
+            ->useAttachment($useAttachment)
+            ->useShortAttachment($useShortAttachment)
+            ->includeContextAndExtra($includeContextAndExtra)
+            ->excludeFields($excludeFields);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function format(array $record)
+    {
+        $record = $this->removeExcludedFields($record);
+
+        // The final array being output. Should be a partial of https://api.slack.com/messaging/composing/layouts
+        $dataArray = array();
+
+        $message = $record['message'];
+
+        if ($this->useAttachment) {
+            $attachment = array(
+                'fallback'  => $message,
+                'text'      => $message,
+                'color'     => $this->getAttachmentColor($record['level']),
+                'fields'    => array(),
+                'mrkdwn_in' => array('fields'),
+                'ts'        => $record['datetime']->getTimestamp(),
+            );
+
+            if ($this->useShortAttachment) {
+                $attachment['title'] = $record['level_name'];
+            } else {
+                $attachment['title'] = 'Message';
+                $attachment['fields'][] = $this->generateAttachmentField('Level', $record['level_name']);
+            }
+
+            if ($this->includeContextAndExtra) {
+                foreach (['extra', 'context'] as $key) {
+                    if (empty($record[$key])) {
+                        continue;
+                    }
+
+                    if ($this->useShortAttachment) {
+                        $attachment['fields'][] = $this->generateAttachmentField(
+                            (string)$key,
+                            $record[$key]
+                        );
+                    } else {
+                        // Add all extra fields as individual fields in attachment
+                        $attachment['fields'] = array_merge(
+                            $attachment['fields'],
+                            $this->generateAttachmentFields($record[$key])
+                        );
+                    }
+                }
+            }
+
+            $dataArray['attachments'] = array($attachment);
+        } else {
+            $dataArray['text'] = $message;
+        }
+
+        return $dataArray;
+    }
+
+    /**
+     * @param bool $useAttachment
+     *
+     * @return SlackFormatter
+     */
+    public function useAttachment(bool $useAttachment): SlackFormatter
+    {
+        $this->useAttachment = $useAttachment;
+        return $this;
+    }
+
+    /**
+     * Returns a Slack message attachment color associated with
+     * provided level.
+     */
+    public function getAttachmentColor(int $level): string
+    {
+        switch (true) {
+            case $level >= Logger::ERROR:
+                return static::COLOR_DANGER;
+            case $level >= Logger::WARNING:
+                return static::COLOR_WARNING;
+            case $level >= Logger::INFO:
+                return static::COLOR_GOOD;
+            default:
+                return static::COLOR_DEFAULT;
+        }
+    }
+
+    /**
+     * @param bool $useShortAttachment
+     *
+     * @return SlackFormatter
+     */
+    public function useShortAttachment(bool $useShortAttachment): SlackFormatter
+    {
+        $this->useShortAttachment = $useShortAttachment;
+        return $this;
+    }
+
+    /**
+     * @param bool $includeContextAndExtra
+     *
+     * @return SlackFormatter
+     */
+    public function includeContextAndExtra(bool $includeContextAndExtra): SlackFormatter
+    {
+        $this->includeContextAndExtra = $includeContextAndExtra;
+        return $this;
+    }
+
+    /**
+     * @param array $excludeFields
+     *
+     * @return SlackFormatter
+     */
+    public function excludeFields(array $excludeFields): SlackFormatter
+    {
+        $this->excludeFields = $excludeFields;
+        return $this;
+    }
+
+
+    /**
+     * Generates attachment field
+     *
+     * @param string|array $value
+     */
+    private function generateAttachmentField(string $title, $value): array
+    {
+        $value = is_array($value)
+            ? sprintf('```%s```', substr($this->stringify($value), 0, 1990))
+            : $value;
+
+        return array(
+            'title' => ucfirst($title),
+            'value' => $value,
+            'short' => false,
+        );
+    }
+
+    /**
+     * Generates a collection of attachment fields from array
+     */
+    private function generateAttachmentFields(array $data): array
+    {
+        $fields = array();
+        foreach ($this->normalize($data) as $key => $value) {
+            $fields[] = $this->generateAttachmentField((string) $key, $value);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Stringifies an array of key/value pairs to be used in attachment fields
+     */
+    public function stringify(array $fields): string
+    {
+        $normalized = $this->normalize($fields);
+
+        $hasSecondDimension = count(array_filter($normalized, 'is_array'));
+        $hasNonNumericKeys = !count(array_filter(array_keys($normalized), 'is_numeric'));
+
+        return $hasSecondDimension || $hasNonNumericKeys
+            ? Utils::jsonEncode($normalized, JSON_PRETTY_PRINT|Utils::DEFAULT_JSON_FLAGS)
+            : Utils::jsonEncode($normalized, Utils::DEFAULT_JSON_FLAGS);
+    }
+
+    /**
+     * Get a copy of record with fields excluded according to $this->excludeFields
+     */
+    private function removeExcludedFields(array $record): array
+    {
+        foreach ($this->excludeFields as $field) {
+            $keys = explode('.', $field);
+            $node = &$record;
+            $lastKey = end($keys);
+            foreach ($keys as $key) {
+                if (!isset($node[$key])) {
+                    break;
+                }
+                if ($lastKey === $key) {
+                    unset($node[$key]);
+                    break;
+                }
+                $node = &$node[$key];
+            }
+        }
+
+        return $record;
+    }
+}

--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -11,10 +11,8 @@
 
 namespace Monolog\Handler\Slack;
 
-use Monolog\Logger;
-use Monolog\Utils;
-use Monolog\Formatter\NormalizerFormatter;
-use Monolog\Formatter\FormatterInterface;
+use InvalidArgumentException;
+use Monolog\Formatter\SlackFormatter;
 
 /**
  * Slack record utility helping to log to Slack webhooks or API.
@@ -26,12 +24,16 @@ use Monolog\Formatter\FormatterInterface;
  */
 class SlackRecord
 {
+    /** @deprecated Use {@see SlackFormatter::COLOR_DANGER} */
     public const COLOR_DANGER = 'danger';
 
+    /** @deprecated Use {@see SlackFormatter::COLOR_WARNING} */
     public const COLOR_WARNING = 'warning';
 
+    /** @deprecated Use {@see SlackFormatter::COLOR_GOOD} */
     public const COLOR_GOOD = 'good';
 
+    /** @deprecated Use {@see SlackFormatter::COLOR_DEFAULT} */
     public const COLOR_DEFAULT = '#e3e4e6';
 
     /**
@@ -52,63 +54,15 @@ class SlackRecord
      */
     private $userIcon;
 
-    /**
-     * Whether the message should be added to Slack as attachment (plain text otherwise)
-     * @var bool
-     */
-    private $useAttachment;
-
-    /**
-     * Whether the the context/extra messages added to Slack as attachments are in a short style
-     * @var bool
-     */
-    private $useShortAttachment;
-
-    /**
-     * Whether the attachment should include context and extra data
-     * @var bool
-     */
-    private $includeContextAndExtra;
-
-    /**
-     * Dot separated list of fields to exclude from slack message. E.g. ['context.field1', 'extra.field2']
-     * @var array
-     */
-    private $excludeFields;
-
-    /**
-     * @var FormatterInterface
-     */
-    private $formatter;
-
-    /**
-     * @var NormalizerFormatter
-     */
-    private $normalizerFormatter;
-
     public function __construct(
         ?string $channel = null,
         ?string $username = null,
-        bool $useAttachment = true,
-        ?string $userIcon = null,
-        bool $useShortAttachment = false,
-        bool $includeContextAndExtra = false,
-        array $excludeFields = array(),
-        FormatterInterface $formatter = null
+        ?string $userIcon = null
     ) {
         $this
             ->setChannel($channel)
             ->setUsername($username)
-            ->useAttachment($useAttachment)
-            ->setUserIcon($userIcon)
-            ->useShortAttachment($useShortAttachment)
-            ->includeContextAndExtra($includeContextAndExtra)
-            ->excludeFields($excludeFields)
-            ->setFormatter($formatter);
-
-        if ($this->includeContextAndExtra) {
-            $this->normalizerFormatter = new NormalizerFormatter();
-        }
+            ->setUserIcon($userIcon);
     }
 
     /**
@@ -118,7 +72,6 @@ class SlackRecord
     public function getSlackData(array $record): array
     {
         $dataArray = array();
-        $record = $this->removeExcludedFields($record);
 
         if ($this->username) {
             $dataArray['username'] = $this->username;
@@ -128,53 +81,18 @@ class SlackRecord
             $dataArray['channel'] = $this->channel;
         }
 
-        if ($this->formatter && !$this->useAttachment) {
-            $message = $this->formatter->format($record);
-        } else {
-            $message = $record['message'];
-        }
+        // Add the slack-formatted message to the json body
+        $message = $record['formatted'] ?? $record['message'];
 
-        if ($this->useAttachment) {
-            $attachment = array(
-                'fallback'  => $message,
-                'text'      => $message,
-                'color'     => $this->getAttachmentColor($record['level']),
-                'fields'    => array(),
-                'mrkdwn_in' => array('fields'),
-                'ts'        => $record['datetime']->getTimestamp(),
+        if (is_array($message)) {
+            $dataArray = array_merge($dataArray, $message);
+        } else if (is_scalar($message)) {
+            $dataArray['text'] = (string) $message;
+        } else {
+            throw new InvalidArgumentException(
+                'Expected formatter to return a scalar or a slack message array. Instead got type '
+                . gettype($message)
             );
-
-            if ($this->useShortAttachment) {
-                $attachment['title'] = $record['level_name'];
-            } else {
-                $attachment['title'] = 'Message';
-                $attachment['fields'][] = $this->generateAttachmentField('Level', $record['level_name']);
-            }
-
-            if ($this->includeContextAndExtra) {
-                foreach (array('extra', 'context') as $key) {
-                    if (empty($record[$key])) {
-                        continue;
-                    }
-
-                    if ($this->useShortAttachment) {
-                        $attachment['fields'][] = $this->generateAttachmentField(
-                            (string) $key,
-                            $record[$key]
-                        );
-                    } else {
-                        // Add all extra fields as individual fields in attachment
-                        $attachment['fields'] = array_merge(
-                            $attachment['fields'],
-                            $this->generateAttachmentFields($record[$key])
-                        );
-                    }
-                }
-            }
-
-            $dataArray['attachments'] = array($attachment);
-        } else {
-            $dataArray['text'] = $message;
         }
 
         if ($this->userIcon) {
@@ -189,44 +107,7 @@ class SlackRecord
     }
 
     /**
-     * Returns a Slack message attachment color associated with
-     * provided level.
-     */
-    public function getAttachmentColor(int $level): string
-    {
-        switch (true) {
-            case $level >= Logger::ERROR:
-                return static::COLOR_DANGER;
-            case $level >= Logger::WARNING:
-                return static::COLOR_WARNING;
-            case $level >= Logger::INFO:
-                return static::COLOR_GOOD;
-            default:
-                return static::COLOR_DEFAULT;
-        }
-    }
-
-    /**
-     * Stringifies an array of key/value pairs to be used in attachment fields
-     */
-    public function stringify(array $fields): string
-    {
-        $normalized = $this->normalizerFormatter->format($fields);
-
-        $hasSecondDimension = count(array_filter($normalized, 'is_array'));
-        $hasNonNumericKeys = !count(array_filter(array_keys($normalized), 'is_numeric'));
-
-        return $hasSecondDimension || $hasNonNumericKeys
-            ? Utils::jsonEncode($normalized, JSON_PRETTY_PRINT|Utils::DEFAULT_JSON_FLAGS)
-            : Utils::jsonEncode($normalized, Utils::DEFAULT_JSON_FLAGS);
-    }
-
-    /**
      * Channel used by the bot when posting
-     *
-     * @param ?string $channel
-     *
-     * @return SlackHandler
      */
     public function setChannel(?string $channel = null): self
     {
@@ -237,21 +118,10 @@ class SlackRecord
 
     /**
      * Username used by the bot when posting
-     *
-     * @param ?string $username
-     *
-     * @return SlackHandler
      */
     public function setUsername(?string $username = null): self
     {
         $this->username = $username;
-
-        return $this;
-    }
-
-    public function useAttachment(bool $useAttachment = true): self
-    {
-        $this->useAttachment = $useAttachment;
 
         return $this;
     }
@@ -265,92 +135,5 @@ class SlackRecord
         }
 
         return $this;
-    }
-
-    public function useShortAttachment(bool $useShortAttachment = false): self
-    {
-        $this->useShortAttachment = $useShortAttachment;
-
-        return $this;
-    }
-
-    public function includeContextAndExtra(bool $includeContextAndExtra = false): self
-    {
-        $this->includeContextAndExtra = $includeContextAndExtra;
-
-        if ($this->includeContextAndExtra) {
-            $this->normalizerFormatter = new NormalizerFormatter();
-        }
-
-        return $this;
-    }
-
-    public function excludeFields(array $excludeFields = []): self
-    {
-        $this->excludeFields = $excludeFields;
-
-        return $this;
-    }
-
-    public function setFormatter(?FormatterInterface $formatter = null): self
-    {
-        $this->formatter = $formatter;
-
-        return $this;
-    }
-
-    /**
-     * Generates attachment field
-     *
-     * @param string|array $value
-     */
-    private function generateAttachmentField(string $title, $value): array
-    {
-        $value = is_array($value)
-            ? sprintf('```%s```', substr($this->stringify($value), 0, 1990))
-            : $value;
-
-        return array(
-            'title' => ucfirst($title),
-            'value' => $value,
-            'short' => false,
-        );
-    }
-
-    /**
-     * Generates a collection of attachment fields from array
-     */
-    private function generateAttachmentFields(array $data): array
-    {
-        $fields = array();
-        foreach ($this->normalizerFormatter->format($data) as $key => $value) {
-            $fields[] = $this->generateAttachmentField((string) $key, $value);
-        }
-
-        return $fields;
-    }
-
-    /**
-     * Get a copy of record with fields excluded according to $this->excludeFields
-     */
-    private function removeExcludedFields(array $record): array
-    {
-        foreach ($this->excludeFields as $field) {
-            $keys = explode('.', $field);
-            $node = &$record;
-            $lastKey = end($keys);
-            foreach ($keys as $key) {
-                if (!isset($node[$key])) {
-                    break;
-                }
-                if ($lastKey === $key) {
-                    unset($node[$key]);
-                    break;
-                }
-                $node = &$node[$key];
-            }
-        }
-
-        return $record;
     }
 }

--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -12,6 +12,7 @@
 namespace Monolog\Handler;
 
 use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\SlackFormatter;
 use Monolog\Logger;
 use Monolog\Utils;
 use Monolog\Handler\Slack\SlackRecord;
@@ -70,12 +71,15 @@ class SlackHandler extends SocketHandler
         $this->slackRecord = new SlackRecord(
             $channel,
             $username,
+            $iconEmoji
+        );
+
+        $this->setFormatter(new SlackFormatter(
             $useAttachment,
-            $iconEmoji,
             $useShortAttachment,
             $includeContextAndExtra,
             $excludeFields
-        );
+        ));
 
         $this->token = $token;
     }
@@ -160,22 +164,6 @@ class SlackHandler extends SocketHandler
         $this->closeSocket();
     }
 
-    public function setFormatter(FormatterInterface $formatter): HandlerInterface
-    {
-        parent::setFormatter($formatter);
-        $this->slackRecord->setFormatter($formatter);
-
-        return $this;
-    }
-
-    public function getFormatter(): FormatterInterface
-    {
-        $formatter = parent::getFormatter();
-        $this->slackRecord->setFormatter($formatter);
-
-        return $formatter;
-    }
-
     /**
      * Channel used by the bot when posting
      */
@@ -196,9 +184,23 @@ class SlackHandler extends SocketHandler
         return $this;
     }
 
+    /**
+     * This function is deprecated, please use
+     * ```php
+     *     ((SlackFormatter) $slackHandler->getFormatter())->useAttachment()
+     * ```
+     *
+     * @deprecated Replaced by {@see SlackFormatter::useAttachment()}
+     *
+     * @param bool $useAttachment
+     *
+     * @return $this
+     */
     public function useAttachment(bool $useAttachment): self
     {
-        $this->slackRecord->useAttachment($useAttachment);
+        if ($this->formatter instanceof SlackFormatter) {
+            $this->formatter->useAttachment($useAttachment);
+        }
 
         return $this;
     }
@@ -210,23 +212,65 @@ class SlackHandler extends SocketHandler
         return $this;
     }
 
+    /**
+     * This function is deprecated, please use
+     * ```php
+     *     ((SlackFormatter) $slackHandler->getFormatter())->useShortAttachment()
+     * ```
+     *
+     * @deprecated Replaced by {@see SlackFormatter::useShortAttachment()}
+     *
+     * @param bool $useShortAttachment
+     *
+     * @return $this
+     */
     public function useShortAttachment(bool $useShortAttachment): self
     {
-        $this->slackRecord->useShortAttachment($useShortAttachment);
+        if ($this->formatter instanceof SlackFormatter) {
+            $this->formatter->useShortAttachment($useShortAttachment);
+        }
 
         return $this;
     }
 
+    /**
+     * This function is deprecated, please use
+     * ```php
+     *     ((SlackFormatter) $slackHandler->getFormatter())->includeContextAndExtra()
+     * ```
+     *
+     * @deprecated Replaced by {@see SlackFormatter::includeContextAndExtra()}
+     *
+     * @param bool $includeContextAndExtra
+     *
+     * @return $this
+     */
     public function includeContextAndExtra(bool $includeContextAndExtra): self
     {
-        $this->slackRecord->includeContextAndExtra($includeContextAndExtra);
+        if ($this->formatter instanceof SlackFormatter) {
+            $this->formatter->includeContextAndExtra($includeContextAndExtra);
+        }
 
         return $this;
     }
 
+    /**
+     * This function is deprecated, please use
+     * ```php
+     *     ((SlackFormatter) $slackHandler->getFormatter())->excludeFields()
+     * ```
+     *
+     * @deprecated Replaced by {@see SlackFormatter::excludeFields()}
+     *
+     * @param array $excludeFields
+     *
+     * @return $this
+     */
     public function excludeFields(array $excludeFields): self
     {
-        $this->slackRecord->excludeFields($excludeFields);
+        if ($this->formatter instanceof SlackFormatter) {
+            $this->formatter->excludeFields($excludeFields);
+        }
 
         return $this;
     }

--- a/src/Monolog/Handler/SlackWebhookHandler.php
+++ b/src/Monolog/Handler/SlackWebhookHandler.php
@@ -11,7 +11,7 @@
 
 namespace Monolog\Handler;
 
-use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\SlackFormatter;
 use Monolog\Logger;
 use Monolog\Utils;
 use Monolog\Handler\Slack\SlackRecord;
@@ -67,12 +67,16 @@ class SlackWebhookHandler extends AbstractProcessingHandler
         $this->slackRecord = new SlackRecord(
             $channel,
             $username,
+            $iconEmoji
+        );
+
+        // Use the SlackFormatter by default
+        $this->setFormatter(new SlackFormatter(
             $useAttachment,
-            $iconEmoji,
             $useShortAttachment,
             $includeContextAndExtra,
             $excludeFields
-        );
+        ));
     }
 
     public function getSlackRecord(): SlackRecord
@@ -110,21 +114,5 @@ class SlackWebhookHandler extends AbstractProcessingHandler
         curl_setopt_array($ch, $options);
 
         Curl\Util::execute($ch);
-    }
-
-    public function setFormatter(FormatterInterface $formatter): HandlerInterface
-    {
-        parent::setFormatter($formatter);
-        $this->slackRecord->setFormatter($formatter);
-
-        return $this;
-    }
-
-    public function getFormatter(): FormatterInterface
-    {
-        $formatter = parent::getFormatter();
-        $this->slackRecord->setFormatter($formatter);
-
-        return $formatter;
     }
 }

--- a/tests/Monolog/Formatter/SlackFormatterTest.php
+++ b/tests/Monolog/Formatter/SlackFormatterTest.php
@@ -1,0 +1,295 @@
+<?php
+
+
+namespace Monolog\Formatter;
+
+use Monolog\Logger;
+use Monolog\Test\TestCase;
+
+/**
+ * @covers \Monolog\Formatter\SlackFormatter
+ */
+class SlackFormatterTest extends TestCase
+{
+    public function dataGetAttachmentColor()
+    {
+        return array(
+            array(Logger::DEBUG, SlackFormatter::COLOR_DEFAULT),
+            array(Logger::INFO, SlackFormatter::COLOR_GOOD),
+            array(Logger::NOTICE, SlackFormatter::COLOR_GOOD),
+            array(Logger::WARNING, SlackFormatter::COLOR_WARNING),
+            array(Logger::ERROR, SlackFormatter::COLOR_DANGER),
+            array(Logger::CRITICAL, SlackFormatter::COLOR_DANGER),
+            array(Logger::ALERT, SlackFormatter::COLOR_DANGER),
+            array(Logger::EMERGENCY, SlackFormatter::COLOR_DANGER),
+        );
+    }
+
+    /**
+     * @dataProvider dataGetAttachmentColor
+     */
+    public function testGetAttachmentColor($logLevel, $expectedColour)
+    {
+        $slackFormatter = new SlackFormatter();
+        $this->assertSame(
+            $expectedColour,
+            $slackFormatter->getAttachmentColor($logLevel)
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function dataStringify()
+    {
+        $multipleDimensions = array(array(1, 2));
+        $numericKeys = array('library' => 'monolog');
+        $singleDimension = array(1, 'Hello', 'Jordi');
+
+        return array(
+            array(array(), '[]'),
+            array($multipleDimensions, json_encode($multipleDimensions, JSON_PRETTY_PRINT)),
+            array($numericKeys, json_encode($numericKeys, JSON_PRETTY_PRINT)),
+            array($singleDimension, json_encode($singleDimension)),
+        );
+    }
+
+    /**
+     * @dataProvider dataStringify
+     */
+    public function testStringify($fields, $expectedResult)
+    {
+        $slackRecord = new SlackFormatter(true, true, true);
+
+        $this->assertSame($expectedResult, $slackRecord->stringify($fields));
+    }
+
+    public function testAttachmentsNotPresentIfNoAttachment()
+    {
+        $record = new SlackFormatter(false);
+        $data = $record->format($this->getRecord());
+
+        $this->assertArrayNotHasKey('attachments', $data);
+    }
+
+    public function testAddsOneAttachment()
+    {
+        $record = new SlackFormatter();
+        $data = $record->format($this->getRecord());
+
+        $this->assertArrayHasKey('attachments', $data);
+        $this->assertArrayHasKey(0, $data['attachments']);
+        $this->assertIsArray($data['attachments'][0]);
+    }
+
+    public function testTextEqualsMessageIfNoAttachment()
+    {
+        $message = 'Test message';
+        $record = new SlackFormatter(false);
+        $data = $record->format($this->getRecord(Logger::WARNING, $message));
+
+        $this->assertArrayHasKey('text', $data);
+        $this->assertSame($message, $data['text']);
+    }
+
+    public function testAddsFallbackAndTextToAttachment()
+    {
+        $message = 'Test message';
+        $record = new SlackFormatter();
+        $data = $record->format($this->getRecord(Logger::WARNING, $message));
+
+        $this->assertSame($message, $data['attachments'][0]['text']);
+        $this->assertSame($message, $data['attachments'][0]['fallback']);
+    }
+
+    public function testMapsLevelToColorAttachmentColor()
+    {
+        $record = new SlackFormatter();
+        $errorLoggerRecord = $this->getRecord(Logger::ERROR);
+        $emergencyLoggerRecord = $this->getRecord(Logger::EMERGENCY);
+        $warningLoggerRecord = $this->getRecord(Logger::WARNING);
+        $infoLoggerRecord = $this->getRecord(Logger::INFO);
+        $debugLoggerRecord = $this->getRecord(Logger::DEBUG);
+
+        $data = $record->format($errorLoggerRecord);
+        $this->assertSame(SlackFormatter::COLOR_DANGER, $data['attachments'][0]['color']);
+
+        $data = $record->format($emergencyLoggerRecord);
+        $this->assertSame(SlackFormatter::COLOR_DANGER, $data['attachments'][0]['color']);
+
+        $data = $record->format($warningLoggerRecord);
+        $this->assertSame(SlackFormatter::COLOR_WARNING, $data['attachments'][0]['color']);
+
+        $data = $record->format($infoLoggerRecord);
+        $this->assertSame(SlackFormatter::COLOR_GOOD, $data['attachments'][0]['color']);
+
+        $data = $record->format($debugLoggerRecord);
+        $this->assertSame(SlackFormatter::COLOR_DEFAULT, $data['attachments'][0]['color']);
+    }
+
+    public function testAddsShortAttachmentWithoutContextAndExtra()
+    {
+        $level = Logger::ERROR;
+        $levelName = Logger::getLevelName($level);
+        $record = new SlackFormatter(true, true);
+        $data = $record->format($this->getRecord($level, 'test', array('test' => 1)));
+
+        $attachment = $data['attachments'][0];
+        $this->assertArrayHasKey('title', $attachment);
+        $this->assertArrayHasKey('fields', $attachment);
+        $this->assertSame($levelName, $attachment['title']);
+        $this->assertSame(array(), $attachment['fields']);
+    }
+
+
+    public function testAddsShortAttachmentWithContextAndExtra()
+    {
+        $level = Logger::ERROR;
+        $levelName = Logger::getLevelName($level);
+        $context = array('test' => 1);
+        $extra = array('tags' => array('web'));
+        $record = new SlackFormatter(true, true, true);
+        $loggerRecord = $this->getRecord($level, 'test', $context);
+        $loggerRecord['extra'] = $extra;
+        $data = $record->format($loggerRecord);
+
+        $attachment = $data['attachments'][0];
+        $this->assertArrayHasKey('title', $attachment);
+        $this->assertArrayHasKey('fields', $attachment);
+        $this->assertCount(2, $attachment['fields']);
+        $this->assertSame($levelName, $attachment['title']);
+        $this->assertSame(
+            array(
+                array(
+                    'title' => 'Extra',
+                    'value' => sprintf('```%s```', json_encode($extra, JSON_PRETTY_PRINT)),
+                    'short' => false,
+                ),
+                array(
+                    'title' => 'Context',
+                    'value' => sprintf('```%s```', json_encode($context, JSON_PRETTY_PRINT)),
+                    'short' => false,
+                ),
+            ),
+            $attachment['fields']
+        );
+    }
+
+    public function testAddsLongAttachmentWithoutContextAndExtra()
+    {
+        $level = Logger::ERROR;
+        $levelName = Logger::getLevelName($level);
+        $record = new SlackFormatter(true);
+        $data = $record->format($this->getRecord($level, 'test', array('test' => 1)));
+
+        $attachment = $data['attachments'][0];
+        $this->assertArrayHasKey('title', $attachment);
+        $this->assertArrayHasKey('fields', $attachment);
+        $this->assertCount(1, $attachment['fields']);
+        $this->assertSame('Message', $attachment['title']);
+        $this->assertSame(
+            array(array(
+                'title' => 'Level',
+                'value' => $levelName,
+                'short' => false,
+            )),
+            $attachment['fields']
+        );
+    }
+
+    public function testAddsLongAttachmentWithContextAndExtra()
+    {
+        $level = Logger::ERROR;
+        $levelName = Logger::getLevelName($level);
+        $context = array('test' => 1);
+        $extra = array('tags' => array('web'));
+        $record = new SlackFormatter(true, false, true);
+        $loggerRecord = $this->getRecord($level, 'test', $context);
+        $loggerRecord['extra'] = $extra;
+        $data = $record->format($loggerRecord);
+
+        $expectedFields = array(
+            array(
+                'title' => 'Level',
+                'value' => $levelName,
+                'short' => false,
+            ),
+            array(
+                'title' => 'Tags',
+                'value' => sprintf('```%s```', json_encode($extra['tags'])),
+                'short' => false,
+            ),
+            array(
+                'title' => 'Test',
+                'value' => $context['test'],
+                'short' => false,
+            ),
+        );
+
+        $attachment = $data['attachments'][0];
+        $this->assertArrayHasKey('title', $attachment);
+        $this->assertArrayHasKey('fields', $attachment);
+        $this->assertCount(3, $attachment['fields']);
+        $this->assertSame('Message', $attachment['title']);
+        $this->assertSame(
+            $expectedFields,
+            $attachment['fields']
+        );
+    }
+
+    public function testAddsTimestampToAttachment()
+    {
+        $record = $this->getRecord();
+        $slackRecord = new SlackFormatter();
+        $data = $slackRecord->format($this->getRecord());
+
+        $attachment = $data['attachments'][0];
+        $this->assertArrayHasKey('ts', $attachment);
+        $this->assertSame($record['datetime']->getTimestamp(), $attachment['ts']);
+    }
+
+    public function testContextHasException()
+    {
+        $record = $this->getRecord(Logger::CRITICAL, 'This is a critical message.', array('exception' => new \Exception()));
+        $slackRecord = new SlackFormatter( true, false, true);
+        $data = $slackRecord->format($record);
+        $this->assertIsString($data['attachments'][0]['fields'][1]['value']);
+    }
+
+    public function testExcludeExtraAndContextFields()
+    {
+        $record = $this->getRecord(
+            Logger::WARNING,
+            'test',
+            array('info' => array('library' => 'monolog', 'author' => 'Jordi'))
+        );
+        $record['extra'] = array('tags' => array('web', 'cli'));
+
+        $slackRecord = new SlackFormatter(
+            true,
+            false,
+            true,
+            array('context.info.library', 'extra.absent', 'extra.tags.1')
+        );
+        $data = $slackRecord->format($record);
+        $attachment = $data['attachments'][0];
+
+        $expected = array(
+            array(
+                'title' => 'Info',
+                'value' => sprintf('```%s```', json_encode(array('author' => 'Jordi'), JSON_PRETTY_PRINT)),
+                'short' => false,
+            ),
+            array(
+                'title' => 'Tags',
+                'value' => sprintf('```%s```', json_encode(array('web'))),
+                'short' => false,
+            ),
+        );
+
+        foreach ($expected as $field) {
+            $this->assertNotFalse(array_search($field, $attachment['fields']));
+            break;
+        }
+    }
+}

--- a/tests/Monolog/Handler/Slack/SlackRecordTest.php
+++ b/tests/Monolog/Handler/Slack/SlackRecordTest.php
@@ -11,43 +11,15 @@
 
 namespace Monolog\Handler\Slack;
 
+use InvalidArgumentException;
 use Monolog\Logger;
 use Monolog\Test\TestCase;
 
 /**
- * @coversDefaultClass Monolog\Handler\Slack\SlackRecord
+ * @covers \Monolog\Handler\Slack\SlackRecord
  */
 class SlackRecordTest extends TestCase
 {
-    public function dataGetAttachmentColor()
-    {
-        return array(
-            array(Logger::DEBUG, SlackRecord::COLOR_DEFAULT),
-            array(Logger::INFO, SlackRecord::COLOR_GOOD),
-            array(Logger::NOTICE, SlackRecord::COLOR_GOOD),
-            array(Logger::WARNING, SlackRecord::COLOR_WARNING),
-            array(Logger::ERROR, SlackRecord::COLOR_DANGER),
-            array(Logger::CRITICAL, SlackRecord::COLOR_DANGER),
-            array(Logger::ALERT, SlackRecord::COLOR_DANGER),
-            array(Logger::EMERGENCY, SlackRecord::COLOR_DANGER),
-        );
-    }
-
-    /**
-     * @dataProvider dataGetAttachmentColor
-     * @param int    $logLevel
-     * @param string $expectedColour RGB hex color or name of Slack color
-     * @covers ::getAttachmentColor
-     */
-    public function testGetAttachmentColor($logLevel, $expectedColour)
-    {
-        $slackRecord = new SlackRecord();
-        $this->assertSame(
-            $expectedColour,
-            $slackRecord->getAttachmentColor($logLevel)
-        );
-    }
-
     public function testAddsChannel()
     {
         $channel = '#test';
@@ -64,40 +36,6 @@ class SlackRecordTest extends TestCase
         $data = $record->getSlackData($this->getRecord());
 
         $this->assertArrayNotHasKey('username', $data);
-    }
-
-    /**
-     * @return array
-     */
-    public function dataStringify()
-    {
-        $multipleDimensions = array(array(1, 2));
-        $numericKeys = array('library' => 'monolog');
-        $singleDimension = array(1, 'Hello', 'Jordi');
-
-        return array(
-            array(array(), '[]'),
-            array($multipleDimensions, json_encode($multipleDimensions, JSON_PRETTY_PRINT)),
-            array($numericKeys, json_encode($numericKeys, JSON_PRETTY_PRINT)),
-            array($singleDimension, json_encode($singleDimension)),
-        );
-    }
-
-    /**
-     * @dataProvider dataStringify
-     */
-    public function testStringify($fields, $expectedResult)
-    {
-        $slackRecord = new SlackRecord(
-            '#test',
-            'test',
-            true,
-            null,
-            true,
-            true
-        );
-
-        $this->assertSame($expectedResult, $slackRecord->stringify($fields));
     }
 
     public function testAddsCustomUsername()
@@ -121,10 +59,10 @@ class SlackRecordTest extends TestCase
     public function testAddsIcon()
     {
         $record = $this->getRecord();
-        $slackRecord = new SlackRecord(null, null, false, 'ghost');
+        $slackRecord = new SlackRecord(null, null, 'ghost');
         $data = $slackRecord->getSlackData($record);
 
-        $slackRecord2 = new SlackRecord(null, null, false, 'http://github.com/Seldaek/monolog');
+        $slackRecord2 = new SlackRecord(null, null, 'http://github.com/Seldaek/monolog');
         $data2 = $slackRecord2->getSlackData($record);
 
         $this->assertArrayHasKey('icon_emoji', $data);
@@ -133,258 +71,79 @@ class SlackRecordTest extends TestCase
         $this->assertSame('http://github.com/Seldaek/monolog', $data2['icon_url']);
     }
 
-    public function testAttachmentsNotPresentIfNoAttachment()
+    public function testCanCreateMessageFromFormattedString()
     {
-        $record = new SlackRecord(null, null, false);
-        $data = $record->getSlackData($this->getRecord());
+        $record = $this->getRecord(Logger::WARNING, 'Discarded message');
+        $record['formatted'] = 'Formatted message';
 
-        $this->assertArrayNotHasKey('attachments', $data);
-    }
-
-    public function testAddsOneAttachment()
-    {
-        $record = new SlackRecord();
-        $data = $record->getSlackData($this->getRecord());
-
-        $this->assertArrayHasKey('attachments', $data);
-        $this->assertArrayHasKey(0, $data['attachments']);
-        $this->assertIsArray($data['attachments'][0]);
-    }
-
-    public function testTextEqualsMessageIfNoAttachment()
-    {
-        $message = 'Test message';
-        $record = new SlackRecord(null, null, false);
-        $data = $record->getSlackData($this->getRecord(Logger::WARNING, $message));
-
-        $this->assertArrayHasKey('text', $data);
-        $this->assertSame($message, $data['text']);
-    }
-
-    public function testTextEqualsFormatterOutput()
-    {
-        $formatter = $this->createMock('Monolog\\Formatter\\FormatterInterface');
-        $formatter
-            ->expects($this->any())
-            ->method('format')
-            ->will($this->returnCallback(function ($record) {
-                return $record['message'] . 'test';
-            }));
-
-        $formatter2 = $this->createMock('Monolog\\Formatter\\FormatterInterface');
-        $formatter2
-            ->expects($this->any())
-            ->method('format')
-            ->will($this->returnCallback(function ($record) {
-                return $record['message'] . 'test1';
-            }));
-
-        $message = 'Test message';
-        $record = new SlackRecord(null, null, false, null, false, false, array(), $formatter);
-        $data = $record->getSlackData($this->getRecord(Logger::WARNING, $message));
-
-        $this->assertArrayHasKey('text', $data);
-        $this->assertSame($message . 'test', $data['text']);
-
-        $record->setFormatter($formatter2);
-        $data = $record->getSlackData($this->getRecord(Logger::WARNING, $message));
-
-        $this->assertArrayHasKey('text', $data);
-        $this->assertSame($message . 'test1', $data['text']);
-    }
-
-    public function testAddsFallbackAndTextToAttachment()
-    {
-        $message = 'Test message';
-        $record = new SlackRecord(null);
-        $data = $record->getSlackData($this->getRecord(Logger::WARNING, $message));
-
-        $this->assertSame($message, $data['attachments'][0]['text']);
-        $this->assertSame($message, $data['attachments'][0]['fallback']);
-    }
-
-    public function testMapsLevelToColorAttachmentColor()
-    {
-        $record = new SlackRecord(null);
-        $errorLoggerRecord = $this->getRecord(Logger::ERROR);
-        $emergencyLoggerRecord = $this->getRecord(Logger::EMERGENCY);
-        $warningLoggerRecord = $this->getRecord(Logger::WARNING);
-        $infoLoggerRecord = $this->getRecord(Logger::INFO);
-        $debugLoggerRecord = $this->getRecord(Logger::DEBUG);
-
-        $data = $record->getSlackData($errorLoggerRecord);
-        $this->assertSame(SlackRecord::COLOR_DANGER, $data['attachments'][0]['color']);
-
-        $data = $record->getSlackData($emergencyLoggerRecord);
-        $this->assertSame(SlackRecord::COLOR_DANGER, $data['attachments'][0]['color']);
-
-        $data = $record->getSlackData($warningLoggerRecord);
-        $this->assertSame(SlackRecord::COLOR_WARNING, $data['attachments'][0]['color']);
-
-        $data = $record->getSlackData($infoLoggerRecord);
-        $this->assertSame(SlackRecord::COLOR_GOOD, $data['attachments'][0]['color']);
-
-        $data = $record->getSlackData($debugLoggerRecord);
-        $this->assertSame(SlackRecord::COLOR_DEFAULT, $data['attachments'][0]['color']);
-    }
-
-    public function testAddsShortAttachmentWithoutContextAndExtra()
-    {
-        $level = Logger::ERROR;
-        $levelName = Logger::getLevelName($level);
-        $record = new SlackRecord(null, null, true, null, true);
-        $data = $record->getSlackData($this->getRecord($level, 'test', array('test' => 1)));
-
-        $attachment = $data['attachments'][0];
-        $this->assertArrayHasKey('title', $attachment);
-        $this->assertArrayHasKey('fields', $attachment);
-        $this->assertSame($levelName, $attachment['title']);
-        $this->assertSame(array(), $attachment['fields']);
-    }
-
-    public function testAddsShortAttachmentWithContextAndExtra()
-    {
-        $level = Logger::ERROR;
-        $levelName = Logger::getLevelName($level);
-        $context = array('test' => 1);
-        $extra = array('tags' => array('web'));
-        $record = new SlackRecord(null, null, true, null, true, true);
-        $loggerRecord = $this->getRecord($level, 'test', $context);
-        $loggerRecord['extra'] = $extra;
-        $data = $record->getSlackData($loggerRecord);
-
-        $attachment = $data['attachments'][0];
-        $this->assertArrayHasKey('title', $attachment);
-        $this->assertArrayHasKey('fields', $attachment);
-        $this->assertCount(2, $attachment['fields']);
-        $this->assertSame($levelName, $attachment['title']);
-        $this->assertSame(
-            array(
-                array(
-                    'title' => 'Extra',
-                    'value' => sprintf('```%s```', json_encode($extra, JSON_PRETTY_PRINT)),
-                    'short' => false,
-                ),
-                array(
-                    'title' => 'Context',
-                    'value' => sprintf('```%s```', json_encode($context, JSON_PRETTY_PRINT)),
-                    'short' => false,
-                ),
-            ),
-            $attachment['fields']
-        );
-    }
-
-    public function testAddsLongAttachmentWithoutContextAndExtra()
-    {
-        $level = Logger::ERROR;
-        $levelName = Logger::getLevelName($level);
-        $record = new SlackRecord(null, null, true, null);
-        $data = $record->getSlackData($this->getRecord($level, 'test', array('test' => 1)));
-
-        $attachment = $data['attachments'][0];
-        $this->assertArrayHasKey('title', $attachment);
-        $this->assertArrayHasKey('fields', $attachment);
-        $this->assertCount(1, $attachment['fields']);
-        $this->assertSame('Message', $attachment['title']);
-        $this->assertSame(
-            array(array(
-                'title' => 'Level',
-                'value' => $levelName,
-                'short' => false,
-            )),
-            $attachment['fields']
-        );
-    }
-
-    public function testAddsLongAttachmentWithContextAndExtra()
-    {
-        $level = Logger::ERROR;
-        $levelName = Logger::getLevelName($level);
-        $context = array('test' => 1);
-        $extra = array('tags' => array('web'));
-        $record = new SlackRecord(null, null, true, null, false, true);
-        $loggerRecord = $this->getRecord($level, 'test', $context);
-        $loggerRecord['extra'] = $extra;
-        $data = $record->getSlackData($loggerRecord);
-
-        $expectedFields = array(
-            array(
-                'title' => 'Level',
-                'value' => $levelName,
-                'short' => false,
-            ),
-            array(
-                'title' => 'Tags',
-                'value' => sprintf('```%s```', json_encode($extra['tags'])),
-                'short' => false,
-            ),
-            array(
-                'title' => 'Test',
-                'value' => $context['test'],
-                'short' => false,
-            ),
-        );
-
-        $attachment = $data['attachments'][0];
-        $this->assertArrayHasKey('title', $attachment);
-        $this->assertArrayHasKey('fields', $attachment);
-        $this->assertCount(3, $attachment['fields']);
-        $this->assertSame('Message', $attachment['title']);
-        $this->assertSame(
-            $expectedFields,
-            $attachment['fields']
-        );
-    }
-
-    public function testAddsTimestampToAttachment()
-    {
-        $record = $this->getRecord();
-        $slackRecord = new SlackRecord();
-        $data = $slackRecord->getSlackData($this->getRecord());
-
-        $attachment = $data['attachments'][0];
-        $this->assertArrayHasKey('ts', $attachment);
-        $this->assertSame($record['datetime']->getTimestamp(), $attachment['ts']);
-    }
-
-    public function testContextHasException()
-    {
-        $record = $this->getRecord(Logger::CRITICAL, 'This is a critical message.', array('exception' => new \Exception()));
-        $slackRecord = new SlackRecord(null, null, true, null, false, true);
+        $slackRecord = new SlackRecord(null, null, null);
         $data = $slackRecord->getSlackData($record);
-        $this->assertIsString($data['attachments'][0]['fields'][1]['value']);
+
+        $this->assertArrayHasKey('text', $data);
+        $this->assertSame('Formatted message', $data['text']);
     }
 
-    public function testExcludeExtraAndContextFields()
+    public function testCanCreateMessageFromPartialSchema()
     {
-        $record = $this->getRecord(
-            Logger::WARNING,
-            'test',
-            array('info' => array('library' => 'monolog', 'author' => 'Jordi'))
+        $record = $this->getRecord(Logger::WARNING, 'a message');
+        $record['formatted'] = [
+            'text' => 'Some text',
+            'attachments' => [
+                'text' => 'attachment text',
+            ],
+        ];
+
+        $slackRecord = new SlackRecord('channel1','Tom');
+        $message = $slackRecord->getSlackData($record);
+
+        $this->assertEquals(
+            [
+                'channel' => 'channel1',
+                'username' => 'Tom',
+                'text' => 'Some text',
+                'attachments' => [
+                    'text' => 'attachment text',
+                ],
+            ],
+            $message
         );
-        $record['extra'] = array('tags' => array('web', 'cli'));
+    }
 
-        $slackRecord = new SlackRecord(null, null, true, null, false, true, array('context.info.library', 'extra.tags.1'));
-        $data = $slackRecord->getSlackData($record);
-        $attachment = $data['attachments'][0];
+    public function testCantCreateMessageFromObject()
+    {
+        $record = $this->getRecord(Logger::WARNING, 'a message');
+        $record['formatted'] = (object) [
+            'a' => 1,
+            'b' => 2,
+        ];
 
-        $expected = array(
-            array(
-                'title' => 'Info',
-                'value' => sprintf('```%s```', json_encode(array('author' => 'Jordi'), JSON_PRETTY_PRINT)),
-                'short' => false,
-            ),
-            array(
-                'title' => 'Tags',
-                'value' => sprintf('```%s```', json_encode(array('web'))),
-                'short' => false,
-            ),
-        );
+        $slackRecord = new SlackRecord('channel1','Tom');
 
-        foreach ($expected as $field) {
-            $this->assertNotFalse(array_search($field, $attachment['fields']));
-            break;
+        try {
+            $slackRecord->getSlackData($record);
+            $this->fail('Expected an exception');
+        } catch (InvalidArgumentException $e) {
+            $this->assertEquals(
+                'Expected formatter to return a scalar or a slack message array. Instead got type object',
+                $e->getMessage()
+            );
         }
+    }
+
+    public function testFallbackToMessageWithoutFormatter()
+    {
+        $record = $this->getRecord(Logger::WARNING, 'a message');
+
+        $slackRecord = new SlackRecord('channel1','Tom');
+        $message = $slackRecord->getSlackData($record);
+
+        $this->assertEquals(
+            [
+                'channel' => 'channel1',
+                'username' => 'Tom',
+                'text' => 'a message',
+            ],
+            $message
+        );
     }
 }

--- a/tests/Monolog/Handler/SlackHandlerTest.php
+++ b/tests/Monolog/Handler/SlackHandlerTest.php
@@ -148,7 +148,5 @@ class SlackHandlerTest extends TestCase
         $this->handler->expects($this->any())
             ->method('closeSocket')
             ->will($this->returnValue(true));
-
-        $this->handler->setFormatter($this->getIdentityFormatter());
     }
 }

--- a/tests/Monolog/Handler/SlackWebhookHandlerTest.php
+++ b/tests/Monolog/Handler/SlackWebhookHandlerTest.php
@@ -33,6 +33,9 @@ class SlackWebhookHandlerTest extends TestCase
     {
         $handler = new SlackWebhookHandler(self::WEBHOOK_URL);
         $record = $this->getRecord();
+        // Pass the record through the default SlackWebhookHandler formatter
+        $record['formatted'] = $handler->getFormatter()->format($record);
+
         $slackRecord = $handler->getSlackRecord();
         $this->assertInstanceOf('Monolog\Handler\Slack\SlackRecord', $slackRecord);
         $this->assertEquals(array(
@@ -75,13 +78,17 @@ class SlackWebhookHandlerTest extends TestCase
         );
 
         $slackRecord = $handler->getSlackRecord();
+        $record = $this->getRecord();
+        // Pass the record through the default SlackWebhookHandler formatter
+        $record['formatted'] = $handler->getFormatter()->format($record);
+
         $this->assertInstanceOf('Monolog\Handler\Slack\SlackRecord', $slackRecord);
         $this->assertEquals(array(
             'username' => 'test-username',
             'text' => 'test',
             'channel' => 'test-channel',
             'icon_emoji' => ':ghost:',
-        ), $slackRecord->getSlackData($this->getRecord()));
+        ), $slackRecord->getSlackData($record));
     }
 
     /**


### PR DESCRIPTION
Moves the message formatting parts of SlackRecord into SlackFormatter. This allows the SlackFormatter to be swapped out by users to create new message formats.

100% coverage on SlackFormatter and SlackRecord.

Api Changes:

- Deprecates:
  - SlackHandler::useAttachment
  - SlackHandler::useShortAttachment
  - SlackHandler::includeContextAndExtra
  - SlackHandler::excludeFields
  - SlackRecord::COLOR_*

Doesn't deprecate the arguments in SlackHandler's constructor or SlackWebhookHandler's constructor, as the SlackFormatter is created by default to preserve the majority of use-cases.

- Breaking API Changes:
  - When using SetFormatter on SlackHandler or SlackWebhookHandler. Doing so will mean useAttachment, useShortAttachment, includeContextAndExtra, and excludeFields are all ignored, and any formatted text produced by the formatter will be directly added to the text in the sent slack message.
  - SlackRecord's useAttachment, useShortAttachment, includeContextAndExtra, and excludeFields.
  - Direct usage of SlackRecord will result in different outputs, however messages sent by SlackHandler and SlackWebhookHandler are preserved.

Benefits:
  - Users can now easily design and create their own slack message formatters, which can produce any kind of slack message, including e.g. using the new Blocks api: https://api.slack.com/reference/block-kit/blocks