### PR TITLE
Mark FormattableHandlerTrait::$formatter as nullable

### DIFF
--- a/src/Monolog/Handler/FormattableHandlerTrait.php
+++ b/src/Monolog/Handler/FormattableHandlerTrait.php
@@ -22,9 +22,9 @@ use Monolog\Formatter\LineFormatter;
 trait FormattableHandlerTrait
 {
     /**
-     * @var FormatterInterface
+     * @var ?FormatterInterface
      */
-    protected $formatter;
+    protected $formatter = null;
 
     /**
      * {@inheritdoc}

--- a/src/Monolog/Handler/FormattableHandlerTrait.php
+++ b/src/Monolog/Handler/FormattableHandlerTrait.php
@@ -24,7 +24,7 @@ trait FormattableHandlerTrait
     /**
      * @var ?FormatterInterface
      */
-    protected $formatter = null;
+    protected $formatter;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
This fixes a Psalm error at level 2 and above when extending `AbstractProcessingHandler`:

```
$formatter is not defined in constructor...and in any private or final methods called in the constructor (see https://psalm.dev/074)
```