### PR TITLE
Add Datadog integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.2.0 (not yet released)
+
+  * Added integration with Datadog by providing a `DatadogHandler` and a `DatadogFormatter`
+
 ### 2.1.1 (2020-07-23)
 
   * Fixed removing of json encoding options

--- a/doc/02-handlers-formatters-processors.md
+++ b/doc/02-handlers-formatters-processors.md
@@ -155,7 +155,7 @@
 - [_FlowdockFormatter_](../src/Monolog/Formatter/FlowdockFormatter.php): Used to format log records into Flowdock messages, only useful for the FlowdockHandler.
 - [_MongoDBFormatter_](../src/Monolog/Formatter/MongoDBFormatter.php): Converts \DateTime instances to \MongoDate and objects recursively to arrays, only useful with the MongoDBHandler.
 - [_LogmaticFormatter_](../src/Monolog/Formatter/LogmaticFormatter.php): User to format log records to [Logmatic](http://logmatic.io/) messages, only useful for the LogmaticHandler.
-- [_Datadog_Formatter_](../src/Monolog/Formatter/DatadogFormatter.php): Used to format log records into [Datadog](https://www.datadoghq.com/) event json, with some [special](https://docs.datadoghq.com/logs/log_collection/?tab=http#how-to-get-the-most-of-your-application-logs) & [reserved](https://docs.datadoghq.com/logs/log_collection/?tab=http#reserved-attributes) attributes from Datadog.
+- [_Datadog_Formatter_](../src/Monolog/Formatter/DatadogFormatter.php): Used to format log records into [Datadog](https://www.datadoghq.com/) (JSON format), with some [special](https://docs.datadoghq.com/logs/log_collection/?tab=http#how-to-get-the-most-of-your-application-logs) & [reserved](https://docs.datadoghq.com/logs/log_collection/?tab=http#reserved-attributes) attributes from Datadog.
 
 ## Processors
 

--- a/doc/02-handlers-formatters-processors.md
+++ b/doc/02-handlers-formatters-processors.md
@@ -62,6 +62,7 @@
 - [_SqsHandler_](../src/Monolog/Handler/SqsHandler.php): Logs records to an [AWS SQS](http://docs.aws.amazon.com/aws-sdk-php/v2/guide/service-sqs.html) queue.
 - [_RavenHandler_](../src/Monolog/Handler/RavenHandler.php): Logs records to a [Sentry](http://getsentry.com/) server using
   [raven](https://packagist.org/packages/raven/raven). **Deprecated** and removed in Monolog 2.0, use sentry/sentry 2.x and the [Sentry\Monolog\Handler](https://github.com/getsentry/sentry-php/blob/master/src/Monolog/Handler.php) class instead.
+- [_DatadogHandler_](../src/Monolog/Handler/DatadogHandler.php): Logs records to a [Datadog](https://www.datadoghq.com/) account.
 
 ### Logging in development
 
@@ -110,8 +111,8 @@
    application to crash and may wish to continue to log to other handlers.
 - [_FallbackGroupHandler_](../src/Monolog/Handler/FallbackGroupHandler.php): This handler extends the _GroupHandler_ ignoring
    exceptions raised by each child handler, until one has handled without throwing.
-   This allows you to ignore issues where a remote tcp connection may have died 
-   but you do not want your entire application to crash and may wish to continue 
+   This allows you to ignore issues where a remote tcp connection may have died
+   but you do not want your entire application to crash and may wish to continue
    to attempt log to other handlers, until one does not throw.
 - [_BufferHandler_](../src/Monolog/Handler/BufferHandler.php): This handler will buffer all the log records it receives
   until `close()` is called at which point it will call `handleBatch()` on the
@@ -154,6 +155,7 @@
 - [_FlowdockFormatter_](../src/Monolog/Formatter/FlowdockFormatter.php): Used to format log records into Flowdock messages, only useful for the FlowdockHandler.
 - [_MongoDBFormatter_](../src/Monolog/Formatter/MongoDBFormatter.php): Converts \DateTime instances to \MongoDate and objects recursively to arrays, only useful with the MongoDBHandler.
 - [_LogmaticFormatter_](../src/Monolog/Formatter/LogmaticFormatter.php): User to format log records to [Logmatic](http://logmatic.io/) messages, only useful for the LogmaticHandler.
+- [_Datadog_Formatter_](../src/Monolog/Formatter/DatadogFormatter.php): Used to format log records into [Datadog](https://www.datadoghq.com/) event json, with some [special](https://docs.datadoghq.com/logs/log_collection/?tab=http#how-to-get-the-most-of-your-application-logs) & [reserved](https://docs.datadoghq.com/logs/log_collection/?tab=http#reserved-attributes) attributes from Datadog.
 
 ## Processors
 

--- a/src/Monolog/Formatter/DatadogFormatter.php
+++ b/src/Monolog/Formatter/DatadogFormatter.php
@@ -94,7 +94,7 @@ class DatadogFormatter extends NormalizerFormatter
         }
 
         if (null !== $this->env) {
-            $record['env'] = $this->applicationName;
+            $record['env'] = $this->env;
         }
 
         if (!empty($record['context'] && !empty($record['context']['exception']) && !empty($record['context']['exception']['class']))) {

--- a/src/Monolog/Formatter/DatadogFormatter.php
+++ b/src/Monolog/Formatter/DatadogFormatter.php
@@ -50,7 +50,7 @@ class DatadogFormatter extends NormalizerFormatter
      * @param string|null $applicationName The name of the application or service generating the log events used as the "source" Datadog attribute.
      *                                     It is used to switch from Logs to APM, so make sure you define the same value when you use both products.
      * @param string|null $systemName      The system/machine name, used as the "host" field of Datadog, defaults to the hostname of the machine
-     * @param string|null $env               The environment name used as the "env" field of Datadog
+     * @param string|null $env             The environment name used as the "env" field of Datadog
      * @param string|null $source          This corresponds to the integration name: the technology from which the log originated.
      *                                     Must be one of the "Pipeline Library" (https://app.datadoghq.eu/logs/pipelines/pipeline/library)
      * @param string|null $loggerName      Name of the logger, defaults to monolog

--- a/src/Monolog/Formatter/DatadogFormatter.php
+++ b/src/Monolog/Formatter/DatadogFormatter.php
@@ -50,7 +50,7 @@ class DatadogFormatter extends NormalizerFormatter
      * @param string|null $applicationName The name of the application or service generating the log events used as the "source" Datadog attribute.
      *                                     It is used to switch from Logs to APM, so make sure you define the same value when you use both products.
      * @param string|null $systemName      The system/machine name, used as the "host" field of Datadog, defaults to the hostname of the machine
-     * @param string|null $env      The system/machine name, used as the "host" field of Datadog, defaults to the hostname of the machine
+     * @param string|null $env                     The environment name used as the "env" field of Datadog
      * @param string|null $source          This corresponds to the integration name: the technology from which the log originated.
      *                                     Must be one of the "Pipeline Library" (https://app.datadoghq.eu/logs/pipelines/pipeline/library)
      * @param string|null $loggerName      Name of the logger, defaults to monolog

--- a/src/Monolog/Formatter/DatadogFormatter.php
+++ b/src/Monolog/Formatter/DatadogFormatter.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+/**
+ * Serializes a log message to take advantages of Datadog capacities
+ *
+ * @see https://docs.datadoghq.com/logs/log_collection/?tab=http#reserved-attributes
+ * @see https://docs.datadoghq.com/logs/log_collection/?tab=http#how-to-get-the-most-of-your-application-logs
+ *
+ * @author Tristan Bessoussa <tristan.bessoussa@gmail.com>
+ */
+class DatadogFormatter extends NormalizerFormatter
+{
+    /**
+     * @var string|null
+     */
+    protected $systemName;
+
+    /**
+     * @var string|null
+     */
+    protected $applicationName;
+
+    /**
+     * @var string|null
+     */
+    protected $source;
+
+    /**
+     * @var string|null
+     */
+    protected $loggerName;
+
+    /**
+     * @param string|null $applicationName The name of the application or service generating the log events used as the "source" Datadog attribute.
+     *                                     It is used to switch from Logs to APM, so make sure you define the same value when you use both products.
+     * @param string|null $systemName      The system/machine name, used as the "host" field of Datadog, defaults to the hostname of the machine
+     * @param string|null $source          This corresponds to the integration name: the technology from which the log originated.
+     *                                     Must be one of the "Pipeline Library" (https://app.datadoghq.eu/logs/pipelines/pipeline/library)
+     * @param string|null $loggerName      Name of the logger, defaults to monolog
+     */
+    public function __construct(?string $applicationName = null, ?string $systemName = null, ?string $source = 'php', ?string $loggerName = 'monolog')
+    {
+        parent::__construct();
+        $this->systemName = $systemName === null ? gethostname() : $systemName;
+        $this->applicationName = $applicationName;
+        $this->source = $source;
+        $this->loggerName = $loggerName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function format(array $record): string
+    {
+        $record = parent::format($record);
+
+        if (empty($record['logger.name'])) {
+            $record['logger.name'] = $this->loggerName;
+        }
+
+        if (empty($record['host'])) {
+            $record['host'] = $this->systemName;
+        }
+
+        if (empty($record['source'])) {
+            $record['ddsource'] = $this->source;
+        }
+
+        if (isset($record['level_name'])) {
+            $record['status'] = $record['level_name'];
+            unset($record['level_name']);
+        }
+
+        if (null !== $this->applicationName) {
+            $record['service'] = $this->applicationName;
+        }
+
+        if (!empty($record['context'] && !empty($record['context']['exception']) && !empty($record['context']['exception']['class']))) {
+            $record['error.kind'] = $record['context']['exception']['class'];
+        }
+
+        return $this->toJson($record) . "\n";
+    }
+}

--- a/src/Monolog/Formatter/DatadogFormatter.php
+++ b/src/Monolog/Formatter/DatadogFormatter.php
@@ -34,6 +34,11 @@ class DatadogFormatter extends NormalizerFormatter
     /**
      * @var string|null
      */
+    protected $env;
+
+    /**
+     * @var string|null
+     */
     protected $source;
 
     /**
@@ -45,15 +50,17 @@ class DatadogFormatter extends NormalizerFormatter
      * @param string|null $applicationName The name of the application or service generating the log events used as the "source" Datadog attribute.
      *                                     It is used to switch from Logs to APM, so make sure you define the same value when you use both products.
      * @param string|null $systemName      The system/machine name, used as the "host" field of Datadog, defaults to the hostname of the machine
+     * @param string|null $env      The system/machine name, used as the "host" field of Datadog, defaults to the hostname of the machine
      * @param string|null $source          This corresponds to the integration name: the technology from which the log originated.
      *                                     Must be one of the "Pipeline Library" (https://app.datadoghq.eu/logs/pipelines/pipeline/library)
      * @param string|null $loggerName      Name of the logger, defaults to monolog
      */
-    public function __construct(?string $applicationName = null, ?string $systemName = null, ?string $source = 'php', ?string $loggerName = 'monolog')
+    public function __construct(?string $applicationName = null, ?string $systemName = null, ?string $env = null, ?string $source = 'php', ?string $loggerName = 'monolog')
     {
         parent::__construct();
-        $this->systemName = $systemName === null ? gethostname() : $systemName;
         $this->applicationName = $applicationName;
+        $this->systemName = $systemName === null ? gethostname() : $systemName;
+        $this->env = $env;
         $this->source = $source;
         $this->loggerName = $loggerName;
     }
@@ -84,6 +91,10 @@ class DatadogFormatter extends NormalizerFormatter
 
         if (null !== $this->applicationName) {
             $record['service'] = $this->applicationName;
+        }
+
+        if (null !== $this->env) {
+            $record['env'] = $this->applicationName;
         }
 
         if (!empty($record['context'] && !empty($record['context']['exception']) && !empty($record['context']['exception']['class']))) {

--- a/src/Monolog/Formatter/DatadogFormatter.php
+++ b/src/Monolog/Formatter/DatadogFormatter.php
@@ -50,7 +50,7 @@ class DatadogFormatter extends NormalizerFormatter
      * @param string|null $applicationName The name of the application or service generating the log events used as the "source" Datadog attribute.
      *                                     It is used to switch from Logs to APM, so make sure you define the same value when you use both products.
      * @param string|null $systemName      The system/machine name, used as the "host" field of Datadog, defaults to the hostname of the machine
-     * @param string|null $env                     The environment name used as the "env" field of Datadog
+     * @param string|null $env               The environment name used as the "env" field of Datadog
      * @param string|null $source          This corresponds to the integration name: the technology from which the log originated.
      *                                     Must be one of the "Pipeline Library" (https://app.datadoghq.eu/logs/pipelines/pipeline/library)
      * @param string|null $loggerName      Name of the logger, defaults to monolog

--- a/src/Monolog/Handler/DatadogHandler.php
+++ b/src/Monolog/Handler/DatadogHandler.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Logger;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\DatadogFormatter;
+
+/**
+ * Inspired on InsightOpsHandler.
+ *
+ * @see https://docs.datadoghq.com/logs/log_collection/?tab=tcp
+ *
+ * @author Tristan Bessoussa <tristan.bessoussa@gmail.com>
+ */
+class DatadogHandler extends SocketHandler
+{
+    /**
+     * @var string
+     */
+    protected $logToken;
+
+    /**
+     * @param string     $apiKey API key supplied by Datadog
+     * @param string     $region Region where InsightOps account is hosted. Could be 'us' or 'eu'.
+     * @param bool       $useSSL Whether or not SSL encryption should be used
+     * @param string|int $level  The minimum logging level to trigger this handler
+     * @param bool       $bubble Whether or not messages that are handled should bubble up the stack.
+     *
+     * @throws MissingExtensionException If SSL encryption is set to true and OpenSSL is missing
+     */
+    public function __construct(string $apiKey, string $region = 'us', bool $useSSL = true, $level = Logger::DEBUG, bool $bubble = true)
+    {
+        if ($useSSL && !extension_loaded('openssl')) {
+            throw new MissingExtensionException('The OpenSSL PHP plugin is required to use SSL encrypted connection for DatadogHandler');
+        }
+
+        // 'us' is the default region
+        $tld = 'com';
+        if ('eu' === $region) {
+            $tld = 'eu';
+        }
+
+        $endpoint = $useSSL
+            ? 'ssl://tcp-intake.logs.datadoghq.'.$tld.':443'
+            : 'tcp-intake.logs.datadoghq.'.$tld.':1883';
+
+        parent::__construct($endpoint, $level, $bubble);
+        $this->logToken = $apiKey;
+    }
+
+    protected function generateDataStream(array $record): string
+    {
+        return $this->logToken . ' ' . $record['formatted'];
+    }
+
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new DatadogFormatter();
+    }
+}

--- a/tests/Monolog/Formatter/DatadogFormatterTest.php
+++ b/tests/Monolog/Formatter/DatadogFormatterTest.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Monolog\Logger;
+use Monolog\Test\TestCase;
+
+/**
+ * @author Tristan Bessoussa <tristan.bessoussa@gmail.com>
+ */
+class DatadogFormatterTest extends TestCase
+{
+    /**
+     * @covers Monolog\Formatter\DatadogFormatter::format
+     */
+    public function testFormat()
+    {
+        $formatter = new DatadogFormatter('app_test', 'vps-host-1');
+        $record = $this->getRecord();
+
+        $formattedDecoded = json_decode($formatter->format($record), true);
+
+        $this->assertArrayHasKey('ddsource', $formattedDecoded);
+        $this->assertEquals('php', $formattedDecoded['ddsource']);
+
+        $this->assertArrayHasKey('host', $formattedDecoded);
+        $this->assertEquals('vps-host-1', $formattedDecoded['host']);
+
+        $this->assertArrayHasKey('service', $formattedDecoded);
+        $this->assertEquals('app_test', $formattedDecoded['service']);
+
+        $this->assertArrayNotHasKey('level_name', $formattedDecoded);
+        $this->assertArrayHasKey('status', $formattedDecoded);
+        $this->assertEquals(Logger::getLevelName(Logger::WARNING), $formattedDecoded['status']);
+    }
+}

--- a/tests/Monolog/Handler/DatadogHandlerTest.php
+++ b/tests/Monolog/Handler/DatadogHandlerTest.php
@@ -50,8 +50,8 @@ class DatadogHandlerTest extends TestCase
         $this->createHandler();
         $this->handler->handleBatch($records);
 
-        fseek($this->res, 0);
-        $content = fread($this->res, 1024);
+        fseek($this->resource, 0);
+        $content = fread($this->resource, 1024);
 
         $this->assertRegexp('/^testToken \{"message":"Critical write test","context":\[\],"level":500,"channel":"test","datetime":"([^"]+)","extra":\[\],"logger.name":"monolog","host":"([^"]+)","ddsource":"php","status":"CRITICAL"\}\\n$/', $content);
     }

--- a/tests/Monolog/Handler/DatadogHandlerTest.php
+++ b/tests/Monolog/Handler/DatadogHandlerTest.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Test\TestCase;
+use Monolog\Logger;
+
+/**
+ * @author Tristan Bessoussa <tristan.bessoussa@gmail.com>
+ */
+class DatadogHandlerTest extends TestCase
+{
+    /**
+     * @var resource
+     */
+    private $resource;
+
+    /**
+     * @var DatadogHandler
+     */
+    private $handler;
+
+    public function testWriteContent()
+    {
+        $this->createHandler();
+        $this->handler->handle($this->getRecord(Logger::CRITICAL, 'Critical write test'));
+
+        fseek($this->resource, 0);
+        $content = fread($this->resource, 1024);
+
+        $this->assertRegexp('/^testToken \{"message":"Critical write test","context":\[\],"level":500,"channel":"test","datetime":"([^"]+)","extra":\[\],"logger.name":"monolog","host":"([^"]+)","ddsource":"php","status":"CRITICAL"\}\\n$/', $content);
+    }
+
+    public function testWriteBatchContent()
+    {
+        $records = [
+            $this->getRecord(),
+            $this->getRecord(),
+            $this->getRecord(),
+        ];
+        $this->createHandler();
+        $this->handler->handleBatch($records);
+
+        fseek($this->res, 0);
+        $content = fread($this->res, 1024);
+
+        $this->assertRegexp('/^testToken \{"message":"Critical write test","context":\[\],"level":500,"channel":"test","datetime":"([^"]+)","extra":\[\],"logger.name":"monolog","host":"([^"]+)","ddsource":"php","status":"CRITICAL"\}\\n$/', $content);
+    }
+
+    private function createHandler()
+    {
+        $useSSL = extension_loaded('openssl');
+        $args = array('testToken', 'eu', $useSSL, Logger::DEBUG, true);
+        $this->resource = fopen('php://memory', 'a');
+        $this->handler = $this->getMockBuilder(DatadogHandler::class)
+            ->setMethods(array('fsockopen', 'streamSetTimeout', 'closeSocket'))
+            ->setConstructorArgs($args)
+            ->getMock();
+
+        $reflectionProperty = new \ReflectionProperty('\Monolog\Handler\SocketHandler', 'connectionString');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($this->handler, 'localhost:1234');
+
+        $this->handler->expects($this->any())
+            ->method('fsockopen')
+            ->will($this->returnValue($this->resource));
+        $this->handler->expects($this->any())
+            ->method('streamSetTimeout')
+            ->will($this->returnValue(true));
+        $this->handler->expects($this->any())
+            ->method('closeSocket')
+            ->will($this->returnValue(true));
+    }
+}

--- a/tests/Monolog/Handler/DatadogHandlerTest.php
+++ b/tests/Monolog/Handler/DatadogHandlerTest.php
@@ -43,9 +43,9 @@ class DatadogHandlerTest extends TestCase
     public function testWriteBatchContent()
     {
         $records = [
-            $this->getRecord(),
-            $this->getRecord(),
-            $this->getRecord(),
+            $this->getRecord(Logger::CRITICAL, 'Critical write test'),
+            $this->getRecord(Logger::INFO, 'Info write test'),
+            $this->getRecord(Logger::WARNING, 'Warning write test'),
         ];
         $this->createHandler();
         $this->handler->handleBatch($records);
@@ -53,7 +53,12 @@ class DatadogHandlerTest extends TestCase
         fseek($this->resource, 0);
         $content = fread($this->resource, 1024);
 
-        $this->assertRegexp('/^testToken \{"message":"Critical write test","context":\[\],"level":500,"channel":"test","datetime":"([^"]+)","extra":\[\],"logger.name":"monolog","host":"([^"]+)","ddsource":"php","status":"CRITICAL"\}\\n$/', $content);
+        $lines = explode("\n", $content);
+
+        $this->assertRegexp('/^testToken \{"message":"Critical write test","context":\[\],"level":500,"channel":"test","datetime":"([^"]+)","extra":\[\],"logger.name":"monolog","host":"([^"]+)","ddsource":"php","status":"CRITICAL"\}$/', $lines[0]);
+        $this->assertRegexp('/^testToken \{"message":"Info write test","context":\[\],"level":200,"channel":"test","datetime":"([^"]+)","extra":\[\],"logger.name":"monolog","host":"([^"]+)","ddsource":"php","status":"INFO"\}$/', $lines[1]);
+        $this->assertRegexp('/^testToken \{"message":"Warning write test","context":\[\],"level":300,"channel":"test","datetime":"([^"]+)","extra":\[\],"logger.name":"monolog","host":"([^"]+)","ddsource":"php","status":"WARNING"\}$/', $lines[2]);
+        $this->assertSame('', $lines[3]);
     }
 
     private function createHandler()


### PR DESCRIPTION
<p align="center">
  <img width="150"  src="https://user-images.githubusercontent.com/346010/95359396-62dd0500-08ca-11eb-950c-5408e1128ef9.png">
</p>


The [Datadog](https://www.datadoghq.com/) integration was missing.

I added the support by adding a `DatadogHandler` and a `DatadogFormatter` that takes benefit of some of the Datadog features.

Here's what is outputed in the datadog log section: 

### Summary:
![Log_Explorer___Datadog](https://user-images.githubusercontent.com/346010/95358949-e34f3600-08c9-11eb-8289-6680d3e03fa1.png)

### Log details: 
![Log_Explorer___Datadog](https://user-images.githubusercontent.com/346010/95359174-23161d80-08ca-11eb-802f-56ebf9af4a53.png)

### Exception:
![Log_Explorer___Datadog](https://user-images.githubusercontent.com/346010/95359102-0da0f380-08ca-11eb-8c9c-a49c027cfb9b.png)
