### PR TITLE
Allow string numeric log levels

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -410,6 +410,10 @@ class Logger implements LoggerInterface, ResettableInterface
     public static function toMonologLevel($level): int
     {
         if (is_string($level)) {
+            if (is_numeric($level)) {
+                return intval($level);
+            }
+            
             // Contains chars of all log levels and avoids using strtoupper() which may have
             // strange results depending on locale (for example, "i" will become "İ" in Turkish locale)
             $upper = strtr($level, 'abcdefgilmnortuwy', 'ABCDEFGILMNORTUWY');


### PR DESCRIPTION
This allows for log level to be string numeric in case of setting from environment variables or other sources with ambivalent type