### PR TITLE
Adds return value in handler wrapper

### DIFF
--- a/src/Monolog/Handler/HandlerWrapper.php
+++ b/src/Monolog/Handler/HandlerWrapper.php
@@ -108,6 +108,8 @@ class HandlerWrapper implements HandlerInterface, ProcessableHandlerInterface, F
     {
         if ($this->handler instanceof FormattableHandlerInterface) {
             $this->handler->setFormatter($formatter);
+
+            return $this;
         }
 
         throw new \LogicException('The wrapped handler does not implement ' . FormattableHandlerInterface::class);


### PR DESCRIPTION
Method `setFormatter` in `HandlerWrapper` always throws an exception, fixed it.