### PR TITLE
Support for Elastica client up to v7.0.0, with optional drop support for ES types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "phpunit/phpunit": "^8.5",
         "predis/predis": "^1.1",
         "rollbar/rollbar": "^1.3",
-        "ruflin/elastica": ">=0.90 <3.0",
+        "ruflin/elastica": ">=0.90 <7.0.1",
         "swiftmailer/swiftmailer": "^5.3|^6.0",
         "phpstan/phpstan": "^0.12.59"
     },

--- a/src/Monolog/Formatter/ElasticaFormatter.php
+++ b/src/Monolog/Formatter/ElasticaFormatter.php
@@ -58,6 +58,9 @@ class ElasticaFormatter extends NormalizerFormatter
         return $this->index;
     }
 
+    /**
+     * @deprecated since Elastica 7 type has no effect
+     */
     public function getType(): string
     {
         return $this->type;
@@ -72,7 +75,9 @@ class ElasticaFormatter extends NormalizerFormatter
     {
         $document = new Document();
         $document->setData($record);
-        $document->setType($this->type);
+        if(method_exists($document, 'setType')) {
+            $document->setType($this->type);
+        }
         $document->setIndex($this->index);
 
         return $document;

--- a/src/Monolog/Handler/ElasticaHandler.php
+++ b/src/Monolog/Handler/ElasticaHandler.php
@@ -25,7 +25,7 @@ use Elastica\Exception\ExceptionInterface;
  *    $client = new \Elastica\Client();
  *    $options = array(
  *        'index' => 'elastic_index_name',
- *        'type' => 'elastic_doc_type',
+ *        'type' => 'elastic_doc_type', Types have been removed in Elastica 7
  *    );
  *    $handler = new ElasticaHandler($client, $options);
  *    $log = new Logger('application');

--- a/tests/Monolog/Formatter/ElasticaFormatterTest.php
+++ b/tests/Monolog/Formatter/ElasticaFormatterTest.php
@@ -55,9 +55,10 @@ class ElasticaFormatterTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('Elastica\Document', $doc);
 
         // Document parameters
-        $params = $doc->getParams();
-        $this->assertEquals('my_index', $params['_index']);
-        $this->assertEquals('doc_type', $params['_type']);
+        $this->assertEquals('my_index', $doc->getIndex());
+        if(method_exists($doc, 'getType')) {
+            $this->assertEquals('doc_type', $doc->getType());
+        }
 
         // Document data values
         $data = $doc->getData();

--- a/tests/Monolog/Handler/ElasticaHandlerTest.php
+++ b/tests/Monolog/Handler/ElasticaHandlerTest.php
@@ -288,7 +288,7 @@ class ElasticaHandlerTest extends TestCase
     protected function getDocSourceFromElastic(Client $client, $index, $type, $documentId)
     {
         if($type === null) {
-            $path  = "/{$index}/{$documentId}";
+            $path  = "/{$index}/_doc/{$documentId}";
         } else {
             $path  = "/{$index}/{$type}/{$documentId}";
         }

--- a/tests/Monolog/Handler/ElasticaHandlerTest.php
+++ b/tests/Monolog/Handler/ElasticaHandlerTest.php
@@ -156,7 +156,7 @@ class ElasticaHandlerTest extends TestCase
     }
 
     /**
-     * Integration test using localhost Elastic Search server
+     * Integration test using localhost Elastic Search server version <7
      *
      * @covers Monolog\Handler\ElasticaHandler::__construct
      * @covers Monolog\Handler\ElasticaHandler::handleBatch
@@ -210,6 +210,61 @@ class ElasticaHandlerTest extends TestCase
     }
 
     /**
+     * Integration test using localhost Elastic Search server version 7+
+     *
+     * @covers Monolog\Handler\ElasticaHandler::__construct
+     * @covers Monolog\Handler\ElasticaHandler::handleBatch
+     * @covers Monolog\Handler\ElasticaHandler::bulkSend
+     * @covers Monolog\Handler\ElasticaHandler::getDefaultFormatter
+     */
+    public function testHandleIntegrationNewESVersion()
+    {
+        $msg = [
+            'level' => Logger::ERROR,
+            'level_name' => 'ERROR',
+            'channel' => 'meh',
+            'context' => ['foo' => 7, 'bar', 'class' => new \stdClass],
+            'datetime' => new \DateTimeImmutable("@0"),
+            'extra' => [],
+            'message' => 'log',
+        ];
+
+        $expected = $msg;
+        $expected['datetime'] = $msg['datetime']->format(\DateTime::ISO8601);
+        $expected['context'] = [
+            'class' => '[object] (stdClass: {})',
+            'foo' => 7,
+            0 => 'bar',
+        ];
+
+        $client = new Client();
+        $handler = new ElasticaHandler($client, $this->options);
+
+        try {
+            $handler->handleBatch([$msg]);
+        } catch (\RuntimeException $e) {
+            $this->markTestSkipped("Cannot connect to Elastic Search server on localhost");
+        }
+
+        // check document id from ES server response
+        $documentId = $this->getCreatedDocId($client->getLastResponse());
+        $this->assertNotEmpty($documentId, 'No elastic document id received');
+
+        // retrieve document source from ES and validate
+        $document = $this->getDocSourceFromElastic(
+            $client,
+            $this->options['index'],
+            null,
+            $documentId
+        );
+        $this->assertEquals($expected, $document);
+
+        // remove test index from ES
+        $client->request("/{$this->options['index']}", Request::DELETE);
+    }
+
+
+    /**
      * Return last created document id from ES response
      * @param  Response    $response Elastica Response object
      * @return string|null
@@ -226,13 +281,18 @@ class ElasticaHandlerTest extends TestCase
      * Retrieve document by id from Elasticsearch
      * @param  Client $client     Elastica client
      * @param  string $index
-     * @param  string $type
+     * @param  ?string $type
      * @param  string $documentId
      * @return array
      */
     protected function getDocSourceFromElastic(Client $client, $index, $type, $documentId)
     {
-        $resp = $client->request("/{$index}/{$type}/{$documentId}", Request::GET);
+        if($type === null) {
+            $path  = "/{$index}/{$documentId}";
+        } else {
+            $path  = "/{$index}/{$type}/{$documentId}";
+        }
+        $resp = $client->request($path, Request::GET);
         $data = $resp->getData();
         if (!empty($data['_source'])) {
             return $data['_source'];


### PR DESCRIPTION
If you use the Elastica 7 client, which is only compatible with v7 of ElasticSearch, support of types has been dropped. This PR tests for the Elastica client version and conditionally drops types if they are no longer supported.

It replaces #1476 that mistakes `OpType` (operation type) parameter for ES types.

Resolves #1399