### PR TITLE
Reset wrapped handler of the FilterHandler

### DIFF
--- a/src/Monolog/Handler/FilterHandler.php
+++ b/src/Monolog/Handler/FilterHandler.php
@@ -185,5 +185,9 @@ class FilterHandler extends Handler implements ProcessableHandlerInterface, Rese
     public function reset()
     {
         $this->resetProcessors();
+
+        if ($this->getHandler() instanceof ResettableInterface) {
+            $this->getHandler()->reset();
+        }
     }
 }

--- a/tests/Monolog/Handler/FilterHandlerTest.php
+++ b/tests/Monolog/Handler/FilterHandlerTest.php
@@ -180,4 +180,27 @@ class FilterHandlerTest extends TestCase
         $handler->handleBatch(array());
         $this->assertSame(array(), $test->getRecords());
     }
+
+    /**
+     * @covers Monolog\Handler\FilterHandler::handle
+     * @covers Monolog\Handler\FilterHandler::reset
+     */
+    public function testResetTestHandler()
+    {
+        $test = new TestHandler();
+        $handler = new FilterHandler($test, [Logger::INFO, Logger::ERROR]);
+
+        $handler->handle($this->getRecord(Logger::INFO));
+        $this->assertTrue($test->hasInfoRecords());
+
+        $handler->handle($this->getRecord(Logger::ERROR));
+        $this->assertTrue($test->hasErrorRecords());
+
+        $handler->reset();
+
+        $this->assertFalse($test->hasInfoRecords());
+        $this->assertFalse($test->hasInfoRecords());
+
+        $this->assertSame(array(), $test->getRecords());
+    }
 }


### PR DESCRIPTION
When we reset the FilterHandler we should call the handler we are wrapping.