### PR TITLE
Replace api_user and api_key with Bearer token

### DIFF
--- a/src/Monolog/Handler/SendGridHandler.php
+++ b/src/Monolog/Handler/SendGridHandler.php
@@ -75,8 +75,6 @@ class SendGridHandler extends MailHandler
     protected function send(string $content, array $records): void
     {
         $message = [];
-        $message['api_user'] = $this->apiUser;
-        $message['api_key'] = $this->apiKey;
         $message['from'] = $this->from;
         foreach ($this->to as $recipient) {
             $message['to[]'] = $recipient;
@@ -92,6 +90,7 @@ class SendGridHandler extends MailHandler
 
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, 'https://api.sendgrid.com/api/mail.send.json');
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Authorization: Bearer ' . $this->apiKey]);
         curl_setopt($ch, CURLOPT_POST, 1);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($message));


### PR DESCRIPTION
The Bearer Token seems to be how the v3 API will be handling authorization, which the v2 API currently accepts as well.