### PR TITLE
Fluentd formatter: format as dictionnary for Record Accessor support

### DIFF
--- a/src/Monolog/Formatter/FluentdFormatter.php
+++ b/src/Monolog/Formatter/FluentdFormatter.php
@@ -73,7 +73,7 @@ class FluentdFormatter implements FormatterInterface
             $message['level_name'] = $record['level_name'];
         }
 
-        return Utils::jsonEncode([$tag, $record['datetime']->getTimestamp(), $message]);
+        return Utils::jsonEncode(['tag' => $tag, 'timestamp' => $record['datetime']->getTimestamp(), 'record' => $message]);
     }
 
     public function formatBatch(array $records): string


### PR DESCRIPTION
Fluentbit, a lightweight Fluentd shipper, only supports dictionnary records for its record accessor functionnality ( https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/record-accessor )
Using keys instead of array indexes is generally easier and less error-prone in any case.
This PR changes the Fluentd formatting to return a dictionnary instead of an array.