### PR TITLE
Stop using deprecated MockBuilder::setMethods in unit tests

### DIFF
--- a/tests/Monolog/Handler/AmqpHandlerTest.php
+++ b/tests/Monolog/Handler/AmqpHandlerTest.php
@@ -33,7 +33,7 @@ class AmqpHandlerTest extends TestCase
         $messages = [];
 
         $exchange = $this->getMockBuilder('AMQPExchange')
-            ->setMethods(['publish', 'setName'])
+            ->onlyMethods(['publish', 'setName'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -85,7 +85,7 @@ class AmqpHandlerTest extends TestCase
         $messages = [];
 
         $exchange = $this->getMockBuilder('PhpAmqpLib\Channel\AMQPChannel')
-            ->setMethods(['basic_publish', '__destruct'])
+            ->onlyMethods(['basic_publish', '__destruct'])
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/Monolog/Handler/AmqpHandlerTest.php
+++ b/tests/Monolog/Handler/AmqpHandlerTest.php
@@ -84,8 +84,13 @@ class AmqpHandlerTest extends TestCase
 
         $messages = [];
 
+        $methodsToMock = ['basic_publish'];
+        if (method_exists('PhpAmqpLib\Channel\AMQPChannel', '__destruct')) {
+            $methodsToMock[] = '__destruct';
+        }
+
         $exchange = $this->getMockBuilder('PhpAmqpLib\Channel\AMQPChannel')
-            ->onlyMethods(['basic_publish', '__destruct'])
+            ->onlyMethods($methodsToMock)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/Monolog/Handler/DoctrineCouchDBHandlerTest.php
+++ b/tests/Monolog/Handler/DoctrineCouchDBHandlerTest.php
@@ -26,7 +26,7 @@ class DoctrineCouchDBHandlerTest extends TestCase
     public function testHandle()
     {
         $client = $this->getMockBuilder('Doctrine\\CouchDB\\CouchDBClient')
-            ->setMethods(['postDocument'])
+            ->onlyMethods(['postDocument'])
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/Monolog/Handler/DynamoDbHandlerTest.php
+++ b/tests/Monolog/Handler/DynamoDbHandlerTest.php
@@ -29,10 +29,10 @@ class DynamoDbHandlerTest extends TestCase
 
         $implementedMethods = ['__call'];
         $absentMethods = [];
-        if ($this->isV3) {
-            $absentMethods[] = 'formatAttributes';
-        } else {
+        if (method_exists('Aws\DynamoDb\DynamoDbClient', 'formatAttributes')) {
             $implementedMethods[] = 'formatAttributes';
+        } else {
+            $absentMethods[] = 'formatAttributes';
         }
 
         $this->client = $this->getMockBuilder('Aws\DynamoDb\DynamoDbClient')

--- a/tests/Monolog/Handler/DynamoDbHandlerTest.php
+++ b/tests/Monolog/Handler/DynamoDbHandlerTest.php
@@ -24,7 +24,7 @@ class DynamoDbHandlerTest extends TestCase
         }
 
         $this->client = $this->getMockBuilder('Aws\DynamoDb\DynamoDbClient')
-            ->setMethods(['formatAttributes', '__call'])
+            ->onlyMethods(['formatAttributes', '__call'])
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/tests/Monolog/Handler/DynamoDbHandlerTest.php
+++ b/tests/Monolog/Handler/DynamoDbHandlerTest.php
@@ -35,11 +35,14 @@ class DynamoDbHandlerTest extends TestCase
             $absentMethods[] = 'formatAttributes';
         }
 
-        $this->client = $this->getMockBuilder('Aws\DynamoDb\DynamoDbClient')
+        $clientMockBuilder = $this->getMockBuilder('Aws\DynamoDb\DynamoDbClient')
             ->onlyMethods($implementedMethods)
-            ->addMethods($absentMethods)
-            ->disableOriginalConstructor()
-            ->getMock();
+            ->disableOriginalConstructor();
+        if ($absentMethods) {
+            $clientMockBuilder->addMethods($absentMethods);
+        }
+
+        $this->client = $clientMockBuilder->getMock();
     }
 
     public function testConstruct()

--- a/tests/Monolog/Handler/ElasticaHandlerTest.php
+++ b/tests/Monolog/Handler/ElasticaHandlerTest.php
@@ -43,7 +43,7 @@ class ElasticaHandlerTest extends TestCase
 
         // base mock Elastica Client object
         $this->client = $this->getMockBuilder('Elastica\Client')
-            ->setMethods(['addDocuments'])
+            ->onlyMethods(['addDocuments'])
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/tests/Monolog/Handler/ElasticsearchHandlerTest.php
+++ b/tests/Monolog/Handler/ElasticsearchHandlerTest.php
@@ -42,7 +42,7 @@ class ElasticsearchHandlerTest extends TestCase
 
         // base mock Elasticsearch Client object
         $this->client = $this->getMockBuilder('Elasticsearch\Client')
-            ->setMethods(['bulk'])
+            ->onlyMethods(['bulk'])
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/tests/Monolog/Handler/FlowdockHandlerTest.php
+++ b/tests/Monolog/Handler/FlowdockHandlerTest.php
@@ -65,7 +65,7 @@ class FlowdockHandlerTest extends TestCase
         $this->res = fopen('php://memory', 'a');
         $this->handler = $this->getMockBuilder('Monolog\Handler\FlowdockHandler')
             ->setConstructorArgs($constructorArgs)
-            ->setMethods(['fsockopen', 'streamSetTimeout', 'closeSocket'])
+            ->onlyMethods(['fsockopen', 'streamSetTimeout', 'closeSocket'])
             ->getMock();
 
         $reflectionProperty = new \ReflectionProperty('Monolog\Handler\SocketHandler', 'connectionString');

--- a/tests/Monolog/Handler/GelfHandlerTest.php
+++ b/tests/Monolog/Handler/GelfHandlerTest.php
@@ -44,7 +44,7 @@ class GelfHandlerTest extends TestCase
     protected function getMessagePublisher()
     {
         return $this->getMockBuilder('Gelf\Publisher')
-            ->setMethods(['publish'])
+            ->onlyMethods(['publish'])
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/tests/Monolog/Handler/InsightOpsHandlerTest.php
+++ b/tests/Monolog/Handler/InsightOpsHandlerTest.php
@@ -58,7 +58,7 @@ class InsightOpsHandlerTest extends TestCase
         $args = array('testToken', 'us', $useSSL, Logger::DEBUG, true);
         $this->resource = fopen('php://memory', 'a');
         $this->handler = $this->getMockBuilder(InsightOpsHandler::class)
-            ->setMethods(array('fsockopen', 'streamSetTimeout', 'closeSocket'))
+            ->onlyMethods(array('fsockopen', 'streamSetTimeout', 'closeSocket'))
             ->setConstructorArgs($args)
             ->getMock();
 

--- a/tests/Monolog/Handler/LogEntriesHandlerTest.php
+++ b/tests/Monolog/Handler/LogEntriesHandlerTest.php
@@ -63,7 +63,7 @@ class LogEntriesHandlerTest extends TestCase
         $this->res = fopen('php://memory', 'a');
         $this->handler = $this->getMockBuilder('Monolog\Handler\LogEntriesHandler')
             ->setConstructorArgs($args)
-            ->setMethods(['fsockopen', 'streamSetTimeout', 'closeSocket'])
+            ->onlyMethods(['fsockopen', 'streamSetTimeout', 'closeSocket'])
             ->getMock();
 
         $reflectionProperty = new \ReflectionProperty('Monolog\Handler\SocketHandler', 'connectionString');

--- a/tests/Monolog/Handler/LogmaticHandlerTest.php
+++ b/tests/Monolog/Handler/LogmaticHandlerTest.php
@@ -63,7 +63,7 @@ class LogmaticHandlerTest extends TestCase
         $this->res = fopen('php://memory', 'a');
         $this->handler = $this->getMockBuilder('Monolog\Handler\LogmaticHandler')
             ->setConstructorArgs($args)
-            ->setMethods(['fsockopen', 'streamSetTimeout', 'closeSocket'])
+            ->onlyMethods(['fsockopen', 'streamSetTimeout', 'closeSocket'])
             ->getMock();
 
         $reflectionProperty = new \ReflectionProperty('Monolog\Handler\SocketHandler', 'connectionString');

--- a/tests/Monolog/Handler/PHPConsoleHandlerTest.php
+++ b/tests/Monolog/Handler/PHPConsoleHandlerTest.php
@@ -60,7 +60,7 @@ class PHPConsoleHandlerTest extends TestCase
     {
         return $this->getMockBuilder('PhpConsole\Dispatcher\Debug')
             ->disableOriginalConstructor()
-            ->setMethods(['dispatchDebug'])
+            ->onlyMethods(['dispatchDebug'])
             ->setConstructorArgs([$connector, $connector->getDumper()])
             ->getMock();
     }
@@ -69,7 +69,7 @@ class PHPConsoleHandlerTest extends TestCase
     {
         return $this->getMockBuilder('PhpConsole\Dispatcher\Errors')
             ->disableOriginalConstructor()
-            ->setMethods(['dispatchError', 'dispatchException'])
+            ->onlyMethods(['dispatchError', 'dispatchException'])
             ->setConstructorArgs([$connector, $connector->getDumper()])
             ->getMock();
     }
@@ -78,7 +78,7 @@ class PHPConsoleHandlerTest extends TestCase
     {
         $connector = $this->getMockBuilder('PhpConsole\Connector')
             ->disableOriginalConstructor()
-            ->setMethods([
+            ->onlyMethods([
                 'sendMessage',
                 'onShutDown',
                 'isActiveClient',

--- a/tests/Monolog/Handler/ProcessHandlerTest.php
+++ b/tests/Monolog/Handler/ProcessHandlerTest.php
@@ -40,7 +40,7 @@ class ProcessHandlerTest extends TestCase
         ];
 
         $mockBuilder = $this->getMockBuilder('Monolog\Handler\ProcessHandler');
-        $mockBuilder->setMethods(['writeProcessInput']);
+        $mockBuilder->onlyMethods(['writeProcessInput']);
         // using echo as command, as it is most probably available
         $mockBuilder->setConstructorArgs([self::DUMMY_COMMAND]);
 
@@ -126,7 +126,7 @@ class ProcessHandlerTest extends TestCase
     public function testStartupWithFailingToSelectErrorStreamThrowsUnexpectedValueException()
     {
         $mockBuilder = $this->getMockBuilder('Monolog\Handler\ProcessHandler');
-        $mockBuilder->setMethods(['selectErrorStream']);
+        $mockBuilder->onlyMethods(['selectErrorStream']);
         $mockBuilder->setConstructorArgs([self::DUMMY_COMMAND]);
 
         $handler = $mockBuilder->getMock();
@@ -159,7 +159,7 @@ class ProcessHandlerTest extends TestCase
     public function testWritingWithErrorsOnStdOutOfProcessThrowsInvalidArgumentException()
     {
         $mockBuilder = $this->getMockBuilder('Monolog\Handler\ProcessHandler');
-        $mockBuilder->setMethods(['readProcessErrors']);
+        $mockBuilder->onlyMethods(['readProcessErrors']);
         // using echo as command, as it is most probably available
         $mockBuilder->setConstructorArgs([self::DUMMY_COMMAND]);
 

--- a/tests/Monolog/Handler/PushoverHandlerTest.php
+++ b/tests/Monolog/Handler/PushoverHandlerTest.php
@@ -118,7 +118,7 @@ class PushoverHandlerTest extends TestCase
         $this->res = fopen('php://memory', 'a');
         $this->handler = $this->getMockBuilder('Monolog\Handler\PushoverHandler')
             ->setConstructorArgs($constructorArgs)
-            ->setMethods(['fsockopen', 'streamSetTimeout', 'closeSocket'])
+            ->onlyMethods(['fsockopen', 'streamSetTimeout', 'closeSocket'])
             ->getMock();
 
         $reflectionProperty = new \ReflectionProperty('Monolog\Handler\SocketHandler', 'connectionString');

--- a/tests/Monolog/Handler/RedisHandlerTest.php
+++ b/tests/Monolog/Handler/RedisHandlerTest.php
@@ -109,7 +109,10 @@ class RedisHandlerTest extends TestCase
     {
         $redis = $this->createPartialMock('Predis\Client', ['transaction']);
 
-        $redisTransaction = $this->createPartialMock('Predis\Client', ['rPush', 'lTrim']);
+        $redisTransaction = $this->getMockBuilder('Predis\Client')
+            ->disableOriginalConstructor()
+            ->addMethods(['rPush', 'lTrim'])
+            ->getMock();
 
         $redisTransaction->expects($this->once())
             ->method('rPush')

--- a/tests/Monolog/Handler/RollbarHandlerTest.php
+++ b/tests/Monolog/Handler/RollbarHandlerTest.php
@@ -64,7 +64,7 @@ class RollbarHandlerTest extends TestCase
 
         $this->rollbarLogger = $this->getMockBuilder(RollbarLogger::class)
             ->setConstructorArgs(array($config))
-            ->setMethods(array('log'))
+            ->onlyMethods(array('log'))
             ->getMock();
 
         $this->rollbarLogger

--- a/tests/Monolog/Handler/SlackHandlerTest.php
+++ b/tests/Monolog/Handler/SlackHandlerTest.php
@@ -132,7 +132,7 @@ class SlackHandlerTest extends TestCase
         $this->res = fopen('php://memory', 'a');
         $this->handler = $this->getMockBuilder('Monolog\Handler\SlackHandler')
             ->setConstructorArgs($constructorArgs)
-            ->setMethods(['fsockopen', 'streamSetTimeout', 'closeSocket'])
+            ->onlyMethods(['fsockopen', 'streamSetTimeout', 'closeSocket'])
             ->getMock();
 
         $reflectionProperty = new \ReflectionProperty('Monolog\Handler\SocketHandler', 'connectionString');

--- a/tests/Monolog/Handler/SocketHandlerTest.php
+++ b/tests/Monolog/Handler/SocketHandlerTest.php
@@ -298,7 +298,7 @@ class SocketHandlerTest extends TestCase
         $finalMethods = array_merge($defaultMethods, $newMethods);
 
         $this->handler = $this->getMockBuilder('Monolog\Handler\SocketHandler')
-            ->setMethods($finalMethods)
+            ->onlyMethods($finalMethods)
             ->setConstructorArgs(['localhost:1234'])
             ->getMock();
 

--- a/tests/Monolog/Handler/SyslogUdpHandlerTest.php
+++ b/tests/Monolog/Handler/SyslogUdpHandlerTest.php
@@ -75,11 +75,8 @@ class SyslogUdpHandlerTest extends TestCase
 
         $handler = $this->getMockBuilder('\Monolog\Handler\SyslogUdpHandler')
             ->setConstructorArgs(array("127.0.0.1", 514, "authpriv", 'debug', true, "php", \Monolog\Handler\SyslogUdpHandler::RFC3164))
-            ->onlyMethods(array('getDateTime'))
+            ->onlyMethods([])
             ->getMock();
-
-        $handler->method('getDateTime')
-            ->willReturn($time);
 
         $handler->setFormatter(new \Monolog\Formatter\ChromePHPFormatter());
 

--- a/tests/Monolog/Handler/SyslogUdpHandlerTest.php
+++ b/tests/Monolog/Handler/SyslogUdpHandlerTest.php
@@ -35,7 +35,7 @@ class SyslogUdpHandlerTest extends TestCase
 
         $time = '2014-01-07T12:34:56+00:00';
         $socket = $this->getMockBuilder('Monolog\Handler\SyslogUdp\UdpSocket')
-            ->setMethods(['write'])
+            ->onlyMethods(['write'])
             ->setConstructorArgs(['lol'])
             ->getMock();
         $socket->expects($this->at(0))
@@ -56,7 +56,7 @@ class SyslogUdpHandlerTest extends TestCase
         $handler->setFormatter($this->getIdentityFormatter());
 
         $socket = $this->getMockBuilder('Monolog\Handler\SyslogUdp\UdpSocket')
-            ->setMethods(['write'])
+            ->onlyMethods(['write'])
             ->setConstructorArgs(['lol'])
             ->getMock();
         $socket->expects($this->never())
@@ -75,7 +75,7 @@ class SyslogUdpHandlerTest extends TestCase
 
         $handler = $this->getMockBuilder('\Monolog\Handler\SyslogUdpHandler')
             ->setConstructorArgs(array("127.0.0.1", 514, "authpriv", 'debug', true, "php", \Monolog\Handler\SyslogUdpHandler::RFC3164))
-            ->setMethods(array('getDateTime'))
+            ->onlyMethods(array('getDateTime'))
             ->getMock();
 
         $handler->method('getDateTime')
@@ -85,7 +85,7 @@ class SyslogUdpHandlerTest extends TestCase
 
         $socket = $this->getMockBuilder('\Monolog\Handler\SyslogUdp\UdpSocket')
             ->setConstructorArgs(array('lol', 999))
-            ->setMethods(array('write'))
+            ->onlyMethods(array('write'))
             ->getMock();
         $socket->expects($this->at(0))
             ->method('write')

--- a/tests/Monolog/Handler/TelegramBotHandlerTest.php
+++ b/tests/Monolog/Handler/TelegramBotHandlerTest.php
@@ -47,7 +47,7 @@ class TelegramBotHandlerTest extends TestCase
 
         $this->handler = $this->getMockBuilder(TelegramBotHandler::class)
             ->setConstructorArgs($constructorArgs)
-            ->setMethods(['send'])
+            ->onlyMethods(['send'])
             ->getMock();
 
         $this->handler->expects($this->atLeast(1))

--- a/tests/Monolog/Handler/UdpSocketTest.php
+++ b/tests/Monolog/Handler/UdpSocketTest.php
@@ -22,7 +22,7 @@ class UdpSocketTest extends TestCase
     public function testWeDoNotTruncateShortMessages()
     {
         $socket = $this->getMockBuilder('Monolog\Handler\SyslogUdp\UdpSocket')
-            ->setMethods(['send'])
+            ->onlyMethods(['send'])
             ->setConstructorArgs(['lol'])
             ->getMock();
 
@@ -36,7 +36,7 @@ class UdpSocketTest extends TestCase
     public function testLongMessagesAreTruncated()
     {
         $socket = $this->getMockBuilder('Monolog\Handler\SyslogUdp\UdpSocket')
-            ->setMethods(['send'])
+            ->onlyMethods(['send'])
             ->setConstructorArgs(['lol'])
             ->getMock();
 

--- a/tests/Monolog/Handler/ZendMonitorHandlerTest.php
+++ b/tests/Monolog/Handler/ZendMonitorHandlerTest.php
@@ -36,7 +36,7 @@ class ZendMonitorHandlerTest extends TestCase
         ];
 
         $zendMonitor = $this->getMockBuilder('Monolog\Handler\ZendMonitorHandler')
-            ->setMethods(['writeZendMonitorCustomEvent', 'getDefaultFormatter'])
+            ->onlyMethods(['writeZendMonitorCustomEvent', 'getDefaultFormatter'])
             ->getMock();
 
         $formatterMock = $this->getMockBuilder('Monolog\Formatter\NormalizerFormatter')

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -239,7 +239,7 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
 
         $processor = $this->getMockBuilder('Monolog\Processor\WebProcessor')
             ->disableOriginalConstructor()
-            ->setMethods(['__invoke'])
+            ->onlyMethods(['__invoke'])
             ->getMock()
         ;
         $processor->expects($this->once())


### PR DESCRIPTION
`MockBuilder::setMethods()` is marked as deprecated since PHPUnit 8, but it's used in monolog tests.
In this pull request I've replaced these calls to `onlyMethods()` / `addMethods()`.

Summary of changes:
1. the replace `setMethods()` -> `onlyMethods()` was enough in most cases
2. `DynamoDbHandlerTest` has a tricky case (Aws\DynamoDb\DynamoDbClient:: formatAttributes exists in aws/aws-sdk-php v2, but was removed in v3.0, but its call was tested based on the version)
3. AmqpHandlerTest requires the checking of `\PhpAmqpLib\Channel\AMQPChannel::__destruct` existence before the onlyMethods() usage (because __destruct was removed in php-amqplib/php-amqplib:2.5.0)
4. RedisHandlerTest requires the usage of `addMethods()` because Predis\Client uses magic method `__call()` for commands processing