### PR TITLE
Allows you to use 'normalize()' method instead of 'normalizeValue()'

### DIFF
--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -131,7 +131,11 @@ class NormalizerFormatter implements FormatterInterface
             return 'Over ' . $this->maxNormalizeDepth . ' levels deep, aborting normalization';
         }
 
-        if (null === $data || is_scalar($data)) {
+        if (is_null($data) || is_scalar($data)) {
+            if (is_array($data)) {
+                return $this->toJson($data, true);
+            }
+
             if (is_float($data)) {
                 if (is_infinite($data)) {
                     return ($data > 0 ? '' : '-') . 'INF';

--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -131,7 +131,7 @@ class NormalizerFormatter implements FormatterInterface
             return 'Over ' . $this->maxNormalizeDepth . ' levels deep, aborting normalization';
         }
 
-        if (is_null($data) || is_scalar($data)) {
+        if ($data === null || is_scalar($data)) {
             if (is_array($data)) {
                 return $this->toJson($data, true);
             }

--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -130,12 +130,12 @@ class NormalizerFormatter implements FormatterInterface
         if ($depth > $this->maxNormalizeDepth) {
             return 'Over ' . $this->maxNormalizeDepth . ' levels deep, aborting normalization';
         }
+        
+        if (is_array($data) && is_scalar($data)) { 
+            return $this->toJson($data, true);
+        } 
 
         if ($data === null || is_scalar($data)) {
-            if (is_array($data)) {
-                return $this->toJson($data, true);
-            }
-
             if (is_float($data)) {
                 if (is_infinite($data)) {
                     return ($data > 0 ? '' : '-') . 'INF';

--- a/src/Monolog/Formatter/ScalarFormatter.php
+++ b/src/Monolog/Formatter/ScalarFormatter.php
@@ -25,24 +25,9 @@ class ScalarFormatter extends NormalizerFormatter
     public function format(array $record): array
     {
         foreach ($record as $key => $value) {
-            $record[$key] = $this->normalizeValue($value);
+            $record[$key] = $this->normalize($value);
         }
 
         return $record;
-    }
-
-    /**
-     * @param  mixed $value
-     * @return string|int|bool|null
-     */
-    protected function normalizeValue($value)
-    {
-        $normalized = $this->normalize($value);
-
-        if (is_array($normalized)) {
-            return $this->toJson($normalized, true);
-        }
-
-        return $normalized;
     }
 }


### PR DESCRIPTION
There is no need to use the `normalizeValue ()` method in the `ScalarFormatter` class. The `normalize()` method already performs a scalar control. When doing this control, if the data type `Scalar` is sent as a string, it allows the data given by `toJson` to be converted to Json encoding.