### PR TITLE
Fix deprecation warning on PHP 8.1

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -321,7 +321,7 @@ class Logger implements LoggerInterface, ResettableInterface
         if ($this->microsecondTimestamps && PHP_VERSION_ID < 70100) {
             $ts = \DateTime::createFromFormat('U.u', sprintf('%.6F', microtime(true)), static::$timezone);
         } else {
-            $ts = new \DateTime(null, static::$timezone);
+            $ts = new \DateTime('now', static::$timezone);
         }
         $ts->setTimezone(static::$timezone);
 


### PR DESCRIPTION
PHP 8.1 issues a deprecation warning for Monolog:

> DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated

This PR attempts to fix the problem.