### PR TITLE
Reduce calls to date_default_timezone_get()

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -140,6 +140,11 @@ class Logger implements LoggerInterface, ResettableInterface
     protected $exceptionHandler;
 
     /**
+     * @var DateTimeZone|null
+     */
+    private static $defaultTimezone;
+
+    /**
      * @psalm-param array<callable(array): array> $processors
      *
      * @param string             $name       The logging channel, a simple descriptive name that is attached to all log records
@@ -152,7 +157,14 @@ class Logger implements LoggerInterface, ResettableInterface
         $this->name = $name;
         $this->setHandlers($handlers);
         $this->processors = $processors;
-        $this->timezone = $timezone ?: new DateTimeZone(date_default_timezone_get() ?: 'UTC');
+        if ($timezone !== null) {
+            $this->timezone = $timezone;
+            return;
+        }
+        if (!isset(self::$defaultTimezone)) {
+            self::$defaultTimezone = new DateTimeZone(date_default_timezone_get() ?: 'UTC');
+        }
+        $this->timezone = self::$defaultTimezone;
     }
 
     public function getName(): string


### PR DESCRIPTION
Not sure why, but this call seems to be time consuming enough to appear
in performance profiles (maybe reading from disk is involved or
something).
This should probably not be resolved in dependency injection containers
since one might one to build the container on one machine, and then
deploy on many machines in different timezones.

Below is a screenshot from a 20.2 ms trace. 2.48 ms are spent on `date_default_timezone_get()` 


![5 calls resulting in 12% time spent here](https://user-images.githubusercontent.com/657779/119618928-bffadc00-be03-11eb-855a-a0f579892072.png)

A quick benchmark shows an improvement:

```php
<?php

use Monolog\Logger;

require 'vendor/autoload.php';

$start = microtime(true);
foreach (range(0, 10000) as $whatever) {
    new Logger('hello');
}

$end = microtime(true);

var_dump($end - $start);
```


Before:

float(0.006029844284057617)

After:

float(0.0030698776245117188)

I will try to get something less biased with phpbench. Note that I have to resort to a lot more iteration to observe a significant difference, so my claim that this call is slow is a bit dubious… maybe it depends on the environment?

UPD:

```
LoggerBench

    benchConstruct..........................I4 - Mo0.413μs (±0.19%)
    benchConstructWithoutMemoization........I4 - Mo9.966μs (±0.07%)

Subjects: 2, Assertions: 0, Failures: 0, Errors: 0

+-------------+----------------------------------+-----+-------+-----+----------+---------+--------+
| benchmark   | subject                          | set | revs  | its | mem_peak | mode    | rstdev |
+-------------+----------------------------------+-----+-------+-----+----------+---------+--------+
| LoggerBench | benchConstruct                   | 0   | 10000 | 5   | 1.588mb  | 0.413μs | ±0.19% |
| LoggerBench | benchConstructWithoutMemoization | 0   | 10000 | 5   | 1.588mb  | 9.966μs | ±0.07% |
+-------------+----------------------------------+-----+-------+-----+----------+---------+--------+
```

```php
<?php

use Monolog\Logger;

class LoggerBench
{
    /**
     * @Revs(10000)
     * @Iterations(5)
     * @RetryThreshold(2.0)
     */
    public function benchConstruct(): void
    {
        new Logger('💩', [], [], null, true);
    }

    /**
     * @Revs(10000)
     * @Iterations(5)
     * @RetryThreshold(2.0)
     */
    public function benchConstructWithoutMemoization(): void
    {
        new Logger('💩', [], [], null, false);
    }
}
```

I added a boolean to toggle the memoization:

```php
    public function __construct(string $name, array $handlers = [], array $processors = [], ?DateTimeZone $timezone = null, bool $memoizeTz)
    {
        $this->name = $name;
        $this->setHandlers($handlers);
        $this->processors = $processors;
        if ($timezone !== null) {
            $this->timezone = $timezone;
            return;
        }
        if (!isset(self::$defaultTimezone)) {
            $tz = new DateTimeZone(date_default_timezone_get() ?: 'UTC');
            if ($memoizeTz) {
                self::$defaultTimezone = $tz;
            }
        }
        $this->timezone = self::$defaultTimezone;
    }

```