### PR TITLE
JsonFormatter::normalize() : respect date format from Formatter

### DIFF
--- a/src/Monolog/Formatter/JsonFormatter.php
+++ b/src/Monolog/Formatter/JsonFormatter.php
@@ -44,6 +44,8 @@ class JsonFormatter extends NormalizerFormatter
         $this->batchMode = $batchMode;
         $this->appendNewline = $appendNewline;
         $this->ignoreEmptyContextAndExtra = $ignoreEmptyContextAndExtra;
+
+        parent::__construct();
     }
 
     /**

--- a/src/Monolog/Formatter/JsonFormatter.php
+++ b/src/Monolog/Formatter/JsonFormatter.php
@@ -173,6 +173,10 @@ class JsonFormatter extends NormalizerFormatter
             return $normalized;
         }
 
+        if ($data instanceof \DateTimeInterface) {
+            return $this->formatDate($data);
+        }
+
         if ($data instanceof Throwable) {
             return $this->normalizeException($data, $depth);
         }


### PR DESCRIPTION
Hello! :)

This seems to be a leftover from #1459: JsonFormatter is not respecting the content of FormatterInterface->dateFormat.
The problem is because JsonFormatter extends the `normalize` method, but doesn't handle `DateTimeInterface` objects the same way `parent::normalize()` does. This PR fixes the issue. :)