### PR TITLE
Fix Utils::getClass() with PHP8

### DIFF
--- a/src/Monolog/Utils.php
+++ b/src/Monolog/Utils.php
@@ -19,7 +19,15 @@ final class Utils
     {
         $class = \get_class($object);
 
-        return 'c' === $class[0] && 0 === strpos($class, "class@anonymous\0") ? get_parent_class($class).'@anonymous' : $class;
+        if (false === ($pos = \strpos($class, "@anonymous\0"))) {
+            return $class;
+        }
+
+        if (false === ($parent = \get_parent_class($class))) {
+            return \substr($class, 0, $pos + 10);
+        }
+
+        return $parent . '@anonymous';
     }
 
     public static function substr(string $string, int $start, ?int $length = null): string

--- a/src/Monolog/Utils.php
+++ b/src/Monolog/Utils.php
@@ -19,11 +19,15 @@ final class Utils
     {
         $class = \get_class($object);
 
-        if (\PHP_VERSION_ID > 80000) {
+        if (false === ($pos = \strpos($class, "@anonymous\0"))) {
             return $class;
         }
-        
-        return 'c' === $class[0] && 0 === strpos($class, "class@anonymous\0") ? get_parent_class($class).'@anonymous' : $class;
+
+        if (false === ($parent = \get_parent_class($class))) {
+            return \substr($class, 0, $pos + 10);
+        }
+
+        return $parent . '@anonymous';
     }
 
     public static function substr(string $string, int $start, ?int $length = null): string

--- a/src/Monolog/Utils.php
+++ b/src/Monolog/Utils.php
@@ -19,15 +19,11 @@ final class Utils
     {
         $class = \get_class($object);
 
-        if (false === ($pos = \strpos($class, "@anonymous\0"))) {
+        if (\PHP_VERSION_ID > 80000) {
             return $class;
         }
-
-        if (false === ($parent = \get_parent_class($class))) {
-            return \substr($class, 0, $pos + 10);
-        }
-
-        return $parent . '@anonymous';
+        
+        return 'c' === $class[0] && 0 === strpos($class, "class@anonymous\0") ? get_parent_class($class).'@anonymous' : $class;
     }
 
     public static function substr(string $string, int $start, ?int $length = null): string

--- a/tests/Monolog/UtilsTest.php
+++ b/tests/Monolog/UtilsTest.php
@@ -15,6 +15,25 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @param string $expected
+     * @param object $object
+     * @dataProvider provideObjects
+     */
+    public function testGetClass($expected, $object)
+    {
+        $this->assertSame($expected, Utils::getClass($object));
+    }
+
+    public function provideObjects()
+    {
+        return [
+            ['stdClass', new \stdClass()],
+            ['class@anonymous', new class {}],
+            ['stdClass@anonymous', new class extends \stdClass {}],
+        ];
+    }
+
+    /**
+     * @param string $expected
      * @param string $input
      * @dataProvider providePathsToCanonicalize
      */


### PR DESCRIPTION
The results of this function differ over PHP versions since from PHP8 anonymous classes names don't necessarily start by _class_.

This PR takes also into account that _get_class_parent()_ may return _false_.