### PR TITLE
Allow psr/log 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "psr-4": {"Monolog\\": "tests/Monolog"}
     },
     "provide": {
-        "psr/log-implementation": "1.0.0"
+        "psr/log-implementation": "1.0.0 || 2.0.0"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "psr/log": "^1.0.1"
+        "psr/log": "^1.0.1 || ^2.0"
     },
     "require-dev": {
         "aws/aws-sdk-php": "^2.4.9 || ^3.0",


### PR DESCRIPTION
`psr/log` 2.0 was just tagged: https://twitter.com/phpfig/status/1415413578191024130

3.0 has been tagged too, but it would require a version bump and dropping support for `psr/log` 1.0, so we'll need to wait for now.

Details are available in the new meta document: https://www.php-fig.org/psr/psr-3/meta/
As always, changes are done in two steps to make a smoother transition path, as per the [PHP-FIG evolution bylaw](https://www.php-fig.org/bylaws/psr-evolution/)