### PR TITLE
Don't use the deprecated LoggerInterfaceTest class

### DIFF
--- a/tests/Monolog/PsrLogCompatTest.php
+++ b/tests/Monolog/PsrLogCompatTest.php
@@ -11,16 +11,130 @@
 
 namespace Monolog;
 
-use Monolog\Handler\TestHandler;
 use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\TestHandler;
 use Monolog\Processor\PsrLogMessageProcessor;
-use Psr\Log\Test\LoggerInterfaceTest;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
-class PsrLogCompatTest extends LoggerInterfaceTest
+class PsrLogCompatTest extends TestCase
 {
+    /**
+     * @var TestHandler
+     */
     private $handler;
 
-    public function getLogger()
+    public function testImplements(): void
+    {
+        $this->assertInstanceOf(LoggerInterface::class, $this->getLogger());
+    }
+
+    /**
+     * @dataProvider provideLevelsAndMessages
+     */
+    public function testLogsAtAllLevels(string $level, string $message): void
+    {
+        $logger = $this->getLogger();
+        $logger->{$level}($message, ['user' => 'Bob']);
+        $logger->log($level, $message, ['user' => 'Bob']);
+
+        $expected = [
+            $level.' message of level '.$level.' with context: Bob',
+            $level.' message of level '.$level.' with context: Bob',
+        ];
+        $this->assertEquals($expected, $this->getLogs());
+    }
+
+    public function provideLevelsAndMessages(): array
+    {
+        return [
+            LogLevel::EMERGENCY => [LogLevel::EMERGENCY, 'message of level emergency with context: {user}'],
+            LogLevel::ALERT => [LogLevel::ALERT, 'message of level alert with context: {user}'],
+            LogLevel::CRITICAL => [LogLevel::CRITICAL, 'message of level critical with context: {user}'],
+            LogLevel::ERROR => [LogLevel::ERROR, 'message of level error with context: {user}'],
+            LogLevel::WARNING => [LogLevel::WARNING, 'message of level warning with context: {user}'],
+            LogLevel::NOTICE => [LogLevel::NOTICE, 'message of level notice with context: {user}'],
+            LogLevel::INFO => [LogLevel::INFO, 'message of level info with context: {user}'],
+            LogLevel::DEBUG => [LogLevel::DEBUG, 'message of level debug with context: {user}'],
+        ];
+    }
+
+    public function testThrowsOnInvalidLevel(): void
+    {
+        $logger = $this->getLogger();
+
+        $this->expectException(InvalidArgumentException::class);
+        $logger->log('invalid level', 'Foo');
+    }
+
+    public function testContextReplacement(): void
+    {
+        $logger = $this->getLogger();
+        $logger->info('{Message {nothing} {user} {foo.bar} a}', ['user' => 'Bob', 'foo.bar' => 'Bar']);
+
+        $expected = ['info {Message {nothing} Bob Bar a}'];
+        $this->assertEquals($expected, $this->getLogs());
+    }
+
+    public function testObjectCastToString(): void
+    {
+        $dummy = new class {
+            public function __toString(): string
+            {
+                return 'DUMMY';
+            }
+        };
+
+        $this->getLogger()->warning($dummy);
+
+        $expected = ['warning DUMMY'];
+        $this->assertEquals($expected, $this->getLogs());
+    }
+
+    public function testContextCanContainAnything(): void
+    {
+        $closed = fopen('php://memory', 'r');
+        fclose($closed);
+
+        $context = [
+            'bool' => true,
+            'null' => null,
+            'string' => 'Foo',
+            'int' => 0,
+            'float' => 0.5,
+            'nested' => ['with object' => new class {
+                public function __toString()
+                {
+                    return 'DummyTest';
+                }
+            }],
+            'object' => new \DateTime,
+            'resource' => fopen('php://memory', 'r'),
+            'closed' => $closed,
+        ];
+
+        $this->getLogger()->warning('Crazy context data', $context);
+
+        $expected = ['warning Crazy context data'];
+        $this->assertEquals($expected, $this->getLogs());
+    }
+
+    public function testContextExceptionKeyCanBeExceptionOrOtherValues(): void
+    {
+        $logger = $this->getLogger();
+        $logger->warning('Random message', ['exception' => 'oops']);
+        $logger->critical('Uncaught Exception!', ['exception' => new \LogicException('Fail')]);
+
+        $expected = [
+            'warning Random message',
+            'critical Uncaught Exception!'
+        ];
+        $this->assertEquals($expected, $this->getLogs());
+    }
+
+    private function getLogger(): Logger
     {
         $logger = new Logger('foo');
         $logger->pushHandler($handler = new TestHandler);
@@ -32,10 +146,10 @@ class PsrLogCompatTest extends LoggerInterfaceTest
         return $logger;
     }
 
-    public function getLogs()
+    private function getLogs(): array
     {
-        $convert = function ($record) {
-            $lower = function ($match) {
+        $convert = static function ($record) {
+            $lower = static function ($match) {
                 return strtolower($match[0]);
             };
 


### PR DESCRIPTION
`Psr\Log\Test\LoggerInterfaceTest` is deprecated and has been removed in `psr/log` 2.0. This PR inlines the test cases from that class. That should unlock #1564.