### PR TITLE
Fix - SocketHandler. Set chunkSize default value

### DIFF
--- a/src/Monolog/Handler/SocketHandler.php
+++ b/src/Monolog/Handler/SocketHandler.php
@@ -271,7 +271,7 @@ class SocketHandler extends AbstractProcessingHandler
         if (!is_resource($this->resource)) {
             throw new LogicException('streamSetChunkSize called but $this->resource is not a resource');
         }
-var_dump(stream_set_chunk_size($this->resource, $this->chunkSize));
+
         return stream_set_chunk_size($this->resource, $this->chunkSize);
     }
 

--- a/tests/Monolog/Handler/SocketHandlerTest.php
+++ b/tests/Monolog/Handler/SocketHandlerTest.php
@@ -328,4 +328,10 @@ class SocketHandlerTest extends TestCase
 
         $this->handler->setFormatter($this->getIdentityFormatter());
     }
+
+    public function testChunkSizeSettedByDefault()
+    {
+        $this->createHandler('garbage://here');
+        $this->assertEquals(SocketHandler::DEFAULT_CHUNK_SIZE, $this->handler->getChunkSize());
+    }
 }


### PR DESCRIPTION
Fixes #1570 

Sets default value of chunkSize to 65023 (a good reasonable number like a UDP datagram size packet).

At the beggining I tried to set it to PHP_INT_MAX (according the documentation in the php website) but I got the following errors while execution the test `testWriteContentWithPlainTextMessage()`:

```

stream_set_chunk_size(): The chunk size cannot be larger than 2147483647
 monolog/src/Monolog/Handler/SocketHandler.php:272
 monolog/src/Monolog/Handler/SocketHandler.php:364
 monolog/src/Monolog/Handler/SocketHandler.php:339
 monolog/src/Monolog/Handler/SocketHandler.php:316
 monolog/src/Monolog/Handler/SocketHandler.php:74
 monolog/src/Monolog/Handler/SlackHandler.php:150
 monolog/src/Monolog/Handler/AbstractProcessingHandler.php:48
 monolog/tests/Monolog/Handler/SlackHandlerTest.php:108
 ```
I got it with php 7.4

So according the error , the number candidate `2147483647` is the max allowed.

But then I changed my mind and used number `65023`, the same used for UDP packets in the UdpHandler in Monolog.

If another number should be use as default, please let me know and I can change the PR asap!

I also fixed/changed some php-doc related issues in the file, and added a simple unit test for this.

Ideas/Suggestions are welcome.