### PR TITLE
Fix - OutOfMemory error in StreamHandler

### DIFF
--- a/src/Monolog/Utils.php
+++ b/src/Monolog/Utils.php
@@ -229,41 +229,27 @@ final class Utils
 
     /**
      * Converts a string with a valid 'memory_limit' format, to bytes.
-     * Reference: Function code from https://www.php.net/manual/en/function.ini-get.php
-     * @param string|int $val
+     *
+     * @param string|false $val
      * @return int|false Returns an integer representing bytes. Returns FALSE in case of error.
      */
-    public static function memoryIniValueToBytes($val)
+    public static function expandIniShorthandBytes($val)
     {
-        if (!is_string($val) && !is_integer($val)) {
+        if (!is_string($val)) {
             return false;
         }
 
-        $val = trim((string)$val);
+        // support -1
+        if ((int) $val < 0) {
+            return (int) $val;
+        }
 
-        if (empty($val)) {
+        if (!preg_match('/^\s*(?<val>\d+)(?:\.\d+)?\s*(?<unit>[gmk]?)\s*$/i', $val, $match)) {
             return false;
         }
 
-        $valLen = strlen($val);
-        $last = strtolower($val[$valLen - 1]);
-
-        if (preg_match('/[a-zA-Z]/', $last)) {
-            if ($valLen == 1) {
-                return false;
-            }
-
-            $val = substr($val, 0, -1);
-        }
-
-        if (!is_numeric($val) || $val < 0) {
-            return false;
-        }
-
-        //Lets be explicit here
-        $val = (int)($val);
-
-        switch ($last) {
+        $val = (int) $match['val'];
+        switch (strtolower($match['unit'] ?? '')) {
             case 'g':
                 $val *= 1024;
             case 'm':

--- a/src/Monolog/Utils.php
+++ b/src/Monolog/Utils.php
@@ -226,4 +226,52 @@ final class Utils
             );
         }
     }
+
+    /**
+     * Converts a string with a valid 'memory_limit' format, to bytes.
+     * Reference: Function code from https://www.php.net/manual/en/function.ini-get.php
+     * @param string|int $val
+     * @return int|false Returns an integer representing bytes. Returns FALSE in case of error.
+     */
+    public static function memoryIniValueToBytes($val)
+    {
+        if (!is_string($val) && !is_integer($val)) {
+            return false;
+        }
+
+        $val = trim((string)$val);
+
+        if (empty($val)) {
+            return false;
+        }
+
+        $valLen = strlen($val);
+        $last = strtolower($val[$valLen - 1]);
+
+        if (preg_match('/[a-zA-Z]/', $last)) {
+            if ($valLen == 1) {
+                return false;
+            }
+
+            $val = substr($val, 0, -1);
+        }
+
+        if (!is_numeric($val) || $val < 0) {
+            return false;
+        }
+
+        //Lets be explicit here
+        $val = (int)($val);
+
+        switch ($last) {
+            case 'g':
+                $val *= 1024;
+            case 'm':
+                $val *= 1024;
+            case 'k':
+                $val *= 1024;
+        }
+
+        return $val;
+    }
 }

--- a/tests/Monolog/UtilsTest.php
+++ b/tests/Monolog/UtilsTest.php
@@ -141,4 +141,47 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
             [-1, 'UNDEFINED_ERROR'],
         ];
     }
+
+    public function provideMemoryIniValuesToConvertToBytes()
+    {
+        return [
+            ['1', 1],
+            ['2', 2],
+            ['2.5', 2],
+            ['2.9', 2],
+            ['1B', 1],
+            ['1X', 1],
+            ['1K', 1024],
+            ['1G', 1073741824],
+            ['', false],
+            [null, false],
+            ['A', false],
+            ['AA', false],
+            ['B', false],
+            ['BB', false],
+            ['G', false],
+            ['GG', false],
+            ['-1', false],
+            ['-123', false],
+            ['-1A', false],
+            ['-1B', false],
+            ['-123G', false],
+            ['-B', false],
+            ['-A', false],
+            ['-', false],
+            [true, false],
+            [false, false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideMemoryIniValuesToConvertToBytes
+     * @param mixed $input
+     * @param int|false $expected
+     */
+    public function testMemoryIniValueToBytes($input, $expected)
+    {
+        $result = Utils::memoryIniValueToBytes($input);
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/tests/Monolog/UtilsTest.php
+++ b/tests/Monolog/UtilsTest.php
@@ -142,16 +142,18 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    public function provideMemoryIniValuesToConvertToBytes()
+    public function provideIniValuesToConvertToBytes()
     {
         return [
             ['1', 1],
             ['2', 2],
             ['2.5', 2],
             ['2.9', 2],
-            ['1B', 1],
-            ['1X', 1],
+            ['1B', false],
+            ['1X', false],
             ['1K', 1024],
+            ['1 K', 1024],
+            ['   5 M  ', 5*1024*1024],
             ['1G', 1073741824],
             ['', false],
             [null, false],
@@ -161,11 +163,11 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
             ['BB', false],
             ['G', false],
             ['GG', false],
-            ['-1', false],
-            ['-123', false],
-            ['-1A', false],
-            ['-1B', false],
-            ['-123G', false],
+            ['-1', -1],
+            ['-123', -123],
+            ['-1A', -1],
+            ['-1B', -1],
+            ['-123G', -123],
             ['-B', false],
             ['-A', false],
             ['-', false],
@@ -175,13 +177,13 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider provideMemoryIniValuesToConvertToBytes
+     * @dataProvider provideIniValuesToConvertToBytes
      * @param mixed $input
      * @param int|false $expected
      */
-    public function testMemoryIniValueToBytes($input, $expected)
+    public function testExpandIniShorthandBytes($input, $expected)
     {
-        $result = Utils::memoryIniValueToBytes($input);
+        $result = Utils::expandIniShorthandBytes($input);
         $this->assertEquals($expected, $result);
     }
 }


### PR DESCRIPTION
Fixes Issue #1577 

This change is meant to prevent setting a stream chunk size bigger than the available amount of memory.

The default value is still set, but can get change after calculations based on the php settings and the memory currently used by the php process.

There is a hard limit for an stream size of 2G ... is does not matter if the PHP process gets 1000 G of memory, the stream size cannot be bigger than 2G! and I suspect is because of some C lib used behind the scenes to implement streams in PHP.

Also ... the official PHP documentation states that `stream_set_chunk_size()` can hold a value of PHP_INT_MAX , but this is not completely true, because no matter what, it cannot be bigger than 2G! (because of the reason I already mentioned.

I suspect that if maybe the libs used in PHP are compiled with a 64 bit version... maybe the size can get bigger than 2G ... but just to be safe ... I would prefer to keep it in 2G.

This topic is quite tricky, please, someone elses opinion on this? ... thanks in advance


Ref: [PHP official documentation for stream_set_chunk_size()](https://www.php.net/manual/en/function.stream-set-chunk-size.php)