### PR TITLE
Removing mention of monolog-cascade

### DIFF
--- a/doc/01-usage.md
+++ b/doc/01-usage.md
@@ -109,10 +109,6 @@ Note that the FirePHPHandler is called first as it is added on top of the
 stack. This allows you to temporarily add a logger with bubbling disabled if
 you want to override other configured loggers.
 
-> If you use Monolog standalone and are looking for an easy way to
-> configure many handlers, the [theorchard/monolog-cascade](https://github.com/theorchard/monolog-cascade)
-> can help you build complex logging configs via PHP arrays, yaml or json configs.
-
 ## Adding extra data in the records
 
 Monolog provides two different ways to add extra information along the simple


### PR DESCRIPTION
monolog-cascade doesn't support monolog ^2.0 or php8

see related issues on theorchard/monolog-cascade:

https://github.com/theorchard/monolog-cascade/issues/90

https://github.com/theorchard/monolog-cascade/issues/102