### PR TITLE
Add constructor injection for `SocketHandler` and its children

### DIFF
--- a/src/Monolog/Handler/FleepHookHandler.php
+++ b/src/Monolog/Handler/FleepHookHandler.php
@@ -45,8 +45,16 @@ class FleepHookHandler extends SocketHandler
      * @param  string                    $token  Webhook token
      * @throws MissingExtensionException
      */
-    public function __construct(string $token, $level = Logger::DEBUG, bool $bubble = true)
-    {
+    public function __construct(
+        string $token,
+        $level = Logger::DEBUG,
+        bool $bubble = true,
+        bool $persistent = false,
+        float $timeout = 0.0,
+        float $writingTimeout = 10.0,
+        ?float $connectionTimeout = null,
+        ?int $chunkSize = null
+    ) {
         if (!extension_loaded('openssl')) {
             throw new MissingExtensionException('The OpenSSL PHP extension is required to use the FleepHookHandler');
         }
@@ -54,7 +62,16 @@ class FleepHookHandler extends SocketHandler
         $this->token = $token;
 
         $connectionString = 'ssl://' . static::FLEEP_HOST . ':443';
-        parent::__construct($connectionString, $level, $bubble);
+        parent::__construct(
+            $connectionString,
+            $level,
+            $bubble,
+            $persistent,
+            $timeout,
+            $writingTimeout,
+            $connectionTimeout,
+            $chunkSize
+        );
     }
 
     /**

--- a/src/Monolog/Handler/FlowdockHandler.php
+++ b/src/Monolog/Handler/FlowdockHandler.php
@@ -39,13 +39,30 @@ class FlowdockHandler extends SocketHandler
     /**
      * @throws MissingExtensionException if OpenSSL is missing
      */
-    public function __construct(string $apiToken, $level = Logger::DEBUG, bool $bubble = true)
-    {
+    public function __construct(
+        string $apiToken,
+        $level = Logger::DEBUG,
+        bool $bubble = true,
+        bool $persistent = false,
+        float $timeout = 0.0,
+        float $writingTimeout = 10.0,
+        ?float $connectionTimeout = null,
+        ?int $chunkSize = null
+    ) {
         if (!extension_loaded('openssl')) {
             throw new MissingExtensionException('The OpenSSL PHP extension is required to use the FlowdockHandler');
         }
 
-        parent::__construct('ssl://api.flowdock.com:443', $level, $bubble);
+        parent::__construct(
+            'ssl://api.flowdock.com:443',
+            $level,
+            $bubble,
+            $persistent,
+            $timeout,
+            $writingTimeout,
+            $connectionTimeout,
+            $chunkSize
+        );
         $this->apiToken = $apiToken;
     }
 

--- a/src/Monolog/Handler/InsightOpsHandler.php
+++ b/src/Monolog/Handler/InsightOpsHandler.php
@@ -33,8 +33,18 @@ class InsightOpsHandler extends SocketHandler
      *
      * @throws MissingExtensionException If SSL encryption is set to true and OpenSSL is missing
      */
-    public function __construct(string $token, string $region = 'us', bool $useSSL = true, $level = Logger::DEBUG, bool $bubble = true)
-    {
+    public function __construct(
+        string $token,
+        string $region = 'us',
+        bool $useSSL = true,
+        $level = Logger::DEBUG,
+        bool $bubble = true,
+        bool $persistent = false,
+        float $timeout = 0.0,
+        float $writingTimeout = 10.0,
+        ?float $connectionTimeout = null,
+        ?int $chunkSize = null
+    ) {
         if ($useSSL && !extension_loaded('openssl')) {
             throw new MissingExtensionException('The OpenSSL PHP plugin is required to use SSL encrypted connection for InsightOpsHandler');
         }
@@ -43,7 +53,16 @@ class InsightOpsHandler extends SocketHandler
             ? 'ssl://' . $region . '.data.logs.insight.rapid7.com:443'
             : $region . '.data.logs.insight.rapid7.com:80';
 
-        parent::__construct($endpoint, $level, $bubble);
+        parent::__construct(
+            $endpoint,
+            $level,
+            $bubble,
+            $persistent,
+            $timeout,
+            $writingTimeout,
+            $connectionTimeout,
+            $chunkSize
+        );
         $this->logToken = $token;
     }
 

--- a/src/Monolog/Handler/LogEntriesHandler.php
+++ b/src/Monolog/Handler/LogEntriesHandler.php
@@ -30,14 +30,33 @@ class LogEntriesHandler extends SocketHandler
      *
      * @throws MissingExtensionException If SSL encryption is set to true and OpenSSL is missing
      */
-    public function __construct(string $token, bool $useSSL = true, $level = Logger::DEBUG, bool $bubble = true, string $host = 'data.logentries.com')
-    {
+    public function __construct(
+        string $token,
+        bool $useSSL = true,
+        $level = Logger::DEBUG,
+        bool $bubble = true,
+        string $host = 'data.logentries.com',
+        bool $persistent = false,
+        float $timeout = 0.0,
+        float $writingTimeout = 10.0,
+        ?float $connectionTimeout = null,
+        ?int $chunkSize = null
+    ) {
         if ($useSSL && !extension_loaded('openssl')) {
             throw new MissingExtensionException('The OpenSSL PHP plugin is required to use SSL encrypted connection for LogEntriesHandler');
         }
 
         $endpoint = $useSSL ? 'ssl://' . $host . ':443' : $host . ':80';
-        parent::__construct($endpoint, $level, $bubble);
+        parent::__construct(
+            $endpoint,
+            $level,
+            $bubble,
+            $persistent,
+            $timeout,
+            $writingTimeout,
+            $connectionTimeout,
+            $chunkSize
+        );
         $this->logToken = $token;
     }
 

--- a/src/Monolog/Handler/LogmaticHandler.php
+++ b/src/Monolog/Handler/LogmaticHandler.php
@@ -43,8 +43,19 @@ class LogmaticHandler extends SocketHandler
      *
      * @throws MissingExtensionException If SSL encryption is set to true and OpenSSL is missing
      */
-    public function __construct(string $token, string $hostname = '', string $appname = '', bool $useSSL = true, $level = Logger::DEBUG, bool $bubble = true)
-    {
+    public function __construct(
+        string $token,
+        string $hostname = '',
+        string $appname = '',
+        bool $useSSL = true,
+        $level = Logger::DEBUG,
+        bool $bubble = true,
+        bool $persistent = false,
+        float $timeout = 0.0,
+        float $writingTimeout = 10.0,
+        ?float $connectionTimeout = null,
+        ?int $chunkSize = null
+    ) {
         if ($useSSL && !extension_loaded('openssl')) {
             throw new MissingExtensionException('The OpenSSL PHP extension is required to use SSL encrypted connection for LogmaticHandler');
         }
@@ -52,7 +63,16 @@ class LogmaticHandler extends SocketHandler
         $endpoint = $useSSL ? 'ssl://api.logmatic.io:10515' : 'api.logmatic.io:10514';
         $endpoint .= '/v1/';
 
-        parent::__construct($endpoint, $level, $bubble);
+        parent::__construct(
+            $endpoint,
+            $level,
+            $bubble,
+            $persistent,
+            $timeout,
+            $writingTimeout,
+            $connectionTimeout,
+            $chunkSize
+        );
 
         $this->logToken = $token;
         $this->hostname = $hostname;

--- a/src/Monolog/Handler/PushoverHandler.php
+++ b/src/Monolog/Handler/PushoverHandler.php
@@ -108,10 +108,24 @@ class PushoverHandler extends SocketHandler
         $highPriorityLevel = Logger::CRITICAL,
         $emergencyLevel = Logger::EMERGENCY,
         int $retry = 30,
-        int $expire = 25200
+        int $expire = 25200,
+        bool $persistent = false,
+        float $timeout = 0.0,
+        float $writingTimeout = 10.0,
+        ?float $connectionTimeout = null,
+        ?int $chunkSize = null
     ) {
         $connectionString = $useSSL ? 'ssl://api.pushover.net:443' : 'api.pushover.net:80';
-        parent::__construct($connectionString, $level, $bubble);
+        parent::__construct(
+            $connectionString,
+            $level,
+            $bubble,
+            $persistent,
+            $timeout,
+            $writingTimeout,
+            $connectionTimeout,
+            $chunkSize
+        );
 
         $this->token = $token;
         $this->users = (array) $users;

--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -59,13 +59,27 @@ class SlackHandler extends SocketHandler
         bool $bubble = true,
         bool $useShortAttachment = false,
         bool $includeContextAndExtra = false,
-        array $excludeFields = array()
+        array $excludeFields = array(),
+        bool $persistent = false,
+        float $timeout = 0.0,
+        float $writingTimeout = 10.0,
+        ?float $connectionTimeout = null,
+        ?int $chunkSize = null
     ) {
         if (!extension_loaded('openssl')) {
             throw new MissingExtensionException('The OpenSSL PHP extension is required to use the SlackHandler');
         }
 
-        parent::__construct('ssl://slack.com:443', $level, $bubble);
+        parent::__construct(
+            'ssl://slack.com:443',
+            $level,
+            $bubble,
+            $persistent,
+            $timeout,
+            $writingTimeout,
+            $connectionTimeout,
+            $chunkSize
+        );
 
         $this->slackRecord = new SlackRecord(
             $channel,

--- a/src/Monolog/Handler/SocketHandler.php
+++ b/src/Monolog/Handler/SocketHandler.php
@@ -48,7 +48,15 @@ class SocketHandler extends AbstractProcessingHandler
     private $lastWritingAt = null;
 
     /**
-     * @param string $connectionString Socket connection string
+     * @param string     $connectionString  Socket connection string
+     * @param bool       $persistent        Flag to enable/disable persistent connections
+     * @param float      $timeout           Socket timeout to wait until the request is being aborted
+     * @param float      $writingTimeout    Socket timeout to wait until the request should've been sent/written
+     * @param float|null $connectionTimeout Socket connect timeout to wait until the connection should've been
+     *                                      established
+     * @param int|null   $chunkSize         Sets the chunk size. Only has effect during connection in the writing cycle
+     *
+     * @throws \InvalidArgumentException    If an invalid timeout value (less than 0) is passed.
      */
     public function __construct(
         string $connectionString,

--- a/src/Monolog/Handler/SocketHandler.php
+++ b/src/Monolog/Handler/SocketHandler.php
@@ -31,15 +31,15 @@ class SocketHandler extends AbstractProcessingHandler
     /** @var resource|null */
     private $resource;
     /** @var float */
-    private $timeout = 0.0;
+    private $timeout;
     /** @var float */
-    private $writingTimeout = 10.0;
+    private $writingTimeout;
     /** @var ?int */
     private $lastSentBytes = null;
     /** @var ?int */
-    private $chunkSize = null;
+    private $chunkSize;
     /** @var bool */
-    private $persistent = false;
+    private $persistent;
     /** @var ?int */
     private $errno = null;
     /** @var ?string */
@@ -50,11 +50,30 @@ class SocketHandler extends AbstractProcessingHandler
     /**
      * @param string $connectionString Socket connection string
      */
-    public function __construct(string $connectionString, $level = Logger::DEBUG, bool $bubble = true)
-    {
+    public function __construct(
+        string $connectionString,
+        $level = Logger::DEBUG,
+        bool $bubble = true,
+        bool $persistent = false,
+        float $timeout = 0.0,
+        float $writingTimeout = 10.0,
+        ?float $connectionTimeout = null,
+        ?int $chunkSize = null
+    ) {
         parent::__construct($level, $bubble);
         $this->connectionString = $connectionString;
-        $this->connectionTimeout = (float) ini_get('default_socket_timeout');
+
+        if ($connectionTimeout !== null) {
+            $this->validateTimeout($connectionTimeout);
+        }
+
+        $this->connectionTimeout = $connectionTimeout ?? (float) ini_get('default_socket_timeout');
+        $this->persistent = $persistent;
+        $this->validateTimeout($timeout);
+        $this->timeout = $timeout;
+        $this->validateTimeout($writingTimeout);
+        $this->writingTimeout = $writingTimeout;
+        $this->chunkSize = $chunkSize;
     }
 
     /**


### PR DESCRIPTION
Hey there,

I'd like to propose a PoC to allow constructor injection for the `SocketHandler` and its children.
Is that something you want to support within monolog?

If not, I'd be fine with closing this. I can wrap around this and implement this as a feature in a dedicated abstraction layer tho.

Thanks in advance,
Max