### PR TITLE
Fixed ElasticsearchHandler.php throws associative context map to text error

### DIFF
--- a/src/Monolog/Formatter/ElasticsearchFormatter.php
+++ b/src/Monolog/Formatter/ElasticsearchFormatter.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 /*
  * This file is part of the Monolog package.
@@ -12,6 +14,7 @@
 namespace Monolog\Formatter;
 
 use DateTimeInterface;
+use Monolog\Utils;
 
 /**
  * Format a log message into an Elasticsearch record
@@ -32,7 +35,7 @@ class ElasticsearchFormatter extends NormalizerFormatter
 
     /**
      * @param string $index Elasticsearch index name
-     * @param string $type  Elasticsearch record type
+     * @param string $type Elasticsearch record type
      */
     public function __construct(string $index, string $type)
     {
@@ -49,8 +52,19 @@ class ElasticsearchFormatter extends NormalizerFormatter
     public function format(array $record)
     {
         $record = parent::format($record);
-
+        if ($this->isAssociativeArray($record['context'])) {
+            $record['context'] = Utils::jsonEncode($record['context']);
+        }
         return $this->getDocument($record);
+    }
+
+    /**
+     * @param array $array
+     * @return bool
+     */
+    function isAssociativeArray(array $array): bool
+    {
+        return count(array_filter(array_keys($array), 'is_string')) > 0;
     }
 
     /**
@@ -76,7 +90,7 @@ class ElasticsearchFormatter extends NormalizerFormatter
     /**
      * Convert a log message into an Elasticsearch record
      *
-     * @param  mixed[] $record Log message
+     * @param mixed[] $record Log message
      * @return mixed[]
      */
     protected function getDocument(array $record): array

--- a/tests/Monolog/Formatter/ElasticsearchFormatterTest.php
+++ b/tests/Monolog/Formatter/ElasticsearchFormatterTest.php
@@ -13,6 +13,8 @@ namespace Monolog\Formatter;
 
 use Monolog\Logger;
 
+use Monolog\Utils;
+
 class ElasticsearchFormatterTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -36,11 +38,11 @@ class ElasticsearchFormatterTest extends \PHPUnit\Framework\TestCase
         // Expected values
         $expected = $msg;
         $expected['datetime'] = '1970-01-01T00:00:00+0000';
-        $expected['context'] = [
-            'class' => ['stdClass' => []],
+        $expected['context'] = Utils::jsonEncode([
             'foo' => 7,
             0 => 'bar',
-        ];
+            'class' => ['stdClass' => []],
+        ]);
 
         // Format log message
         $formatter = new ElasticsearchFormatter('my_index', 'doc_type');


### PR DESCRIPTION
Using associative array causes this error:
Elasticsearch\Common\Exceptions\RuntimeException: mapper_parsing_exception: failed to parse field [context] of type [text] in document with id vendor\monolog\monolog\src\Monolog\Handler\ElasticsearchHandler.php on line 198

For resolving this error I've added a Json encode in ElasticsearchFormatter class to convert associative contexts to Json string