### PR TITLE
Use DateTimeImmutable by proper namespace

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -307,7 +307,7 @@ class Logger implements LoggerInterface, ResettableInterface
                     'level' => $level,
                     'level_name' => $levelName,
                     'channel' => $this->name,
-                    'datetime' => new DateTimeImmutable($this->microsecondTimestamps, $this->timezone),
+                    'datetime' => new \DateTimeImmutable($this->microsecondTimestamps, $this->timezone),
                     'extra' => [],
                 ];
 


### PR DESCRIPTION
With PHP 8.1 this results in:
```
Attempted to load class "DateTimeImmutable" from namespace "Monolog".
Did you forget a "use" statement for another namespace?
```
