### PR TITLE
return self on builder methods for more consistent behaviour

### DIFF
--- a/src/Monolog/Formatter/JsonFormatter.php
+++ b/src/Monolog/Formatter/JsonFormatter.php
@@ -109,11 +109,13 @@ class JsonFormatter extends NormalizerFormatter
     }
 
     /**
-     * @return void
+     * @return self
      */
-    public function includeStacktraces(bool $include = true)
+    public function includeStacktraces(bool $include = true): self
     {
         $this->includeStacktraces = $include;
+
+        return $this;
     }
 
     /**

--- a/src/Monolog/Formatter/LineFormatter.php
+++ b/src/Monolog/Formatter/LineFormatter.php
@@ -48,22 +48,28 @@ class LineFormatter extends NormalizerFormatter
         parent::__construct($dateFormat);
     }
 
-    public function includeStacktraces(bool $include = true): void
+    public function includeStacktraces(bool $include = true): self
     {
         $this->includeStacktraces = $include;
         if ($this->includeStacktraces) {
             $this->allowInlineLineBreaks = true;
         }
+
+        return $this;
     }
 
-    public function allowInlineLineBreaks(bool $allow = true): void
+    public function allowInlineLineBreaks(bool $allow = true): self
     {
         $this->allowInlineLineBreaks = $allow;
+
+        return $this;
     }
 
-    public function ignoreEmptyContextAndExtra(bool $ignore = true): void
+    public function ignoreEmptyContextAndExtra(bool $ignore = true): self
     {
         $this->ignoreEmptyContextAndExtra = $ignore;
+
+        return $this;
     }
 
     /**

--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -267,13 +267,17 @@ class NormalizerFormatter implements FormatterInterface
         return $date->format($this->dateFormat);
     }
 
-    public function addJsonEncodeOption(int $option): void
+    public function addJsonEncodeOption(int $option): self
     {
         $this->jsonEncodeOptions |= $option;
+
+        return $this;
     }
 
-    public function removeJsonEncodeOption(int $option): void
+    public function removeJsonEncodeOption(int $option): self
     {
         $this->jsonEncodeOptions &= ~$option;
+
+        return $this;
     }
 }

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -272,9 +272,11 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * @param bool $micro True to use microtime() to create timestamps
      */
-    public function useMicrosecondTimestamps(bool $micro): void
+    public function useMicrosecondTimestamps(bool $micro): self
     {
         $this->microsecondTimestamps = $micro;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Just an example i just ran into:

```php
$formatter = (new LineFormatter)
    ->setJsonPrettyPrint(true) // -> LineFormatter instance
    ->addJsonEncodeOption(JSON_UNESCAPED_SLASHES) // -> void
    ->addJsonEncodeOption(JSON_UNESCAPED_UNICODE); // boo!
```

I didn't go through the handler classes to check for similar cases.