### PR TITLE
IntrospectionProcessor returns also information about call type

### DIFF
--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -101,6 +101,7 @@ class IntrospectionProcessor implements ProcessorInterface
                 'file'      => isset($trace[$i - 1]['file']) ? $trace[$i - 1]['file'] : null,
                 'line'      => isset($trace[$i - 1]['line']) ? $trace[$i - 1]['line'] : null,
                 'class'     => isset($trace[$i]['class']) ? $trace[$i]['class'] : null,
+                'callType'  => isset($trace[$i]['type']) ? $trace[$]['type'] : null,
                 'function'  => isset($trace[$i]['function']) ? $trace[$i]['function'] : null,
             ]
         );


### PR DESCRIPTION
$record['extra']['callType'] will contain current call type: "->" or "::" depending if it was normal or static method call.
Gives possibility to nicely format messages "{$record['extra']['class']}{$record['extra']['callType']}{$record['extra']['function']} ..."