### PR TITLE
Fix ErrorHandler::handleError signature: make $context nullable

### DIFF
--- a/src/Monolog/ErrorHandler.php
+++ b/src/Monolog/ErrorHandler.php
@@ -210,7 +210,7 @@ class ErrorHandler
      *
      * @param mixed[] $context
      */
-    public function handleError(int $code, string $message, string $file = '', int $line = 0, array $context = []): bool
+    public function handleError(int $code, string $message, string $file = '', int $line = 0, ?array $context = []): bool
     {
         if ($this->handleOnlyReportedErrors && !(error_reporting() & $code)) {
             return false;


### PR DESCRIPTION
Even though the PHP docs don't mention it, the error context can be null. We just experienced this with a failing `getaddrinfo` call from an internal PHP function, which triggered a warning which in turn crashed the Monolog error handler.

A more in-depth explanation for this fix can be found in the Sentry repo, where the same problem was fixed a while back: https://github.com/getsentry/sentry-php/issues/912#issuecomment-548580147

Thanks in advance!