### PR TITLE
Handling the maximum length of a Telegram message

### DIFF
--- a/src/Monolog/Handler/TelegramBotHandler.php
+++ b/src/Monolog/Handler/TelegramBotHandler.php
@@ -174,7 +174,9 @@ class TelegramBotHandler extends AbstractProcessingHandler
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
-            'text' => $message,
+            'text' => strlen($message) <= 4096 ? 
+                $message : 
+                substr($message, 0, 4081) . ' (...truncated)',
             'chat_id' => $this->channel,
             'parse_mode' => $this->parseMode,
             'disable_web_page_preview' => $this->disableWebPagePreview,


### PR DESCRIPTION
The maximum allowed length of a Telegram message - 4096 symbols. Longer messages are not delivered.