### PR TITLE
Handling the maximum length of a Telegram message

### DIFF
--- a/src/Monolog/Handler/TelegramBotHandler.php
+++ b/src/Monolog/Handler/TelegramBotHandler.php
@@ -105,14 +105,15 @@ class TelegramBotHandler extends AbstractProcessingHandler
     public function __construct(
         string $apiKey,
         string $channel,
-        $level = Logger::DEBUG,
-        bool $bubble = true,
+               $level = Logger::DEBUG,
+        bool   $bubble = true,
         string $parseMode = null,
-        bool $disableWebPagePreview = null,
-        bool $disableNotification = null,
-        bool $splitLongMessages = false,
-        bool $delayBetweenMessages = false
-    ) {
+        bool   $disableWebPagePreview = null,
+        bool   $disableNotification = null,
+        bool   $splitLongMessages = false,
+        bool   $delayBetweenMessages = false
+    )
+    {
         if (!extension_loaded('curl')) {
             throw new MissingExtensionException('The curl extension is needed to use the TelegramBotHandler');
         }
@@ -200,7 +201,7 @@ class TelegramBotHandler extends AbstractProcessingHandler
         }
 
         if (!empty($messages)) {
-            $this->send((string) $this->getFormatter()->formatBatch($messages));
+            $this->send((string)$this->getFormatter()->formatBatch($messages));
         }
     }
 
@@ -263,7 +264,7 @@ class TelegramBotHandler extends AbstractProcessingHandler
     private function handleMessageLength(string $message): array
     {
         $truncatedMarker = ' (...truncated)';
-        if(!$this->splitLongMessages && strlen($message) > self::MAX_MESSAGE_LENGTH) {
+        if (!$this->splitLongMessages && strlen($message) > self::MAX_MESSAGE_LENGTH) {
             return [substr($message, 0, self::MAX_MESSAGE_LENGTH - strlen($truncatedMarker)) . $truncatedMarker];
         }
 


### PR DESCRIPTION
The maximum allowed length of a Telegram message - 4096 symbols (['text' field](https://core.telegram.org/bots/api#message)). 
Longer messages are not delivered.

Therefore, I implemented truncating too long message to the maximum length allowed as the default behavior. 
An additional option that you can enable by `splitLongMessages` is  splitting too long message into several. Also, using `delayBetweenMessages` you can enable a 1 second delay between sending a split message to avoid the _429 Too Many Requests_ error (according to the recommendations - [My bot is hitting limits, how do I avoid this?](https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this))