### PR TITLE
SlackWebhookHandler: use footer for username & footer_icon for userIcon

### DIFF
--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -146,12 +146,14 @@ class SlackRecord
 
         if ($this->useAttachment) {
             $attachment = array(
-                'fallback'  => $message,
-                'text'      => $message,
-                'color'     => $this->getAttachmentColor($record['level']),
-                'fields'    => array(),
-                'mrkdwn_in' => array('fields'),
-                'ts'        => $record['datetime']->getTimestamp(),
+                'fallback'    => $message,
+                'text'        => $message,
+                'color'       => $this->getAttachmentColor($record['level']),
+                'fields'      => array(),
+                'mrkdwn_in'   => array('fields'),
+                'ts'          => $record['datetime']->getTimestamp(),
+                'footer'      => $this->username,
+                'footer_icon' => $this->userIcon,
             );
 
             if ($this->useShortAttachment) {

--- a/tests/Monolog/Handler/SlackWebhookHandlerTest.php
+++ b/tests/Monolog/Handler/SlackWebhookHandlerTest.php
@@ -51,6 +51,8 @@ class SlackWebhookHandlerTest extends TestCase
                     'title' => 'Message',
                     'mrkdwn_in' => array('fields'),
                     'ts' => $record['datetime']->getTimestamp(),
+                    'footer' => null,
+                    'footer_icon' => null,
                 ),
             ),
         ), $slackRecord->getSlackData($record));
@@ -82,6 +84,53 @@ class SlackWebhookHandlerTest extends TestCase
             'channel' => 'test-channel',
             'icon_emoji' => ':ghost:',
         ), $slackRecord->getSlackData($this->getRecord()));
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getSlackRecord
+     */
+    public function testConstructorFullWithAttachment()
+    {
+        $handler = new SlackWebhookHandler(
+            self::WEBHOOK_URL,
+            'test-channel-with-attachment',
+            'test-username-with-attachment',
+            true,
+            'https://www.example.com/example.png',
+            false,
+            false,
+            Logger::DEBUG,
+            false
+        );
+
+        $record = $this->getRecord();
+        $slackRecord = $handler->getSlackRecord();
+        $this->assertInstanceOf('Monolog\Handler\Slack\SlackRecord', $slackRecord);
+        $this->assertEquals(array(
+            'username' => 'test-username-with-attachment',
+            'channel' => 'test-channel-with-attachment',
+            'attachments' => array(
+                array(
+                    'fallback' => 'test',
+                    'text' => 'test',
+                    'color' => SlackRecord::COLOR_WARNING,
+                    'fields' => array(
+                        array(
+                            'title' => 'Level',
+                            'value' => Logger::getLevelName(Logger::WARNING),
+                            'short' => false,
+                        ),
+                    ),
+                    'mrkdwn_in' => array('fields'),
+                    'ts' => $record['datetime']->getTimestamp(),
+                    'footer' => 'test-username-with-attachment',
+                    'footer_icon' => 'https://www.example.com/example.png',
+                    'title' => 'Message',
+                ),
+            ),
+            'icon_url' => 'https://www.example.com/example.png',
+        ), $slackRecord->getSlackData($record));
     }
 
     /**


### PR DESCRIPTION
related to https://github.com/Seldaek/monolog/issues/1247 & https://github.com/Seldaek/monolog/issues/1332

Since userIcon & username cannot be overridden, the text & smaller icon in footer can be used instead.

![custom-username](https://user-images.githubusercontent.com/2762992/143627373-a53e28c5-468e-4e4a-afb0-d405ddfbb93e.jpg)

