### PR TITLE
change property visibility to protected

### DIFF
--- a/src/Monolog/Handler/SlackWebhookHandler.php
+++ b/src/Monolog/Handler/SlackWebhookHandler.php
@@ -28,13 +28,13 @@ class SlackWebhookHandler extends AbstractProcessingHandler
      * Slack Webhook token
      * @var string
      */
-    private $webhookUrl;
+    protected $webhookUrl;
 
     /**
      * Instance of the SlackRecord util class preparing data for Slack API.
      * @var SlackRecord
      */
-    private $slackRecord;
+    protected $slackRecord;
 
     /**
      * @param string      $webhookUrl             Slack Webhook URL


### PR DESCRIPTION
Turning the visibility of the properties protected makes the class useable for extension.