### PR TITLE
Add AsMonologProcessor attribute

### DIFF
--- a/src/Monolog/Attribute/AsMonologProcessor.php
+++ b/src/Monolog/Attribute/AsMonologProcessor.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Attribute;
+
+/**
+ * A reusable attribute to help configure a class or a method as a processor.
+ * 
+ * Using it offers no guarantee: it needs to be leveraged by a Monolog third-party consumer.
+ * 
+ * Using it with the Monolog library only has no effect at all: processors should still be turned into a callable if
+ * needed and manually pushed to the loggers and to the processable handlers.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class AsMonologProcessor
+{
+    /**
+     * @param string|null $channel  The logging channel the processor should be pushed to.
+     * @param string|null $handler  The handler the processor should be pushed to.
+     * @param string|null $method   The method that processes the records (if the attribute is used at the class level).
+     */
+    public function __construct(
+        public ?string $channel = null,
+        public ?string $handler = null,
+        public ?string $method = null,
+    ) {
+    }
+} 

--- a/tests/Monolog/Attribute/AsMonologProcessorTest.php
+++ b/tests/Monolog/Attribute/AsMonologProcessorTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Attribute;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @requires PHP 8.0
+ */
+final class AsMonologProcessorTest extends TestCase
+{
+    public function test(): void
+    {
+        $asMonologProcessor = new AsMonologProcessor('channel', 'handler', 'method');
+        $this->assertSame('channel', $asMonologProcessor->channel);
+        $this->assertSame('handler', $asMonologProcessor->handler);
+        $this->assertSame('method', $asMonologProcessor->method);
+
+        $asMonologProcessor = new AsMonologProcessor(null, null, null);
+        $this->assertNull($asMonologProcessor->channel);
+        $this->assertNull($asMonologProcessor->handler);
+        $this->assertNull($asMonologProcessor->method);
+    }
+}


### PR DESCRIPTION
Ref https://github.com/symfony/monolog-bundle/pull/428

This PR adds an attribute that third-party consumers can leverage to "configure" Monolog processors.

I didn't find any real benefits in supporting it directly in Monolog's `pushProcessor()` methods:
1. We would need to widen the type from `callable` to `callable|object` to accept any objects potentially using the attribute, and that would be a BC break.
2. Monolog would only use the `method` "option" and it doesn't bring any real value, it's already easy to do:
```php
->pushProcessor([$myProcessor, 'myCustomMethod'])
```

cc @derrabus and @nicolas-grekas 