### PR TITLE
Forgotten config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,4 +4,4 @@
 /phpstan.neon.dist export-ignore
 /phpunit.xml.dist export-ignore
 /_config.yml export-ignore
-/UPGRADE.md
+/UPGRADE.md export-ignore


### PR DESCRIPTION
Look like the line is incomplete, example: https://github.com/Seldaek/monolog/commit/7ce63f964426a57b6a1c213d45e05eef1f013c54 `Add missing export-ignore`