### PR TITLE
Use never return typehint

### DIFF
--- a/src/Monolog/ErrorHandler.php
+++ b/src/Monolog/ErrorHandler.php
@@ -175,9 +175,6 @@ class ErrorHandler
         ];
     }
 
-    /**
-     * @phpstan-return never
-     */
     private function handleException(\Throwable $e): never
     {
         $level = LogLevel::ERROR;

--- a/src/Monolog/ErrorHandler.php
+++ b/src/Monolog/ErrorHandler.php
@@ -178,7 +178,7 @@ class ErrorHandler
     /**
      * @phpstan-return never
      */
-    private function handleException(\Throwable $e): void
+    private function handleException(\Throwable $e): never
     {
         $level = LogLevel::ERROR;
         foreach ($this->uncaughtExceptionLevelMap as $class => $candidate) {

--- a/src/Monolog/Utils.php
+++ b/src/Monolog/Utils.php
@@ -165,8 +165,6 @@ final class Utils
      * @param  int               $code return code of json_last_error function
      * @param  mixed             $data data that was meant to be encoded
      * @throws \RuntimeException
-     *
-     * @return never
      */
     private static function throwEncodeError(int $code, $data): never
     {

--- a/src/Monolog/Utils.php
+++ b/src/Monolog/Utils.php
@@ -168,7 +168,7 @@ final class Utils
      *
      * @return never
      */
-    private static function throwEncodeError(int $code, $data): void
+    private static function throwEncodeError(int $code, $data): never
     {
         switch ($code) {
             case JSON_ERROR_DEPTH:


### PR DESCRIPTION
The `never` return typehint was added in PHP 8.1 and can be used
to indicate that a function will never return.

RFC: https://wiki.php.net/rfc/noreturn_type