### PR TITLE
replace deprecated method calls in GelfMessageFormatter

### DIFF
--- a/src/Monolog/Formatter/GelfMessageFormatter.php
+++ b/src/Monolog/Formatter/GelfMessageFormatter.php
@@ -108,14 +108,14 @@ class GelfMessageFormatter extends NormalizerFormatter
         }
 
         if (isset($record->channel)) {
-            $message->setFacility($record->channel);
+            $message->setAdditional('facility', $record->channel);
         }
         if (isset($extra['line'])) {
-            $message->setLine($extra['line']);
+            $message->setAdditional('line', $extra['line']);
             unset($extra['line']);
         }
         if (isset($extra['file'])) {
-            $message->setFile($extra['file']);
+            $message->setAdditional('file', $extra['file']);
             unset($extra['file']);
         }
 
@@ -141,11 +141,10 @@ class GelfMessageFormatter extends NormalizerFormatter
             $message->setAdditional($this->contextPrefix . $key, $val);
         }
 
-        /** @phpstan-ignore-next-line */
-        if (null === $message->getFile() && isset($context['exception']['file'])) {
+        if (!$message->hasAdditional('file') && isset($context['exception']['file'])) {
             if (1 === preg_match("/^(.+):([0-9]+)$/", $context['exception']['file'], $matches)) {
-                $message->setFile($matches[1]);
-                $message->setLine($matches[2]);
+                $message->setAdditional('file', $matches[1]);
+                $message->setAdditional('line', $matches[2]);
             }
         }
 

--- a/tests/Monolog/Formatter/GelfMessageFormatterTest.php
+++ b/tests/Monolog/Formatter/GelfMessageFormatterTest.php
@@ -41,9 +41,9 @@ class GelfMessageFormatterTest extends TestCase
         $this->assertInstanceOf('Gelf\Message', $message);
         $this->assertEquals(0, $message->getTimestamp());
         $this->assertEquals('log', $message->getShortMessage());
-        $this->assertEquals('meh', $message->getFacility());
-        $this->assertEquals(null, $message->getLine());
-        $this->assertEquals(null, $message->getFile());
+        $this->assertEquals('meh', $message->getAdditional('facility'));
+        $this->assertEquals(false, $message->hasAdditional('line'));
+        $this->assertEquals(false, $message->hasAdditional('file'));
         $this->assertEquals($this->isLegacy() ? 3 : 'error', $message->getLevel());
         $this->assertNotEmpty($message->getHost());
 
@@ -73,8 +73,8 @@ class GelfMessageFormatterTest extends TestCase
         $message = $formatter->format($record);
 
         $this->assertInstanceOf('Gelf\Message', $message);
-        $this->assertEquals('test', $message->getFile());
-        $this->assertEquals(14, $message->getLine());
+        $this->assertEquals('test', $message->getAdditional('file'));
+        $this->assertEquals(14, $message->getAdditional('line'));
     }
 
     /**
@@ -135,8 +135,8 @@ class GelfMessageFormatterTest extends TestCase
 
         $this->assertInstanceOf('Gelf\Message', $message);
 
-        $this->assertEquals("/some/file/in/dir.php", $message->getFile());
-        $this->assertEquals("56", $message->getLine());
+        $this->assertEquals("/some/file/in/dir.php", $message->getAdditional('file'));
+        $this->assertEquals("56", $message->getAdditional('line'));
     }
 
     /**

--- a/tests/Monolog/Handler/GelfHandlerTest.php
+++ b/tests/Monolog/Handler/GelfHandlerTest.php
@@ -55,7 +55,7 @@ class GelfHandlerTest extends TestCase
         $expectedMessage = new Message();
         $expectedMessage
             ->setLevel(7)
-            ->setFacility("test")
+            ->setAdditional('facility', 'test')
             ->setShortMessage($record->message)
             ->setTimestamp($record->datetime)
         ;
@@ -76,7 +76,7 @@ class GelfHandlerTest extends TestCase
         $expectedMessage = new Message();
         $expectedMessage
             ->setLevel(4)
-            ->setFacility("test")
+            ->setAdditional('facility', 'test')
             ->setShortMessage($record->message)
             ->setTimestamp($record->datetime)
         ;
@@ -103,7 +103,7 @@ class GelfHandlerTest extends TestCase
         $expectedMessage = new Message();
         $expectedMessage
             ->setLevel(4)
-            ->setFacility("test")
+            ->setAdditional('facility', 'test')
             ->setHost("mysystem")
             ->setShortMessage($record->message)
             ->setTimestamp($record->datetime)


### PR DESCRIPTION
- the getter/setter methods for file, level and facility are deprecated in gelf v1.1
- add those fields as additional instead, as suggested in the gelf spec (https://docs.graylog.org/v1/docs/gelf#gelf-payload-specification)
- update tests to reflect changes

(continuation of #1658)