### PR TITLE
[2.X] Allow stacktraces parser on LineFormatter

### DIFF
--- a/src/Monolog/Formatter/LineFormatter.php
+++ b/src/Monolog/Formatter/LineFormatter.php
@@ -33,6 +33,8 @@ class LineFormatter extends NormalizerFormatter
     protected $ignoreEmptyContextAndExtra;
     /** @var bool */
     protected $includeStacktraces;
+    /** @var ?callable */
+    protected $stacktracesParser;
 
     /**
      * @param string|null $format                     The format of the message
@@ -49,11 +51,12 @@ class LineFormatter extends NormalizerFormatter
         parent::__construct($dateFormat);
     }
 
-    public function includeStacktraces(bool $include = true): self
+    public function includeStacktraces(bool $include = true, ?callable $parser = null): self
     {
         $this->includeStacktraces = $include;
         if ($this->includeStacktraces) {
             $this->allowInlineLineBreaks = true;
+            $this->stacktracesParser = $parser;
         }
 
         return $this;
@@ -209,9 +212,25 @@ class LineFormatter extends NormalizerFormatter
         $str .= '): ' . $e->getMessage() . ' at ' . $e->getFile() . ':' . $e->getLine() . ')';
 
         if ($this->includeStacktraces) {
-            $str .= "\n[stacktrace]\n" . $e->getTraceAsString() . "\n";
+            $str .= $this->stacktracesParser($e);
         }
 
         return $str;
+    }
+
+    private function stacktracesParser(\Throwable $e): string
+    {
+        $trace = $e->getTraceAsString();
+
+        if ($this->stacktracesParser) {
+            $trace = $this->stacktracesParserCustom($trace);
+        }
+
+        return "\n[stacktrace]\n" . $trace . "\n";
+    }
+
+    private function stacktracesParserCustom(string $trace): string
+    {
+        return implode("\n", array_filter(array_map($this->stacktracesParser, explode("\n", $trace))));
     }
 }

--- a/tests/Monolog/Formatter/LineFormatterTest.php
+++ b/tests/Monolog/Formatter/LineFormatterTest.php
@@ -155,6 +155,73 @@ class LineFormatterTest extends \PHPUnit\Framework\TestCase
         $this->assertRegexp('{^\['.date('Y-m-d').'] core\.CRITICAL: foobar \{"exception":"\[object] \(RuntimeException\(code: 0\): Foo at '.preg_quote(substr($path, 1, -1)).':'.(__LINE__ - 8).'\)\n\[stacktrace]\n#0}', $message);
     }
 
+    public function testDefFormatWithExceptionAndStacktraceParserFull()
+    {
+        $formatter = new LineFormatter(null, 'Y-m-d');
+        $formatter->includeStacktraces(true, function ($line) {
+            return $line;
+        });
+
+        $message = $formatter->format([
+            'level_name' => 'CRITICAL',
+            'channel' => 'core',
+            'context' => ['exception' => new \RuntimeException('Foo')],
+            'datetime' => new \DateTimeImmutable,
+            'extra' => [],
+            'message' => 'foobar',
+        ]);
+
+        $trace = explode('[stacktrace]', $message, 2)[1];
+
+        $this->assertStringContainsString('TestCase.php', $trace);
+        $this->assertStringContainsString('TestResult.php', $trace);
+    }
+
+    public function testDefFormatWithExceptionAndStacktraceParserCustom()
+    {
+        $formatter = new LineFormatter(null, 'Y-m-d');
+        $formatter->includeStacktraces(true, function ($line) {
+            if (strpos($line, 'TestCase.php') === false) {
+                return $line;
+            }
+        });
+
+        $message = $formatter->format([
+            'level_name' => 'CRITICAL',
+            'channel' => 'core',
+            'context' => ['exception' => new \RuntimeException('Foo')],
+            'datetime' => new \DateTimeImmutable,
+            'extra' => [],
+            'message' => 'foobar',
+        ]);
+
+        $trace = explode('[stacktrace]', $message, 2)[1];
+
+        $this->assertStringNotContainsString('TestCase.php', $trace);
+        $this->assertStringContainsString('TestResult.php', $trace);
+    }
+
+    public function testDefFormatWithExceptionAndStacktraceParserEmpty()
+    {
+        $formatter = new LineFormatter(null, 'Y-m-d');
+        $formatter->includeStacktraces(true, function ($line) {
+            return null;
+        });
+
+        $message = $formatter->format([
+            'level_name' => 'CRITICAL',
+            'channel' => 'core',
+            'context' => ['exception' => new \RuntimeException('Foo')],
+            'datetime' => new \DateTimeImmutable,
+            'extra' => [],
+            'message' => 'foobar',
+        ]);
+
+        $trace = explode('[stacktrace]', $message, 2)[1];
+
+        $this->assertStringNotContainsString('#', $trace);
+    }
+
     public function testDefFormatWithPreviousException()
     {
         $formatter = new LineFormatter(null, 'Y-m-d');


### PR DESCRIPTION
This PR includes the hability to filter or parse the exception `trace` to avoid or customize every trace line.

For example, I want to avoid to log Laravel Framework lines, except if is the first one:

```php
$formatter = new LineFormatter(null, 'Y-m-d H:i:s', true, true);
$formatter->includeStacktraces(true, function ($line) {
    if (!str_contains($line, '/vendor/laravel/') || str_starts_with($line, '#0 ')) {
        return $line;
    }
});
```

Without the parser, I get the log as:

```
[2022-05-06 11:47:16] local.ERROR: Call to undefined method App\Domains\Product\Model\Product::orderyCreatedAt() {"userId":1,"exception":"[object] (BadMethodCallException(code: 0): Call to undefined method App\\Domains\\Product\\Model\\Product::orderyCreatedAt() at /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Support/Traits/ForwardsCalls.php:71)
[stacktrace]
#0 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Support/Traits/ForwardsCalls.php(36): Illuminate\\Database\\Eloquent\\Model::throwBadMethodCallException()
#1 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(2163): Illuminate\\Database\\Eloquent\\Model->forwardCallTo()
#2 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(2175): Illuminate\\Database\\Eloquent\\Model->__call()
#3 /home/lito/www/project/app/Domains/Dashboard/Service/Controller/Index.php(44): Illuminate\\Database\\Eloquent\\Model::__callStatic()
#4 /home/lito/www/project/app/Domains/Dashboard/Service/Controller/Index.php(31): App\\Domains\\Dashboard\\Service\\Controller\\Index->productsWithoutPage()
#5 /home/lito/www/project/app/Domains/Dashboard/Controller/Index.php(18): App\\Domains\\Dashboard\\Service\\Controller\\Index->data()
#6 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Routing/Controller.php(54): App\\Domains\\Dashboard\\Controller\\Index->__invoke()
#7 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Routing/ControllerDispatcher.php(45): Illuminate\\Routing\\Controller->callAction()
#8 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Routing/Route.php(261): Illuminate\\Routing\\ControllerDispatcher->dispatch()
#9 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Routing/Route.php(204): Illuminate\\Routing\\Route->runController()
#10 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Routing/Router.php(725): Illuminate\\Routing\\Route->run()
#11 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(141): Illuminate\\Routing\\Router->Illuminate\\Routing\\{closure}()
#12 /home/lito/www/project/app/Domains/Shared/Controller/ControllerAbstract.php(39): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#13 /home/lito/www/project/app/Domains/Shared/Controller/ControllerAbstract.php(23): App\\Domains\\Shared\\Controller\\ControllerAbstract->setup()
#14 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(162): App\\Domains\\Shared\\Controller\\ControllerAbstract->App\\Domains\\Shared\\Controller\\{closure}()
#15 /home/lito/www/project/app/Domains/CmsMenu/Middleware/Allowed.php(24): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#16 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): App\\Domains\\CmsMenu\\Middleware\\Allowed->handle()
#17 /home/lito/www/project/app/Domains/CmsUser/Middleware/Auth.php(24): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#18 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): App\\Domains\\CmsUser\\Middleware\\Auth->handle()
#19 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(116): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#20 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Routing/Router.php(726): Illuminate\\Pipeline\\Pipeline->then()
#21 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Routing/Router.php(703): Illuminate\\Routing\\Router->runRouteWithinStack()
#22 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Routing/Router.php(667): Illuminate\\Routing\\Router->runRoute()
#23 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Routing/Router.php(656): Illuminate\\Routing\\Router->dispatchToRoute()
#24 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(167): Illuminate\\Routing\\Router->dispatch()
#25 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(141): Illuminate\\Foundation\\Http\\Kernel->Illuminate\\Foundation\\Http\\{closure}()
#26 /home/lito/www/project/vendor/barryvdh/laravel-debugbar/src/Middleware/InjectDebugbar.php(67): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#27 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): Barryvdh\\Debugbar\\Middleware\\InjectDebugbar->handle()
#28 /home/lito/www/project/app/Domains/Language/Middleware/Request.php(21): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#29 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): App\\Domains\\Language\\Middleware\\Request->handle()
#30 /home/lito/www/project/app/Domains/Configuration/Middleware/Request.php(21): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#31 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): App\\Domains\\Configuration\\Middleware\\Request->handle()
#32 /home/lito/www/project/app/Http/Middleware/MessagesShareFromSession.php(23): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#33 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): App\\Http\\Middleware\\MessagesShareFromSession->handle()
#34 /home/lito/www/project/app/Http/Middleware/Reset.php(22): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#35 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): App\\Http\\Middleware\\Reset->handle()
#36 /home/lito/www/project/app/Http/Middleware/RequestLogger.php(20): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#37 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): App\\Http\\Middleware\\RequestLogger->handle()
#38 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Session/Middleware/StartSession.php(121): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#39 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Session/Middleware/StartSession.php(64): Illuminate\\Session\\Middleware\\StartSession->handleStatefulRequest()
#40 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): Illuminate\\Session\\Middleware\\StartSession->handle()
#41 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/AddQueuedCookiesToResponse.php(37): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#42 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse->handle()
#43 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/EncryptCookies.php(67): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#44 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): Illuminate\\Cookie\\Middleware\\EncryptCookies->handle()
#45 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php(86): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#46 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(180): Illuminate\\Foundation\\Http\\Middleware\\PreventRequestsDuringMaintenance->handle()
#47 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(116): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#48 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(142): Illuminate\\Pipeline\\Pipeline->then()
#49 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(111): Illuminate\\Foundation\\Http\\Kernel->sendRequestThroughRouter()
#50 /home/lito/www/project/public/index.php(55): Illuminate\\Foundation\\Http\\Kernel->handle()
#51 {main}
"} 
```
With parser I get only the important lines:
```
[2022-05-06 11:47:02] local.ERROR: Call to undefined method App\Domains\Product\Model\Product::orderyCreatedAt() {"userId":1,"exception":"[object] (BadMethodCallException(code: 0): Call to undefined method App\\Domains\\Product\\Model\\Product::orderyCreatedAt() at /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Support/Traits/ForwardsCalls.php:71)
[stacktrace]
#0 /home/lito/www/project/vendor/laravel/framework/src/Illuminate/Support/Traits/ForwardsCalls.php(36): Illuminate\\Database\\Eloquent\\Model::throwBadMethodCallException()
#3 /home/lito/www/project/app/Domains/Dashboard/Service/Controller/Index.php(44): Illuminate\\Database\\Eloquent\\Model::__callStatic()
#4 /home/lito/www/project/app/Domains/Dashboard/Service/Controller/Index.php(31): App\\Domains\\Dashboard\\Service\\Controller\\Index->productsWithoutPage()
#5 /home/lito/www/project/app/Domains/Dashboard/Controller/Index.php(18): App\\Domains\\Dashboard\\Service\\Controller\\Index->data()
#12 /home/lito/www/project/app/Domains/Shared/Controller/ControllerAbstract.php(39): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#13 /home/lito/www/project/app/Domains/Shared/Controller/ControllerAbstract.php(23): App\\Domains\\Shared\\Controller\\ControllerAbstract->setup()
#15 /home/lito/www/project/app/Domains/CmsMenu/Middleware/Allowed.php(24): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#17 /home/lito/www/project/app/Domains/CmsUser/Middleware/Auth.php(24): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#26 /home/lito/www/project/vendor/barryvdh/laravel-debugbar/src/Middleware/InjectDebugbar.php(67): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#28 /home/lito/www/project/app/Domains/Language/Middleware/Request.php(21): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#30 /home/lito/www/project/app/Domains/Configuration/Middleware/Request.php(21): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#32 /home/lito/www/project/app/Http/Middleware/MessagesShareFromSession.php(23): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#34 /home/lito/www/project/app/Http/Middleware/Reset.php(22): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#36 /home/lito/www/project/app/Http/Middleware/RequestLogger.php(20): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#50 /home/lito/www/project/public/index.php(55): Illuminate\\Foundation\\Http\\Kernel->handle()
#51 {main}
"} 
```
This change is backwards compatible because is a new function argument on `LineFormatter->includeStacktraces` method.

This method can be used as always `$formatter->includeStacktraces(true);` `$formatter->includeStacktraces(false);` or `$formatter->includeStacktraces();`

Regards!