### PR TITLE
Fix MandrillHandler for swiftmailer >= 6.0.0

### DIFF
--- a/src/Monolog/Handler/MandrillHandler.php
+++ b/src/Monolog/Handler/MandrillHandler.php
@@ -50,7 +50,11 @@ class MandrillHandler extends MailHandler
     {
         $message = clone $this->message;
         $message->setBody($content);
-        $message->setDate(time());
+        if (version_compare(\Swift::VERSION, '6.0.0', '>=')) {
+            $message->setDate(new \DateTimeImmutable());
+        } else {
+            $message->setDate(time());
+        }
 
         $ch = curl_init();
 


### PR DESCRIPTION
swiftmailer/swiftmailer ^6.0 is officialy supported and setDate signature has changed in it