### PR TITLE
Check if errorMessage  contain error "File exists"

### DIFF
--- a/src/Monolog/Handler/StreamHandler.php
+++ b/src/Monolog/Handler/StreamHandler.php
@@ -193,7 +193,7 @@ class StreamHandler extends AbstractProcessingHandler
             set_error_handler([$this, 'customErrorHandler']);
             $status = mkdir($dir, 0777, true);
             restore_error_handler();
-            if (false === $status && !is_dir($dir)) {
+            if (false === $status && !is_dir($dir) && strpos($this->errorMessage, 'File exists') !== false) {
                 throw new \UnexpectedValueException(sprintf('There is no existing directory at "%s" and it could not be created: '.$this->errorMessage, $dir));
             }
         }


### PR DESCRIPTION
When we try to create directory we got error and find out that error is to the fact that directory already was created for us. 
If that the case we should not throw exception as it's fine now... 
If file was deleted after that it's not problem of this funtion.