### PR TITLE
final public method for abstract class

### DIFF
--- a/src/Monolog/Handler/AbstractHandler.php
+++ b/src/Monolog/Handler/AbstractHandler.php
@@ -42,7 +42,7 @@ abstract class AbstractHandler extends Handler implements ResettableInterface
     /**
      * @inheritDoc
      */
-    public function isHandling(LogRecord $record): bool
+    final public function isHandling(LogRecord $record): bool
     {
         return $record->level->value >= $this->level->value;
     }
@@ -54,7 +54,7 @@ abstract class AbstractHandler extends Handler implements ResettableInterface
      *
      * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $level
      */
-    public function setLevel(int|string|Level $level): self
+    final public function setLevel(int|string|Level $level): self
     {
         $this->level = Logger::toMonologLevel($level);
 
@@ -64,7 +64,7 @@ abstract class AbstractHandler extends Handler implements ResettableInterface
     /**
      * Gets minimum logging level at which this handler will be triggered.
      */
-    public function getLevel(): Level
+    final public function getLevel(): Level
     {
         return $this->level;
     }
@@ -75,7 +75,7 @@ abstract class AbstractHandler extends Handler implements ResettableInterface
      * @param bool $bubble true means that this handler allows bubbling.
      *                     false means that bubbling is not permitted.
      */
-    public function setBubble(bool $bubble): self
+    final public function setBubble(bool $bubble): self
     {
         $this->bubble = $bubble;
 
@@ -88,7 +88,7 @@ abstract class AbstractHandler extends Handler implements ResettableInterface
      * @return bool true means that this handler allows bubbling.
      *              false means that bubbling is not permitted.
      */
-    public function getBubble(): bool
+    final public function getBubble(): bool
     {
         return $this->bubble;
     }
@@ -96,7 +96,7 @@ abstract class AbstractHandler extends Handler implements ResettableInterface
     /**
      * @inheritDoc
      */
-    public function reset(): void
+    final public function reset(): void
     {
     }
 }

--- a/src/Monolog/Handler/AbstractProcessingHandler.php
+++ b/src/Monolog/Handler/AbstractProcessingHandler.php
@@ -29,7 +29,7 @@ abstract class AbstractProcessingHandler extends AbstractHandler implements Proc
     /**
      * @inheritDoc
      */
-    public function handle(LogRecord $record): bool
+    final public function handle(LogRecord $record): bool
     {
         if (!$this->isHandling($record)) {
             return false;
@@ -51,7 +51,7 @@ abstract class AbstractProcessingHandler extends AbstractHandler implements Proc
      */
     abstract protected function write(LogRecord $record): void;
 
-    public function reset(): void
+    final public function reset(): void
     {
         parent::reset();
 

--- a/src/Monolog/Handler/Handler.php
+++ b/src/Monolog/Handler/Handler.php
@@ -21,7 +21,7 @@ abstract class Handler implements HandlerInterface
     /**
      * @inheritDoc
      */
-    public function handleBatch(array $records): void
+    final public function handleBatch(array $records): void
     {
         foreach ($records as $record) {
             $this->handle($record);
@@ -31,7 +31,7 @@ abstract class Handler implements HandlerInterface
     /**
      * @inheritDoc
      */
-    public function close(): void
+    final public function close(): void
     {
     }
 

--- a/src/Monolog/Handler/MailHandler.php
+++ b/src/Monolog/Handler/MailHandler.php
@@ -25,7 +25,7 @@ abstract class MailHandler extends AbstractProcessingHandler
     /**
      * @inheritDoc
      */
-    public function handleBatch(array $records): void
+    final public function handleBatch(array $records): void
     {
         $messages = [];
 


### PR DESCRIPTION
All public methods of abstract classes should be final. Enforce API encapsulation in an inheritance architecture. If you want to override a method, use the Template method pattern.