### PR TITLE
regular callable call

### DIFF
--- a/src/Monolog/Handler/TestHandler.php
+++ b/src/Monolog/Handler/TestHandler.php
@@ -186,7 +186,7 @@ class TestHandler extends AbstractProcessingHandler
             if (is_callable($callback)) {
                 $args[] = $level;
 
-                return call_user_func_array($callback, $args);
+                return $callback(...$args);
             }
         }
 


### PR DESCRIPTION
Callables must be called without using call_user_func* when possible.