### PR TITLE
void return

### DIFF
--- a/src/Monolog/Formatter/WildfireFormatter.php
+++ b/src/Monolog/Formatter/WildfireFormatter.php
@@ -116,7 +116,7 @@ class WildfireFormatter extends NormalizerFormatter
      *
      * @phpstan-return never
      */
-    public function formatBatch(array $records)
+    public function formatBatch(array $records): void
     {
         throw new \BadMethodCallException('Batch formatting does not make sense for the WildfireFormatter');
     }

--- a/src/Monolog/Handler/RedisHandler.php
+++ b/src/Monolog/Handler/RedisHandler.php
@@ -77,7 +77,7 @@ class RedisHandler extends AbstractProcessingHandler
         } else {
             $redisKey = $this->redisKey;
             $capSize = $this->capSize;
-            $this->redisClient->transaction(function ($tx) use ($record, $redisKey, $capSize) {
+            $this->redisClient->transaction(function ($tx) use ($record, $redisKey, $capSize): void {
                 $tx->rpush($redisKey, $record->formatted);
                 $tx->ltrim($redisKey, -$capSize, -1);
             });


### PR DESCRIPTION
Add void return type to functions with missing or empty return statements, but priority is given to @return annotations.