### PR TITLE
fopen flags

### DIFF
--- a/src/Monolog/Handler/DeduplicationHandler.php
+++ b/src/Monolog/Handler/DeduplicationHandler.php
@@ -129,7 +129,7 @@ class DeduplicationHandler extends BufferHandler
             return;
         }
 
-        $handle = fopen($this->deduplicationStore, 'rw+');
+        $handle = fopen($this->deduplicationStore, 'rw+b');
 
         if (false === $handle) {
             throw new \RuntimeException('Failed to open file for reading and writing: ' . $this->deduplicationStore);

--- a/src/Monolog/Handler/StreamHandler.php
+++ b/src/Monolog/Handler/StreamHandler.php
@@ -123,7 +123,7 @@ class StreamHandler extends AbstractProcessingHandler
             $this->createDir($url);
             $this->errorMessage = null;
             set_error_handler([$this, 'customErrorHandler']);
-            $stream = fopen($url, 'a');
+            $stream = fopen($url, 'ab');
             if ($this->filePermission !== null) {
                 @chmod($url, $this->filePermission);
             }


### PR DESCRIPTION
The flags in fopen calls must omit t, and b must be omitted or included consistently.