### PR TITLE
Fix for PHP Fatal error:  Uncaught Error: Class "Monolog\DateTimeImmutable" not found

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -13,6 +13,7 @@ namespace Monolog;
 
 use Closure;
 use DateTimeZone;
+use DateTimeImmutable;
 use Monolog\Handler\HandlerInterface;
 use Monolog\Processor\ProcessorInterface;
 use Psr\Log\LoggerInterface;


### PR DESCRIPTION
add `use DateTimeImmutable;` to fix
> PHP Fatal error:  Uncaught Error: Class "Monolog\DateTimeImmutable" not found