### PR TITLE
Add an option to set the op_type for the ElasticsearchHandler

### DIFF
--- a/src/Monolog/Handler/ElasticsearchHandler.php
+++ b/src/Monolog/Handler/ElasticsearchHandler.php
@@ -85,6 +85,7 @@ class ElasticsearchHandler extends AbstractProcessingHandler
                 'index'        => 'monolog', // Elastic index name
                 'type'         => '_doc',    // Elastic document type
                 'ignore_error' => false,     // Suppress Elasticsearch exceptions
+                'op_type'      => 'index',   // Elastic op_type (index or create) (https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#docs-index-api-op_type)
             ],
             $options
         );
@@ -162,7 +163,7 @@ class ElasticsearchHandler extends AbstractProcessingHandler
 
             foreach ($records as $record) {
                 $params['body'][] = [
-                    'index' => $this->needsType ? [
+                    $this->options['op_type'] => $this->needsType ? [
                         '_index' => $record['_index'],
                         '_type'  => $record['_type'],
                     ] : [

--- a/tests/Monolog/Handler/ElasticsearchHandlerTest.php
+++ b/tests/Monolog/Handler/ElasticsearchHandlerTest.php
@@ -33,6 +33,7 @@ class ElasticsearchHandlerTest extends TestCase
     protected array $options = [
         'index' => 'my_index',
         'type'  => 'doc_type',
+        'op_type' => 'index',
     ];
 
     public function setUp(): void
@@ -93,6 +94,7 @@ class ElasticsearchHandlerTest extends TestCase
             'index' => $this->options['index'],
             'type' => $this->options['type'],
             'ignore_error' => false,
+            'op_type' => $this->options['op_type'],
         ];
 
         if ($this->client instanceof Client8 || $this->client::VERSION[0] === '7') {


### PR DESCRIPTION
When pushing logs to a [data stream](https://www.elastic.co/guide/en/elasticsearch/reference/current/data-streams.html) in Elasticsearch, the [op_type](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#docs-index-api-op_type) must be set to "create". By default, the ElasticsearchHandler uses the "index" op_type. I have added an option to the ElasticsearchHandler so that you can specify the op_type to use and therefore enable the ability to push logs into an Elasticsearch data stream.

The default selection still is set to "index" so no behavior will change unless you specifically include the "op_type" option when creating the client.

- Elasticsearch Documentation: [Add documents to a data stream](https://www.elastic.co/guide/en/elasticsearch/reference/current/use-a-data-stream.html#add-documents-to-a-data-stream)