### PR TITLE
Add support for enum context values to psr formatter

### DIFF
--- a/src/Monolog/Processor/PsrLogMessageProcessor.php
+++ b/src/Monolog/Processor/PsrLogMessageProcessor.php
@@ -67,6 +67,8 @@ class PsrLogMessageProcessor implements ProcessorInterface
                 } else {
                     $replacements[$placeholder] = $val->format($this->dateFormat ?? static::SIMPLE_DATE);
                 }
+            } elseif ($val instanceof \UnitEnum) {
+                $replacements[$placeholder] = $val instanceof \BackedEnum ? $val->value : $val->name;
             } elseif (is_object($val)) {
                 $replacements[$placeholder] = '[object '.Utils::getClass($val).']';
             } elseif (is_array($val)) {

--- a/tests/Monolog/Processor/PsrLogMessageProcessorTest.php
+++ b/tests/Monolog/Processor/PsrLogMessageProcessorTest.php
@@ -11,6 +11,7 @@
 
 namespace Monolog\Processor;
 
+use Monolog\Level;
 use Monolog\Test\TestCase;
 
 class PsrLogMessageProcessorTest extends TestCase
@@ -66,6 +67,7 @@ class PsrLogMessageProcessorTest extends TestCase
             [[1, 2, 3], 'array[1,2,3]'],
             [['foo' => 'bar'], 'array{"foo":"bar"}'],
             [stream_context_create(), '[resource]'],
+            [Level::Info, Level::Info->value],
         ];
     }
 }


### PR DESCRIPTION
This PR adds support for Enums to the PsrLogMessageProcessor.

Currently Enums passed in the context display as `[object enum-class-name]`. This PR changes this to display the value for `BackedEnums` and displaying the name for non backed enums.