### PR TITLE
Implement HandlerInterface for strict typing

### DIFF
--- a/src/Monolog/Handler/StreamHandler.php
+++ b/src/Monolog/Handler/StreamHandler.php
@@ -22,7 +22,7 @@ use Monolog\LogRecord;
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-class StreamHandler extends AbstractProcessingHandler
+class StreamHandler extends AbstractProcessingHandler implements HandlerInterface
 {
     protected const MAX_CHUNK_SIZE = 2147483647;
     /** 10MB */


### PR DESCRIPTION
This method `Monolog\Logger::pushHandler` expects the first parameter to be of type `\Monolog\Handler\HandlerInterface`.

This fix ensures that `StreamHandler` implements `HandlerInterface` and resolves the strict types error.