### PR TITLE
feat: added method for removing processors/handlers matching a callback

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -222,6 +222,20 @@ class Logger implements LoggerInterface, ResettableInterface
     }
 
     /**
+     * Removes from the handler stack all elements matching the callback.
+     *
+     * @phpstan-param callable(int $index, HandlerInterface $handler): bool $callback
+     */
+    public function removeHandler(callable $callback): void
+    {
+        foreach ($this->handlers as $k => $handler) {
+            if ($callback($k, $handler)) {
+                array_splice($this->handlers, $k, 1);
+            }
+        }
+    }
+
+    /**
      * Set handlers, replacing all existing ones.
      *
      * If a map is passed, keys will be ignored.
@@ -271,6 +285,20 @@ class Logger implements LoggerInterface, ResettableInterface
         }
 
         return array_shift($this->processors);
+    }
+
+    /**
+     * Removes from the processor stack all elements matching the callback.
+     *
+     * @phpstan-param callable(int $index, ProcessorInterface $handler): bool $callback
+     */
+    public function removeProcessor(callable $callback): void
+    {
+        foreach ($this->processors as $k => $processor) {
+            if ($callback($k, $processor)) {
+                array_splice($this->processors, $k, 1);
+            }
+        }
     }
 
     /**
@@ -336,6 +364,7 @@ class Logger implements LoggerInterface, ResettableInterface
 
         if ($logDepth === 3) {
             $this->warning('A possible infinite logging loop was detected and aborted. It appears some of your handler code is triggering logging, see the previous log record for a hint as to what may be the cause.');
+
             return false;
         } elseif ($logDepth >= 5) { // log depth 4 is let through, so we can log the warning above
             return false;
@@ -460,8 +489,8 @@ class Logger implements LoggerInterface, ResettableInterface
     /**
      * Converts PSR-3 levels to Monolog ones if necessary
      *
-     * @param  int|string|Level|LogLevel::* $level Level number (monolog) or name (PSR-3)
-     * @throws \Psr\Log\InvalidArgumentException      If level is not defined
+     * @param  int|string|Level|LogLevel::*      $level Level number (monolog) or name (PSR-3)
+     * @throws \Psr\Log\InvalidArgumentException If level is not defined
      *
      * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $level
      */

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -12,6 +12,7 @@
 namespace Monolog;
 
 use Monolog\Handler\HandlerInterface;
+use Monolog\Processor\ProcessorInterface;
 use Monolog\Processor\WebProcessor;
 use Monolog\Handler\TestHandler;
 use Monolog\Test\TestCase;
@@ -212,6 +213,52 @@ class LoggerTest extends TestCase
     }
 
     /**
+     * @covers Logger::pushHandler
+     * @covers Logger::removeHandler
+     * @covers Logger::getHandlers
+     */
+    public function testPushRemoveHandler()
+    {
+        $logger = new Logger(__METHOD__);
+        $handler1 = new TestHandler;
+        $handler2 = new TestHandler;
+        $handler3 = new TestHandler;
+
+        $logger->pushHandler($handler1);
+        $logger->pushHandler($handler2);
+        $logger->pushHandler($handler3);
+
+        $logger->removeHandler(fn(int $key, HandlerInterface $handler) => $handler === $handler2);
+
+        $this->assertNotContains($handler2, $logger->getHandlers());
+        $this->assertContains($handler1, $logger->getHandlers());
+        $this->assertContains($handler3, $logger->getHandlers());
+    }
+
+    /**
+     * @covers Logger::pushHandler
+     * @covers Logger::removeHandler
+     * @covers Logger::getHandlers
+     */
+    public function testPushRemoveHandlerByIndex()
+    {
+        $logger = new Logger(__METHOD__);
+        $handler1 = new TestHandler;
+        $handler2 = new TestHandler;
+        $handler3 = new TestHandler;
+
+        $logger->pushHandler($handler1);
+        $logger->pushHandler($handler2);
+        $logger->pushHandler($handler3);
+
+        $logger->removeHandler(fn(int $key, HandlerInterface $handler) => 1 === $key);
+
+        $this->assertNotContains($handler2, $logger->getHandlers());
+        $this->assertContains($handler1, $logger->getHandlers());
+        $this->assertContains($handler3, $logger->getHandlers());
+    }
+
+    /**
      * @covers Logger::setHandlers
      */
     public function testSetHandlers()
@@ -254,6 +301,53 @@ class LoggerTest extends TestCase
         $this->expectException(\LogicException::class);
 
         $logger->popProcessor();
+    }
+
+
+    /**
+     * @covers Logger::pushProcessor
+     * @covers Logger::removeProcessor
+     * @covers Logger::getProcessors
+     */
+    public function testPushRemoveProcessor()
+    {
+        $logger = new Logger(__METHOD__);
+        $processor1 = new WebProcessor;
+        $processor2 = new WebProcessor;
+        $processor3 = new WebProcessor;
+
+        $logger->pushProcessor($processor1);
+        $logger->pushProcessor($processor2);
+        $logger->pushProcessor($processor3);
+
+        $logger->removeProcessor(fn(int $key, ProcessorInterface $processor) => $processor === $processor2);
+
+        $this->assertNotContains($processor2, $logger->getProcessors());
+        $this->assertContains($processor1, $logger->getProcessors());
+        $this->assertContains($processor3, $logger->getProcessors());
+    }
+
+    /**
+     * @covers Logger::pushProcessor
+     * @covers Logger::removeProcessor
+     * @covers Logger::getProcessors
+     */
+    public function testPushRemoveProcessorByIndex()
+    {
+        $logger = new Logger(__METHOD__);
+        $processor1 = new WebProcessor;
+        $processor2 = new WebProcessor;
+        $processor3 = new WebProcessor;
+
+        $logger->pushProcessor($processor1);
+        $logger->pushProcessor($processor2);
+        $logger->pushProcessor($processor3);
+
+        $logger->removeProcessor(fn(int $key, ProcessorInterface $processor) => 1 === $key);
+
+        $this->assertNotContains($processor2, $logger->getProcessors());
+        $this->assertContains($processor1, $logger->getProcessors());
+        $this->assertContains($processor3, $logger->getProcessors());
     }
 
     /**


### PR DESCRIPTION
After `Monolog\Logger` was tagged as `@final`, users of Symfony MonologBridge started getting deprecations, as Symfony extends Monolog\Logger.

To stop MonologBridge from extending Monolog\Logger, Monolog would need a way of removing handlers/processors. This MR is to address that.

I'm aware that this might not be the right place to do it, given that it would be a change mainly to support another project's use case, but I'm not sure where a fix can be implemented without disrupting too much the users, or causing a BC break.
