### PR TITLE
Add support for priority to Monolog processors

### DIFF
--- a/src/Monolog/Attribute/AsMonologProcessor.php
+++ b/src/Monolog/Attribute/AsMonologProcessor.php
@@ -23,14 +23,16 @@ namespace Monolog\Attribute;
 class AsMonologProcessor
 {
     /**
-     * @param string|null $channel The logging channel the processor should be pushed to.
-     * @param string|null $handler The handler the processor should be pushed to.
-     * @param string|null $method  The method that processes the records (if the attribute is used at the class level).
+     * @param string|null $channel  The logging channel the processor should be pushed to.
+     * @param string|null $handler  The handler the processor should be pushed to.
+     * @param string|null $method   The method that processes the records (if the attribute is used at the class level).
+     * @param int|null    $priority The priority of the processor so the order can be determined.
      */
     public function __construct(
         public readonly ?string $channel = null,
         public readonly ?string $handler = null,
-        public readonly ?string $method = null
+        public readonly ?string $method = null,
+        public readonly ?int $priority = null
     ) {
     }
 }

--- a/tests/Monolog/Attribute/AsMonologProcessorTest.php
+++ b/tests/Monolog/Attribute/AsMonologProcessorTest.php
@@ -20,14 +20,16 @@ final class AsMonologProcessorTest extends TestCase
 {
     public function test(): void
     {
-        $asMonologProcessor = new AsMonologProcessor('channel', 'handler', 'method');
+        $asMonologProcessor = new AsMonologProcessor('channel', 'handler', 'method', -10);
         $this->assertSame('channel', $asMonologProcessor->channel);
         $this->assertSame('handler', $asMonologProcessor->handler);
         $this->assertSame('method', $asMonologProcessor->method);
+        $this->assertSame(-10, $asMonologProcessor->priority);
 
-        $asMonologProcessor = new AsMonologProcessor(null, null, null);
+        $asMonologProcessor = new AsMonologProcessor(null, null, null, null);
         $this->assertNull($asMonologProcessor->channel);
         $this->assertNull($asMonologProcessor->handler);
         $this->assertNull($asMonologProcessor->method);
+        $this->assertNull($asMonologProcessor->priority);
     }
 }


### PR DESCRIPTION
As suggested in the [Monolog-bundle](https://github.com/symfony/monolog-bundle/pull/455#discussion_r1143066893).

So that the order in which the processors are used by monolog can be determined.