### PR TITLE
TelegramBotHandler topics support

### DIFF
--- a/src/Monolog/Handler/TelegramBotHandler.php
+++ b/src/Monolog/Handler/TelegramBotHandler.php
@@ -89,10 +89,17 @@ class TelegramBotHandler extends AbstractProcessingHandler
     private bool $delayBetweenMessages;
 
     /**
+     * Telegram message thread id, unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+     * See how to get the `message_thread_id` https://stackoverflow.com/a/75178418
+     */
+    private int|null $topic;
+
+    /**
      * @param  string                    $apiKey               Telegram bot access token provided by BotFather
      * @param  string                    $channel              Telegram channel name
      * @param  bool                      $splitLongMessages    Split a message longer than MAX_MESSAGE_LENGTH into parts and send in multiple messages
      * @param  bool                      $delayBetweenMessages Adds delay between sending a split message according to Telegram API
+     * @param  int                       $topic                Telegram message thread id, unique identifier for the target message thread (topic) of the forum
      * @throws MissingExtensionException If the curl extension is missing
      */
     public function __construct(
@@ -104,7 +111,8 @@ class TelegramBotHandler extends AbstractProcessingHandler
         bool   $disableWebPagePreview = null,
         bool   $disableNotification = null,
         bool   $splitLongMessages = false,
-        bool   $delayBetweenMessages = false
+        bool   $delayBetweenMessages = false,
+        int    $topic = null
     ) {
         if (!extension_loaded('curl')) {
             throw new MissingExtensionException('The curl extension is needed to use the TelegramBotHandler');
@@ -119,6 +127,7 @@ class TelegramBotHandler extends AbstractProcessingHandler
         $this->disableNotification($disableNotification);
         $this->splitLongMessages($splitLongMessages);
         $this->delayBetweenMessages($delayBetweenMessages);
+        $this->setTopic($topic);
     }
 
     public function setParseMode(string $parseMode = null): self
@@ -165,6 +174,13 @@ class TelegramBotHandler extends AbstractProcessingHandler
     public function delayBetweenMessages(bool $delayBetweenMessages = false): self
     {
         $this->delayBetweenMessages = $delayBetweenMessages;
+
+        return $this;
+    }
+
+    public function setTopic(int $topic = null): self
+    {
+        $this->topic = $topic;
 
         return $this;
     }
@@ -227,6 +243,7 @@ class TelegramBotHandler extends AbstractProcessingHandler
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
             'text' => $message,
             'chat_id' => $this->channel,
+            'message_thread_id' => $this->topic,
             'parse_mode' => $this->parseMode,
             'disable_web_page_preview' => $this->disableWebPagePreview,
             'disable_notification' => $this->disableNotification,

--- a/src/Monolog/Handler/TelegramBotHandler.php
+++ b/src/Monolog/Handler/TelegramBotHandler.php
@@ -240,14 +240,17 @@ class TelegramBotHandler extends AbstractProcessingHandler
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
+        $params = [
             'text' => $message,
             'chat_id' => $this->channel,
-            'message_thread_id' => $this->topic,
             'parse_mode' => $this->parseMode,
             'disable_web_page_preview' => $this->disableWebPagePreview,
             'disable_notification' => $this->disableNotification,
-        ]));
+        ];
+        if ($this->topic !== null) {
+            $params['message_thread_id'] = $this->topic;
+        }
+        curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($params));
 
         $result = Curl\Util::execute($ch);
         if (!is_string($result)) {

--- a/tests/Monolog/Handler/TelegramBotHandlerTest.php
+++ b/tests/Monolog/Handler/TelegramBotHandlerTest.php
@@ -34,9 +34,10 @@ class TelegramBotHandlerTest extends TestCase
         string $channel = 'testChannel',
         string $parseMode = 'Markdown',
         bool $disableWebPagePreview = false,
-        bool $disableNotification = true
+        bool $disableNotification = true,
+        int $topic = 1
     ): void {
-        $constructorArgs = [$apiKey, $channel, Level::Debug, true, $parseMode, $disableWebPagePreview, $disableNotification];
+        $constructorArgs = [$apiKey, $channel, Level::Debug, true, $parseMode, $disableWebPagePreview, $disableNotification, $topic];
 
         $this->handler = $this->getMockBuilder(TelegramBotHandler::class)
             ->setConstructorArgs($constructorArgs)


### PR DESCRIPTION
The telegram API support sending message to a specific topic for supergroups.

This `message_thread_id` parameter wasn't added on #1451 because it didn't exist by that time.

https://core.telegram.org/bots/api#sendmessage