### PR TITLE
Add support yearly or monthly rotation log file

### DIFF
--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -43,13 +43,13 @@ class RotatingFileHandler extends StreamHandler
      * @param int|null $filePermission Optional file permissions (default (0644) are only for owner read/write)
      * @param bool     $useLocking     Try to lock log file before doing any writes
      */
-    public function __construct(string $filename, int $maxFiles = 0, int|string|Level $level = Level::Debug, bool $bubble = true, ?int $filePermission = null, bool $useLocking = false)
+    public function __construct(string $filename, int $maxFiles = 0, int|string|Level $level = Level::Debug, bool $bubble = true, ?int $filePermission = null, bool $useLocking = false, string $dateFormat = self::FILE_PER_DAY)
     {
         $this->filename = Utils::canonicalizePath($filename);
         $this->maxFiles = $maxFiles;
-        $this->nextRotation = new \DateTimeImmutable('tomorrow');
         $this->filenameFormat = '{filename}-{date}';
-        $this->dateFormat = static::FILE_PER_DAY;
+        $this->setDateFormat($dateFormat);
+        $this->nextRotation = $this->getNextRotation();
 
         parent::__construct($this->getTimedFilename(), $level, $bubble, $filePermission, $useLocking);
     }
@@ -126,7 +126,7 @@ class RotatingFileHandler extends StreamHandler
     {
         // update filename
         $this->url = $this->getTimedFilename();
-        $this->nextRotation = new \DateTimeImmutable('tomorrow');
+        $this->nextRotation = $this->getNextRotation();
 
         // skip GC of old logs if files are unlimited
         if (0 === $this->maxFiles) {
@@ -197,5 +197,27 @@ class RotatingFileHandler extends StreamHandler
         }
 
         return $glob;
+    }
+
+    protected function setDateFormat(string $dateFormat): void
+    {
+        if ($dateFormat !== self::FILE_PER_DAY && $dateFormat !== self::FILE_PER_MONTH && $dateFormat !== self::FILE_PER_YEAR) {
+            throw new InvalidArgumentException(
+                'Invalid date format - format must be one of ' .
+                'RotatingFileHandler::FILE_PER_DAY ("Y-m-d"), RotatingFileHandler::FILE_PER_MONTH ("Y-m") ' .
+                'or RotatingFileHandler::FILE_PER_YEAR ("Y"), or you can set one of the ' .
+                'date formats using slashes, underscores and/or dots instead of dashes.'
+            );
+        }
+        $this->dateFormat = $dateFormat;
+    }
+
+    protected function getNextRotation(): \DateTimeImmutable
+    {
+        return match ($this->dateFormat) {
+            self::FILE_PER_MONTH => (new \DateTimeImmutable('first day of next month'))->setTime(0, 0, 0),
+            self::FILE_PER_YEAR => (new \DateTimeImmutable('first day of January next year'))->setTime(0, 0, 0),
+            default => (new \DateTimeImmutable('tomorrow'))->setTime(0, 0, 0),
+        };
     }
 }

--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -206,7 +206,7 @@ class RotatingFileHandler extends StreamHandler
 
     protected function getNextRotation(): \DateTimeImmutable
     {
-        return match ($this->dateFormat) {
+        return match (str_replace(['/','_','.'], '-', $this->dateFormat)) {
             self::FILE_PER_MONTH => (new \DateTimeImmutable('first day of next month'))->setTime(0, 0, 0),
             self::FILE_PER_YEAR => (new \DateTimeImmutable('first day of January next year'))->setTime(0, 0, 0),
             default => (new \DateTimeImmutable('tomorrow'))->setTime(0, 0, 0),

--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -80,21 +80,13 @@ class RotatingFileHandler extends StreamHandler
 
     public function setFilenameFormat(string $filenameFormat, string $dateFormat): self
     {
-        if (0 === preg_match('{^[Yy](([/_.-]?m)([/_.-]?d)?)?$}', $dateFormat)) {
-            throw new InvalidArgumentException(
-                'Invalid date format - format must be one of '.
-                'RotatingFileHandler::FILE_PER_DAY ("Y-m-d"), RotatingFileHandler::FILE_PER_MONTH ("Y-m") '.
-                'or RotatingFileHandler::FILE_PER_YEAR ("Y"), or you can set one of the '.
-                'date formats using slashes, underscores and/or dots instead of dashes.'
-            );
-        }
+        $this->setDateFormat($dateFormat);
         if (substr_count($filenameFormat, '{date}') === 0) {
             throw new InvalidArgumentException(
                 'Invalid filename format - format must contain at least `{date}`, because otherwise rotating is impossible.'
             );
         }
         $this->filenameFormat = $filenameFormat;
-        $this->dateFormat = $dateFormat;
         $this->url = $this->getTimedFilename();
         $this->close();
 
@@ -201,11 +193,11 @@ class RotatingFileHandler extends StreamHandler
 
     protected function setDateFormat(string $dateFormat): void
     {
-        if ($dateFormat !== self::FILE_PER_DAY && $dateFormat !== self::FILE_PER_MONTH && $dateFormat !== self::FILE_PER_YEAR) {
+        if (0 === preg_match('{^[Yy](([/_.-]?m)([/_.-]?d)?)?$}', $dateFormat)) {
             throw new InvalidArgumentException(
-                'Invalid date format - format must be one of ' .
-                'RotatingFileHandler::FILE_PER_DAY ("Y-m-d"), RotatingFileHandler::FILE_PER_MONTH ("Y-m") ' .
-                'or RotatingFileHandler::FILE_PER_YEAR ("Y"), or you can set one of the ' .
+                'Invalid date format - format must be one of '.
+                'RotatingFileHandler::FILE_PER_DAY ("Y-m-d"), RotatingFileHandler::FILE_PER_MONTH ("Y-m") '.
+                'or RotatingFileHandler::FILE_PER_YEAR ("Y"), or you can set one of the '.
                 'date formats using slashes, underscores and/or dots instead of dashes.'
             );
         }

--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -43,12 +43,11 @@ class RotatingFileHandler extends StreamHandler
      * @param int|null $filePermission Optional file permissions (default (0644) are only for owner read/write)
      * @param bool     $useLocking     Try to lock log file before doing any writes
      */
-    public function __construct(string $filename, int $maxFiles = 0, int|string|Level $level = Level::Debug, bool $bubble = true, ?int $filePermission = null, bool $useLocking = false, string $dateFormat = self::FILE_PER_DAY)
+    public function __construct(string $filename, int $maxFiles = 0, int|string|Level $level = Level::Debug, bool $bubble = true, ?int $filePermission = null, bool $useLocking = false, string $dateFormat = self::FILE_PER_DAY, string $filenameFormat  = '{filename}-{date}')
     {
         $this->filename = Utils::canonicalizePath($filename);
         $this->maxFiles = $maxFiles;
-        $this->filenameFormat = '{filename}-{date}';
-        $this->setDateFormat($dateFormat);
+        $this->setFilenameFormat($filenameFormat, $dateFormat);
         $this->nextRotation = $this->getNextRotation();
 
         parent::__construct($this->getTimedFilename(), $level, $bubble, $filePermission, $useLocking);


### PR DESCRIPTION
The function of adding yearly or monthly rotation log file. Although there are relevant definitions in the code before, it has not really supported it.