### PR TITLE
chore: use stable version of graylog2/gelf-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "aws/aws-sdk-php": "^3.0",
         "doctrine/couchdb": "~1.0@dev",
         "elasticsearch/elasticsearch": "^7 || ^8",
-        "graylog2/gelf-php": "^1.7.1 || ^2.0",
+        "graylog2/gelf-php": "^1.4.2 || ^2.0",
         "guzzlehttp/guzzle": "^7.4.5",
         "guzzlehttp/psr7": "^2.2",
         "mongodb/mongodb": "^1.8",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "aws/aws-sdk-php": "^3.0",
         "doctrine/couchdb": "~1.0@dev",
         "elasticsearch/elasticsearch": "^7 || ^8",
-        "graylog2/gelf-php": "^1.4.2 || ^2@dev",
+        "graylog2/gelf-php": "^1.7.1 || ^2.0",
         "guzzlehttp/guzzle": "^7.4.5",
         "guzzlehttp/psr7": "^2.2",
         "mongodb/mongodb": "^1.8",


### PR DESCRIPTION
Version 2 is stable and released now
https://github.com/bzikarsky/gelf-php/releases