### PR TITLE
Add support for LineFormatter replace inline linebreaks in indexed arrays data

### DIFF
--- a/src/Monolog/Formatter/LineFormatter.php
+++ b/src/Monolog/Formatter/LineFormatter.php
@@ -183,7 +183,7 @@ class LineFormatter extends NormalizerFormatter
     protected function replaceNewlines(string $str): string
     {
         if ($this->allowInlineLineBreaks) {
-            if (0 === strpos($str, '{')) {
+            if (0 === strpos($str, '{') || 0 === strpos($str, '[')) {
                 $str = preg_replace('/(?<!\\\\)\\\\[rn]/', "\n", $str);
                 if (null === $str) {
                     $pcreErrorCode = preg_last_error();

--- a/tests/Monolog/Formatter/LineFormatterTest.php
+++ b/tests/Monolog/Formatter/LineFormatterTest.php
@@ -147,6 +147,8 @@ class LineFormatterTest extends TestCase
         $formatter->allowInlineLineBreaks();
 
         self::assertSame('{"test":"foo'."\n".'bar\\\\name-with-n"}', $formatter->stringify(["test" => "foo\nbar\\name-with-n"]));
+        self::assertSame('["indexed'."\n".'arrays'."\n".'without'."\n".'key","foo'."\n".'bar\\\\name-with-n"]', $formatter->stringify(["indexed\narrays\nwithout\nkey", "foo\nbar\\name-with-n"]));
+        self::assertSame('[{"first":"multi-dimensional'."\n".'arrays"},{"second":"foo'."\n".'bar\\\\name-with-n"}]', $formatter->stringify([["first" => "multi-dimensional\narrays"], ["second" => "foo\nbar\\name-with-n"]]));
     }
 
     public function testDefFormatWithExceptionAndStacktraceParserFull()


### PR DESCRIPTION
When I pass in an indexed array or a multi-dimensional array, `allowInlineLineBreaks` is not working!

I think this revision is useful.

```php
$log->info('Testing new lines in log context.', ["This\nhas\nNew Lines."]);

// before
// local.INFO: Testing new lines in log context. ["This\nhas\nNew Lines."] 

// after
// local.INFO: Testing new lines in log context. ["This
// has
// New Lines."] 

```