### PR TITLE
Fix LogRecord "extra" data leaking between handlers

### DIFF
--- a/src/Monolog/Handler/FallbackGroupHandler.php
+++ b/src/Monolog/Handler/FallbackGroupHandler.php
@@ -33,7 +33,7 @@ class FallbackGroupHandler extends GroupHandler
         }
         foreach ($this->handlers as $handler) {
             try {
-                $handler->handle($record);
+                $handler->handle(clone $record);
                 break;
             } catch (Throwable $e) {
                 // What throwable?
@@ -58,7 +58,7 @@ class FallbackGroupHandler extends GroupHandler
 
         foreach ($this->handlers as $handler) {
             try {
-                $handler->handleBatch($records);
+                $handler->handleBatch(array_map(fn ($record) => clone $record, $records));
                 break;
             } catch (Throwable $e) {
                 // What throwable?

--- a/src/Monolog/Handler/GroupHandler.php
+++ b/src/Monolog/Handler/GroupHandler.php
@@ -70,7 +70,7 @@ class GroupHandler extends Handler implements ProcessableHandlerInterface, Reset
         }
 
         foreach ($this->handlers as $handler) {
-            $handler->handle($record);
+            $handler->handle(clone $record);
         }
 
         return false === $this->bubble;
@@ -90,7 +90,7 @@ class GroupHandler extends Handler implements ProcessableHandlerInterface, Reset
         }
 
         foreach ($this->handlers as $handler) {
-            $handler->handleBatch($records);
+            $handler->handleBatch(array_map(fn ($record) => clone $record, $records));
         }
     }
 

--- a/src/Monolog/Handler/WhatFailureGroupHandler.php
+++ b/src/Monolog/Handler/WhatFailureGroupHandler.php
@@ -33,7 +33,7 @@ class WhatFailureGroupHandler extends GroupHandler
 
         foreach ($this->handlers as $handler) {
             try {
-                $handler->handle($record);
+                $handler->handle(clone $record);
             } catch (Throwable) {
                 // What failure?
             }
@@ -57,7 +57,7 @@ class WhatFailureGroupHandler extends GroupHandler
 
         foreach ($this->handlers as $handler) {
             try {
-                $handler->handleBatch($records);
+                $handler->handleBatch(array_map(fn ($record) => clone $record, $records));
             } catch (Throwable) {
                 // What failure?
             }

--- a/tests/Monolog/Handler/ExceptionTestHandler.php
+++ b/tests/Monolog/Handler/ExceptionTestHandler.php
@@ -19,10 +19,8 @@ class ExceptionTestHandler extends TestHandler
     /**
      * @inheritDoc
      */
-    public function handle(LogRecord $record): bool
+    protected function write(LogRecord $record): void
     {
         throw new Exception("ExceptionTestHandler::handle");
-
-        parent::handle($record);
     }
 }

--- a/tests/Monolog/Handler/GroupHandlerTest.php
+++ b/tests/Monolog/Handler/GroupHandlerTest.php
@@ -11,6 +11,7 @@
 
 namespace Monolog\Handler;
 
+use Monolog\LogRecord;
 use Monolog\Test\TestCase;
 use Monolog\Level;
 
@@ -116,5 +117,38 @@ class GroupHandlerTest extends TestCase
             $this->assertTrue($records[0]['extra']['foo2']);
             $this->assertTrue($records[1]['extra']['foo2']);
         }
+    }
+
+    public function testProcessorsDoNotInterfereBetweenHandlers()
+    {
+        $t1 = new TestHandler();
+        $t2 = new TestHandler();
+        $handler = new GroupHandler([$t1, $t2]);
+
+        $t1->pushProcessor(function (LogRecord $record) {
+            $record->extra['foo'] = 'bar';
+
+            return $record;
+        });
+        $handler->handle($this->getRecord());
+
+        self::assertSame([], $t2->getRecords()[0]->extra);
+    }
+
+    public function testProcessorsDoNotInterfereBetweenHandlersWithBatch()
+    {
+        $t1 = new TestHandler();
+        $t2 = new TestHandler();
+        $handler = new GroupHandler([$t1, $t2]);
+
+        $t1->pushProcessor(function (LogRecord $record) {
+            $record->extra['foo'] = 'bar';
+
+            return $record;
+        });
+
+        $handler->handleBatch([$this->getRecord()]);
+
+        self::assertSame([], $t2->getRecords()[0]->extra);
     }
 }

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -638,6 +638,21 @@ class LoggerTest extends TestCase
         ];
     }
 
+    public function testProcessorsDoNotInterfereBetweenHandlers()
+    {
+        $logger = new Logger('foo');
+        $logger->pushHandler($t1 = new TestHandler());
+        $logger->pushHandler($t2 = new TestHandler());
+        $t1->pushProcessor(function (LogRecord $record) {
+            $record->extra['foo'] = 'bar';
+
+            return $record;
+        });
+        $logger->error('Foo');
+
+        self::assertSame([], $t2->getRecords()[0]->extra);
+    }
+
     /**
      * @covers Logger::setExceptionHandler
      */
@@ -804,9 +819,6 @@ class LoggerTest extends TestCase
         }
     }
 
-    /**
-     * @requires PHP 8.1
-     */
     public function testLogCycleDetectionWithFibersWithoutCycle()
     {
         $logger = new Logger(__METHOD__);
@@ -832,9 +844,6 @@ class LoggerTest extends TestCase
         self::assertCount(10, $testHandler->getRecords());
     }
 
-    /**
-     * @requires PHP 8.1
-     */
     public function testLogCycleDetectionWithFibersWithCycle()
     {
         $logger = new Logger(__METHOD__);


### PR DESCRIPTION
Context:
- Let's say i have 3 handlers attached to monolog logger: file handler, slack handler, elastic search handler.
  - Note that each handler can push its own processor, which can alter the LogRecord entity.
- On the elastic search handler, we need extra info, so push a processor to add them,  (stupid example: `$logRecord->extra['new_entry_just_for_elastic_search'] = 'stuff';`
  - This "extra" data i also available for file handler and slack handler.
  - Basically i will get in slack handler and file handler, this extra that was supposed to be only for elastic search handler.

Why this is happening?
- LogRecord is passed by reference, to each handler.
- LogRecord accepts to alter data from `extra`, so if one handlers manages to alter this object, rest of remaining handlers, will use the altered object.