### PR TITLE
Skip mongodb extension if extension is not installed

### DIFF
--- a/src/Monolog/Formatter/MongoDBFormatter.php
+++ b/src/Monolog/Formatter/MongoDBFormatter.php
@@ -154,7 +154,6 @@ class MongoDBFormatter implements FormatterInterface
             ? (int) $milliseconds
             : (string) $milliseconds;
 
-        // @phpstan-ignore-next-line
         return new UTCDateTime($milliseconds);
     }
 }

--- a/tests/Monolog/Handler/MongoDBHandlerTest.php
+++ b/tests/Monolog/Handler/MongoDBHandlerTest.php
@@ -14,6 +14,9 @@ namespace Monolog\Handler;
 use MongoDB\Driver\Manager;
 use Monolog\Test\TestCase;
 
+/**
+ * @requires extension mongodb
+ */
 class MongoDBHandlerTest extends TestCase
 {
     public function testConstructorShouldThrowExceptionForInvalidMongo()
@@ -25,10 +28,6 @@ class MongoDBHandlerTest extends TestCase
 
     public function testHandleWithLibraryClient()
     {
-        if (!(class_exists('MongoDB\Client'))) {
-            $this->markTestSkipped('mongodb/mongodb not installed');
-        }
-
         $mongodb = $this->getMockBuilder('MongoDB\Client')
             ->disableOriginalConstructor()
             ->getMock();
@@ -56,10 +55,6 @@ class MongoDBHandlerTest extends TestCase
 
     public function testHandleWithDriverManager()
     {
-        if (!(class_exists('MongoDB\Driver\Manager'))) {
-            $this->markTestSkipped('ext-mongodb not installed');
-        }
-
         /* This can become a unit test once ManagerInterface can be mocked.
          * See: https://jira.mongodb.org/browse/PHPC-378
          */

--- a/tests/Monolog/Handler/MongoDBHandlerTest.php
+++ b/tests/Monolog/Handler/MongoDBHandlerTest.php
@@ -28,6 +28,10 @@ class MongoDBHandlerTest extends TestCase
 
     public function testHandleWithLibraryClient()
     {
+        if (!(class_exists('MongoDB\Client'))) {
+            $this->markTestSkipped('mongodb/mongodb not installed');
+        }
+
         $mongodb = $this->getMockBuilder('MongoDB\Client')
             ->disableOriginalConstructor()
             ->getMock();


### PR DESCRIPTION
Without this patch, `MongoDBHandlerTest::testHandleWithLibraryClient()` test fails

---


**⚠ I'm really not sure about this PR!**