### PR TITLE
Revert "Mark Logger @final to discourage extension"

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -30,7 +30,6 @@ use WeakMap;
  * and uses them to store records that are added to it.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
- * @final
  */
 class Logger implements LoggerInterface, ResettableInterface
 {


### PR DESCRIPTION
This reverts commit 3cba75ec0926eec177a4a2cd6c977ecddd0fc7c1.

This `@final` annotation is quite hard to work around in Symfony, see eg https://github.com/symfony/symfony/pull/51229, which is a dead end [according to @stof](https://github.com/symfony/symfony/pull/51229#discussion_r1282056615).

But instead of completing the work around, I'd like to propose to simply revert the annotation. This class has no interfaces for its non-PSR methods, and I don't think making the class final helps maintenance significantly (does it?)

On the other hand, the cost of making this final looks high, on our side at least.

:pray: 