### PR TITLE
Fix fatal error in NormalizeFormatter.

### DIFF
--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -206,6 +206,9 @@ class NormalizerFormatter implements FormatterInterface
             if ($data instanceof \JsonSerializable) {
                 /** @var null|scalar|array<mixed[]|scalar|null> $value */
                 $value = $data->jsonSerialize();
+            } elseif (\get_class($data) === '__PHP_Incomplete_Class') {
+                $accessor = new \ArrayObject($data);
+                $value = $accessor['__PHP_Incomplete_Class_Name'];
             } elseif (method_exists($data, '__toString')) {
                 /** @var string $value */
                 $value = $data->__toString();

--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -402,6 +402,20 @@ class NormalizerFormatterTest extends TestCase
         );
     }
 
+    public function testCanNormalizeIncompleteObject(): void
+    {
+        $serialized = "O:17:\"Monolog\TestClass\":1:{s:23:\"\x00Monolog\TestClass\x00name\";s:4:\"test\";}";
+        $object = unserialize($serialized);
+
+        $formatter = new NormalizerFormatter();
+        $record = $this->getRecord(context: ['object' => $object]);
+        $result = $formatter->format($record);
+
+        $this->assertEquals([
+            '__PHP_Incomplete_Class' => 'Monolog\\TestClass',
+        ], $result['context']['object']);
+    }
+
     private function throwHelper($arg)
     {
         throw new \RuntimeException('Thrown');


### PR DESCRIPTION
> PHP Fatal error:  method_exists(): The script tried to execute a method or access a property of an incomplete object. Please ensure that the class definition "Monolog\TestClass" of the object you
>  are trying to operate on was loaded _before_ unserialize() gets called or provide an autoloader to load the class definition in /var/www/html/vendor/monolog/monolog/src/Monolog/Formatter/NormalizerFormatter.php on line 177
> 

When NormalizeFormatter use method_exists on [incomplete object](https://www.php.net/manual/en/function.unserialize.php) it cause fatal error.