### PR TITLE
Clarified instructions about chat ID for Telegram

### DIFF
--- a/src/Monolog/Handler/TelegramBotHandler.php
+++ b/src/Monolog/Handler/TelegramBotHandler.php
@@ -17,14 +17,18 @@ use Monolog\Utils;
 use Monolog\LogRecord;
 
 /**
- * Handler send logs to Telegram using Telegram Bot API.
+ * Handler sends logs to Telegram using Telegram Bot API.
  *
  * How to use:
- *  1) Create telegram bot with https://telegram.me/BotFather
- *  2) Create a telegram channel where logs will be recorded.
- *  3) Add created bot from step 1 to the created channel from step 2.
+ *  1) Create a Telegram bot with https://telegram.me/BotFather;
+ *  2) Create a Telegram channel or a group where logs will be recorded;
+ *  3) Add the created bot from step 1 to the created channel/group from step 2.
  *
- * Use telegram bot API key from step 1 and channel name with '@' prefix from step 2 to create instance of TelegramBotHandler
+ * In order to create an instance of TelegramBotHandler use
+ *  1. The Telegram bot API key from step 1
+ *  2. The channel name with the `@` prefix if you created a public channel (e.g. `@my_public_channel`),
+ *     or the channel ID with the `-100` prefix if you created a private channel (e.g. `-1001234567890`),
+ *     or the group ID from step 2 (e.g. `-1234567890`).
  *
  * @link https://core.telegram.org/bots/api
  *


### PR DESCRIPTION
These instructions clarify the details of setting Telegram chat ID for different types of chats.

https://github.com/Seldaek/monolog/issues/1787