### PR TITLE
Add a WithMonologChannel attribute

### DIFF
--- a/src/Monolog/Attribute/WithMonologChannel.php
+++ b/src/Monolog/Attribute/WithMonologChannel.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Attribute;
+
+/**
+ * A reusable attribute to help configure a class as expecting a given logger channel.
+ *
+ * Using it offers no guarantee: it needs to be leveraged by a Monolog third-party consumer.
+ *
+ * Using it with the Monolog library only has no effect at all: wiring the logger instance into
+ * other classes is not managed by Monolog.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class WithMonologChannel
+{
+    public function __construct(
+        public readonly string $channel
+    ) {
+    }
+}

--- a/tests/Monolog/Attribute/WithMonologChannelTest.php
+++ b/tests/Monolog/Attribute/WithMonologChannelTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Monolog\Attribute;
+
+use PHPUnit\Framework\TestCase;
+
+class WithMonologChannelTest extends TestCase
+{
+    public function test(): void
+    {
+        $attribute = new WithMonologChannel('fixture');
+        $this->assertSame('fixture', $attribute->channel);
+    }
+
+}


### PR DESCRIPTION
This attribute is meant to be used by frameworks / integrations to choose which logger instance to inject in a class when they manage several channels, if they decide to use it.
This attribute will have no effect in Monolog itself as the wiring of the logger in other classes is not managed by Monolog.