### PR TITLE
Remove usage of soft-deprecated PHPUnit API

### DIFF
--- a/src/Monolog/Test/TestCase.php
+++ b/src/Monolog/Test/TestCase.php
@@ -73,9 +73,9 @@ class TestCase extends \PHPUnit\Framework\TestCase
         $formatter = $this->createMock(FormatterInterface::class);
         $formatter->expects(self::any())
             ->method('format')
-            ->will(self::returnCallback(function ($record) {
+            ->willReturnCallback(function ($record) {
                 return $record->message;
-            }));
+            });
 
         return $formatter;
     }


### PR DESCRIPTION
This method is not yet reported by PHPUnit as a warning. But as it has the `@deprecated` annotation, it gets reported by the phpstan setup as it detects usages of deprecated APIs.