### PR TITLE
Include extra in context in PsrHandler

### DIFF
--- a/tests/Monolog/Handler/PsrHandlerTest.php
+++ b/tests/Monolog/Handler/PsrHandlerTest.php
@@ -60,4 +60,20 @@ class PsrHandlerTest extends TestCase
         $handler->setFormatter(new LineFormatter('dummy'));
         $handler->handle($this->getRecord($level, $message, context: $context, datetime: new \DateTimeImmutable()));
     }
+
+    public function testIncludeExtra()
+    {
+        $message = 'Hello, world!';
+        $context = ['foo' => 'bar'];
+        $extra = ['baz' => 'boo'];
+        $level = Level::Error;
+
+        $psrLogger = $this->createMock('Psr\Log\NullLogger');
+        $psrLogger->expects($this->once())
+            ->method('log')
+            ->with($level->toPsrLogLevel(), $message, ['baz' => 'boo', 'foo' => 'bar']);
+
+        $handler = new PsrHandler($psrLogger, includeExtra: true);
+        $handler->handle($this->getRecord($level, $message, context: $context, datetime: new \DateTimeImmutable(), extra: $extra));
+    }
 }


### PR DESCRIPTION
Currently PsrHandler pass only context, but missing all extra data. This PR adds option to merge this two arrays and pass as context into psr logger.