### PR TITLE
catching exceptions in exception handling

### DIFF
--- a/src/Monolog/Formatter/LineFormatter.php
+++ b/src/Monolog/Formatter/LineFormatter.php
@@ -240,7 +240,12 @@ class LineFormatter extends NormalizerFormatter
 
     private function formatException(\Throwable $e): string
     {
-        $str = '[object] (' . Utils::getClass($e) . '(code: ' . $e->getCode();
+        $str = '[object] (' . Utils::getClass($e) . '(code: ';
+        try {
+            $str .= $e->getCode();  // throws an exception when $code is a string like in PDOException
+        } catch (\Throwable $exception) {
+            $str .= 'n/a';
+        }
         if ($e instanceof \SoapFault) {
             if (isset($e->faultcode)) {
                 $str .= ' faultcode: ' . $e->faultcode;


### PR DESCRIPTION
When an Exception is thrown while logging that has a non numberic code another exception is thrown while formating the exception. This is for example the case when logging to a database and a PDOException is thrown.

[object] (ErrorException(code: 0): Undefined property: Illuminate\\Database\\QueryException::$code