### PR TITLE
Remove `final` from class declaration

### DIFF
--- a/src/Monolog/Formatter/GoogleCloudLoggingFormatter.php
+++ b/src/Monolog/Formatter/GoogleCloudLoggingFormatter.php
@@ -22,7 +22,7 @@ use Monolog\LogRecord;
  *
  * @author Luís Cobucci <lcobucci@gmail.com>
  */
-final class GoogleCloudLoggingFormatter extends JsonFormatter
+class GoogleCloudLoggingFormatter extends JsonFormatter
 {
     protected function normalizeRecord(LogRecord $record): array
     {


### PR DESCRIPTION
Most (if not all) other classes in the project are not marked as final.

Although it's possible to extend the functionality of this class by using composition, it goes against how the rest of the library works for no apparent reason.

In my use case, I was trying to add a field linking the log entry to a request [as described in the Cloud Logging documentation](https://cloud.google.com/run/docs/logging#correlate-logs).