### PR TITLE
Revert Revert "Mark Logger @final to discourage extension"

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -30,7 +30,6 @@ use WeakMap;
  * and uses them to store records that are added to it.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
- * @final
  */
 class Logger implements LoggerInterface, ResettableInterface
 {


### PR DESCRIPTION
This reverts https://github.com/Seldaek/monolog/commit/3cba75ec0926eec177a4a2cd6c977ecddd0fc7c1

The biggest reason I found to extend `Logger` is related to **dependency injection**.

Consider this scenario: I have [two channels](https://github.com/Seldaek/monolog/blob/main/doc/01-usage.md#leveraging-channels), `$debugLogger = new Logger('debug');` and `$securityLogger = new Logger('security');`, each with their own Handlers, Formatters and/or Processors. 

Now some of my class might require `$debugLogger`, while others requires `$securityLogger`. 

**MyClass**:
```
public function __construct(Logger $debugLogger, PHPMailer $phpMailer) {
    // ... 
}
```

**MyOtherClass**:
```
public function __construct(Logger $securityLogger, SomeClass $someClass) { 
    // ... 
}
```

This might work when class are instantiated manually. However, this won't work when using [PHP-DI Autowiring](https://php-di.org/doc/autowiring.html), as it won't be able to determine which Logger to inject. 

I can't even distinguish both in my PHP-DI definition:
```
Logger::class  => function (StreamHandler $handler) {
    $logger = new Logger('debug');
    $logger->pushHandler($handler);

    return $logger;
},

// Doesn't work, can't register two with the same class !
Logger::class  => function (SymfonyMailerHandler $handler) {
    $logger = new Logger('security');
    $logger->pushHandler($handler);

    return $logger;
}
```

Also consider that while both loggers are the same PHP wise, and _can_ be swapped without raising exception, they might provide very different service! I could make a mistake and inject `debug` in `MyOtherClass` and every security log would be passed to the debug handler.


My previous solution was to extend `Logger` for each use. For example :
```
class SecurityLogger extends Logger
{
}

class DebugLogger extends Logger
{
}
```

PHP-DI definition:
```
DebugLogger::class  => function (StreamHandler $handler) {
    $logger = new DebugLogger('debug');
    $logger->pushHandler($handler);

    return $logger;
},

SecurityLogger::class  => function (SymfonyMailerHandler $handler) {
    $logger = new SecurityLogger('security');
    $logger->pushHandler($handler);

    return $logger;
}
```

Now `MyOtherClass` can use `SecurityLogger` to get the proper channel : 
```
public function __construct(SecurityLogger $securityLogger, SomeClass $someClass) { 
    // ... 
}
```

Same for `MyClass` with `DebugLogger`. Plus `DebugLogger` can't be injected by mistake in `MyOtherClass`. 

However, having `Logger` marked as final disable this workaround. So unless there's another solution for this use case, I strongly believe this should not be marked final. I understand the annotation isn't enforced by PHP yet, but it still throws a warning when running PHPStan analysis, and I won't take the change of this annotation being changed to a real final class later.

Reference:
 -  https://github.com/Seldaek/monolog/pull/1827