### PR TITLE
[NormalizerFormatter] Avoid throwing an exception when the toString call fails

### DIFF
--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -210,8 +210,14 @@ class NormalizerFormatter implements FormatterInterface
                 $accessor = new \ArrayObject($data);
                 $value = (string) $accessor['__PHP_Incomplete_Class_Name'];
             } elseif (method_exists($data, '__toString')) {
-                /** @var string $value */
-                $value = $data->__toString();
+                try {
+                    /** @var string $value */
+                    $value = $data->__toString();
+                } catch (\Throwable) {
+                    // if the toString method is failing, use the default behavior
+                    /** @var null|scalar|array<mixed[]|scalar|null> $value */
+                    $value = json_decode($this->toJson($data, true), true);
+                }
             } else {
                 // the rest is normalized by json encoding and decoding it
                 /** @var null|scalar|array<mixed[]|scalar|null> $value */

--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -131,11 +131,25 @@ class NormalizerFormatterTest extends TestCase
     public function testFormatToStringExceptionHandle()
     {
         $formatter = new NormalizerFormatter('Y-m-d');
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('Could not convert to string');
-        $formatter->format($this->getRecord(context: [
+        $formatted = $formatter->format($this->getRecord(context: [
             'myObject' => new TestToStringError(),
         ]));
+        $this->assertEquals(
+            [
+                'level_name' => Level::Warning->getName(),
+                'level' => Level::Warning->value,
+                'channel' => 'test',
+                'message' => 'test',
+                'context' => [
+                    'myObject' => [
+                        TestToStringError::class => [],
+                    ],
+                ],
+                'datetime' => date('Y-m-d'),
+                'extra' => [],
+            ],
+            $formatted
+        );
     }
 
     public function testBatchFormat()


### PR DESCRIPTION
HI @Seldaek

This is an improvement of https://github.com/Seldaek/monolog/issues/673

When a __toString method call throws an exception (which should occurs as few as possible), the Normalizer is throwing an exception too. I believe this behavior is wrong because:
- I cannot say monolog to prefer the default behavior over the __toString method
- If I wouldn't have a __toString method, it would have work correctly

Also, I have the following situation when using DoctrineFixtureBundle:
- I wrote a bug in my fixtures
- An exception is thrown
- During this process, monolog try to do some logs
- For the logs, he look for FooObject::__toString() method
- This method return the name of the FooObject which require a database request (because of doctrine lazy proxy)
- The entity is not found in database (of course, since the fixture loading failure)
- The __toString throws an exception
- Monolog crash
- I get the monolog failure instead of the doctrineFixture one to debug correctly my work.

As soon as I comment the toString method in my entity, I get the correct error.
Imho, if monolog cannot use the toString method, he shouldn't change the "error behavior" and fallback to jsonEncode like the tostring method doesn't exist.

WDYT ?