### PR TITLE
Convert GelfMessage into string required by createAmqpMessage

### DIFF
--- a/src/Monolog/Handler/AmqpHandler.php
+++ b/src/Monolog/Handler/AmqpHandler.php
@@ -11,6 +11,7 @@
 
 namespace Monolog\Handler;
 
+use Gelf\Message as GelfMessage;
 use Monolog\Level;
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Formatter\JsonFormatter;
@@ -116,6 +117,10 @@ class AmqpHandler extends AbstractProcessingHandler
 
             $record = $this->processRecord($record);
             $data = $this->getFormatter()->format($record);
+
+            if($data instanceof GelfMessage) {
+                $data = json_encode($data->toArray());
+            }
 
             $this->exchange->batch_basic_publish(
                 $this->createAmqpMessage($data),

--- a/src/Monolog/Handler/AmqpHandler.php
+++ b/src/Monolog/Handler/AmqpHandler.php
@@ -76,6 +76,10 @@ class AmqpHandler extends AbstractProcessingHandler
         $data = $record->formatted;
         $routingKey = $this->getRoutingKey($record);
 
+        if($data instanceof GelfMessage) {
+            $data = json_encode($data->toArray());
+        }
+
         if ($this->exchange instanceof AMQPExchange) {
             $attributes = [
                 'delivery_mode' => 2,


### PR DESCRIPTION
This is just an idea how to make the GelfMessageFormatter and AmqpHandler compatible (again).