### PR TITLE
Improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Internally Monolog still uses its own level scheme since it predates PSR-3.
 Install the latest version with
 
 ```bash
-$ composer require monolog/monolog
+composer require monolog/monolog
 ```
 
 ## Basic Usage


### PR DESCRIPTION
Remove `$` as it's not valid terminal command and breaks copy-paste flow.