### PR TITLE
fix: Implicitly marking parameter $datetime as nullable is deprecated…

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -328,7 +328,7 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * @phpstan-param value-of<Level::VALUES>|Level $level
      */
-    public function addRecord(int|Level $level, string $message, array $context = [], DateTimeImmutable $datetime = null): bool
+    public function addRecord(int|Level $level, string $message, array $context = [], DateTimeImmutable|null $datetime = null): bool
     {
         if (is_int($level) && isset(self::RFC_5424_LEVELS[$level])) {
             $level = self::RFC_5424_LEVELS[$level];


### PR DESCRIPTION
… on PHP 8.4