### PR TITLE
Remove base path on LineFormatter

### DIFF
--- a/src/Monolog/Formatter/LineFormatter.php
+++ b/src/Monolog/Formatter/LineFormatter.php
@@ -294,7 +294,7 @@ class LineFormatter extends NormalizerFormatter
         $trace = $e->getTraceAsString();
 
         if ($this->basePath !== '') {
-            $trace = preg_replace('{^(#\d+ )' . preg_quote($this->basePath) . '}m', '$1', $trace) ?: $trace;
+            $trace = preg_replace('{^(#\d+ )' . preg_quote($this->basePath) . '}m', '$1', $trace) ?? $trace;
         }
 
         if ($this->stacktracesParser !== null) {

--- a/src/Monolog/Formatter/LineFormatter.php
+++ b/src/Monolog/Formatter/LineFormatter.php
@@ -52,7 +52,11 @@ class LineFormatter extends NormalizerFormatter
         parent::__construct($dateFormat);
     }
 
-    public function basePath(string $path = ''): self
+    /**
+     * Setting a base path will hide the base path from exception and stack trace file names to shorten them
+     * @return $this
+     */
+    public function setBasePath(string $path = ''): self
     {
         if ($path !== '') {
             $path = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
@@ -273,7 +277,7 @@ class LineFormatter extends NormalizerFormatter
 
         $file = $e->getFile();
         if ($this->basePath !== '') {
-            $file = str_replace($this->basePath, '', $e->getFile());
+            $file = preg_replace('{^'.preg_quote($this->basePath).'}', '', $e->getFile());
         }
 
         $str .= '): ' . $e->getMessage() . ' at ' . $file . ':' . $e->getLine() . ')';
@@ -290,7 +294,7 @@ class LineFormatter extends NormalizerFormatter
         $trace = $e->getTraceAsString();
 
         if ($this->basePath !== '') {
-            $trace = str_replace(' ' . $this->basePath, ' ', $trace);
+            $trace = preg_replace('{^(#\d+ )' . preg_quote($this->basePath) . '}m', '$1', $trace);
         }
 
         if ($this->stacktracesParser !== null) {

--- a/src/Monolog/Formatter/LineFormatter.php
+++ b/src/Monolog/Formatter/LineFormatter.php
@@ -277,7 +277,7 @@ class LineFormatter extends NormalizerFormatter
 
         $file = $e->getFile();
         if ($this->basePath !== '') {
-            $file = preg_replace('{^'.preg_quote($this->basePath).'}', '', $e->getFile());
+            $file = preg_replace('{^'.preg_quote($this->basePath).'}', '', $file);
         }
 
         $str .= '): ' . $e->getMessage() . ' at ' . $file . ':' . $e->getLine() . ')';
@@ -294,7 +294,7 @@ class LineFormatter extends NormalizerFormatter
         $trace = $e->getTraceAsString();
 
         if ($this->basePath !== '') {
-            $trace = preg_replace('{^(#\d+ )' . preg_quote($this->basePath) . '}m', '$1', $trace);
+            $trace = preg_replace('{^(#\d+ )' . preg_quote($this->basePath) . '}m', '$1', $trace) ?: $trace;
         }
 
         if ($this->stacktracesParser !== null) {


### PR DESCRIPTION
**OPT-IN**, This makes smaller logs entries, it is easy to read too

**Before**
```
Error at /var/www/vhosts/myvhost.com/app/Models/MyModel.php:165)
[stacktrace]
 /var/www/vhosts/myvhost.com/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1475)
 /var/www/vhosts/myvhost.com/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(1218)
 /var/www/vhosts/myvhost.com/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(1199)
```
**After**
```php
$formatter->basePath('/var/www/vhosts/myvhost.com'); //laravel has base_path()
```
```
Error at app/Models/MyModel.php:165)
[stacktrace]
 vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1475)
 vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(1218)
 vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(1199)
```
