### PR TITLE
add formatted key in ArrayAccess for LogRecord

### DIFF
--- a/src/Monolog/LogRecord.php
+++ b/src/Monolog/LogRecord.php
@@ -17,7 +17,7 @@ use ArrayAccess;
  * Monolog log record
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
- * @template-implements ArrayAccess<'message'|'level'|'context'|'level_name'|'channel'|'datetime'|'extra', int|string|\DateTimeImmutable|array<mixed>>
+ * @template-implements ArrayAccess<'message'|'level'|'context'|'level_name'|'channel'|'datetime'|'extra'|'formatted', int|string|\DateTimeImmutable|array<mixed>>
  */
 class LogRecord implements ArrayAccess
 {


### PR DESCRIPTION
since $record['formatted'] is a legal syntax, it should not be flagged by static analysis tools like phpstan