### PR TITLE
Fix IntrospectionProcessor tests resulting in false positives

### DIFF
--- a/tests/Monolog/Processor/IntrospectionProcessorTest.php
+++ b/tests/Monolog/Processor/IntrospectionProcessorTest.php
@@ -68,7 +68,7 @@ class IntrospectionProcessorTest extends TestCase
     {
         $input = $this->getRecord(Level::Debug);
 
-        $expected = $input;
+        $expected = clone $input;
 
         $processor = new IntrospectionProcessor(Level::Critical);
         $actual = $processor($input);
@@ -80,7 +80,7 @@ class IntrospectionProcessorTest extends TestCase
     {
         $input = $this->getRecord(Level::Critical);
 
-        $expected = $input;
+        $expected = clone $input;
         $expected['extra'] = [
             'file' => null,
             'line' => null,
@@ -99,7 +99,7 @@ class IntrospectionProcessorTest extends TestCase
     {
         $input = $this->getRecord(Level::Emergency);
 
-        $expected = $input;
+        $expected = clone $input;
         $expected['extra'] = [
             'file' => null,
             'line' => null,


### PR DESCRIPTION
Three tests in IntrospectionProcessorTest (testLevelTooLow, testLevelEqual, testLevelHigher) aren't actually testing anything. Because `$expected = $input` is a reference, the changes made to `$expected['extra']` are made to $input and carried forward to $actual. You can demonstrate this by adding a `return $record` at the immediate start of `InstrospectionProcessor::__invoke` -- the tests still pass despite bypassing all the code.

Fixes #1895