### PR TITLE
Make IntrospectionProcessor extendable

### DIFF
--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -29,16 +29,20 @@ use Monolog\LogRecord;
  */
 class IntrospectionProcessor implements ProcessorInterface
 {
-    private Level $level;
+    protected Level $level;
 
     /** @var string[] */
-    private array $skipClassesPartials;
+    protected array $skipClassesPartials;
 
-    private int $skipStackFramesCount;
+    protected int $skipStackFramesCount;
 
-    private const SKIP_FUNCTIONS = [
+    protected const SKIP_FUNCTIONS = [
         'call_user_func',
         'call_user_func_array',
+    ];
+
+    protected const SKIP_CLASSES = [
+        'Monolog\\',
     ];
 
     /**
@@ -50,7 +54,7 @@ class IntrospectionProcessor implements ProcessorInterface
     public function __construct(int|string|Level $level = Level::Debug, array $skipClassesPartials = [], int $skipStackFramesCount = 0)
     {
         $this->level = Logger::toMonologLevel($level);
-        $this->skipClassesPartials = array_merge(['Monolog\\'], $skipClassesPartials);
+        $this->skipClassesPartials = array_merge(static::SKIP_CLASSES, $skipClassesPartials);
         $this->skipStackFramesCount = $skipStackFramesCount;
     }
 


### PR DESCRIPTION
Currently is very hard to make IntrospectionProcessor extendable from custom implementation (we have custom features implemented for Magento logging). 