### PR TITLE
Normalize call normalizeRecord if necessary

### DIFF
--- a/src/Monolog/Formatter/JsonFormatter.php
+++ b/src/Monolog/Formatter/JsonFormatter.php
@@ -171,6 +171,10 @@ class JsonFormatter extends NormalizerFormatter
         }
 
         if (\is_object($data)) {
+            if ($data instanceof LogRecord) {
+                return $this->normalizeRecord($data);
+            }
+            
             if ($data instanceof \DateTimeInterface) {
                 return $this->formatDate($data);
             }


### PR DESCRIPTION
Monolog version 3

Hello,

When you format a logRecord with JsonFormater::format(), it's calling : 
- NormalizeFormatter::format() 
- NormalizeFormatter::normalizeRecord() 

Then we have a nice formatted record, with exception datas, if any.

Now, if we try to format an array of records with JsonFormater::formatBatch() : 
- JsonFormater::formatBatchJson()
- JsonFormater::normalize()

Then, we lost the exception datas.

As I understand, formatBatch is a way to format array of records in an optimized way if possible, and the output should be the same as formatting each records in a foreach.

If this is the case, it may be a bug, and this PR fix it for me. 
I dont know if it's a problem for anything else than "exception datas" but this is this case wich make me found that.
For more context, I was writing a custom Handler, where I call `this->getFormatter()->formatBatch($records);` in `handleBatch()`.
