### PR TITLE
Allow the user to define a custom mode when `fopen`-ing a log file

### DIFF
--- a/src/Monolog/Handler/StreamHandler.php
+++ b/src/Monolog/Handler/StreamHandler.php
@@ -41,6 +41,8 @@ class StreamHandler extends AbstractProcessingHandler
     protected $filePermission;
     /** @var bool */
     protected $useLocking;
+	/** @var string */
+    protected $fileOpenMode = 'a';
     /** @var true|null */
     private $dirCreated = null;
 
@@ -48,10 +50,11 @@ class StreamHandler extends AbstractProcessingHandler
      * @param resource|string $stream         If a missing path can't be created, an UnexpectedValueException will be thrown on first write
      * @param int|null        $filePermission Optional file permissions (default (0644) are only for owner read/write)
      * @param bool            $useLocking     Try to lock log file before doing any writes
+     * @param null            $fileOpenMode   The fopen() mode used when opening a file, if $stream is a file path
      *
      * @throws \InvalidArgumentException If stream is not a resource or string
      */
-    public function __construct($stream, $level = Logger::DEBUG, bool $bubble = true, ?int $filePermission = null, bool $useLocking = false)
+    public function __construct($stream, $level = Logger::DEBUG, bool $bubble = true, ?int $filePermission = null, bool $useLocking = false, $fileOpenMode = null)
     {
         parent::__construct($level, $bubble);
 
@@ -76,6 +79,11 @@ class StreamHandler extends AbstractProcessingHandler
             $this->url = Utils::canonicalizePath($stream);
         } else {
             throw new \InvalidArgumentException('A stream must either be a resource or a string.');
+        }
+
+        $this->fileOpenMode = $fileOpenMode ?? $this->fileOpenMode;
+        if(!$this->fileOpenMode){
+            throw new \InvalidArgumentException("Please define a valid file open mode, as defined by PHP's fopen()");
         }
 
         $this->filePermission = $filePermission;
@@ -138,7 +146,7 @@ class StreamHandler extends AbstractProcessingHandler
                 return $this->customErrorHandler(...$args);
             });
             try {
-                $stream = fopen($url, 'a');
+                $stream = fopen($url, $this->fileOpenMode);
                 if ($this->filePermission !== null) {
                     @chmod($url, $this->filePermission);
                 }
@@ -183,14 +191,14 @@ class StreamHandler extends AbstractProcessingHandler
         fwrite($stream, (string) $record['formatted']);
     }
 
-    private function customErrorHandler(int $code, string $msg): bool
+    protected final function customErrorHandler(int $code, string $msg): bool
     {
         $this->errorMessage = preg_replace('{^(fopen|mkdir)\(.*?\): }', '', $msg);
 
         return true;
     }
 
-    private function getDirFromStream(string $stream): ?string
+    protected final function getDirFromStream(string $stream): ?string
     {
         $pos = strpos($stream, '://');
         if ($pos === false) {
@@ -204,7 +212,7 @@ class StreamHandler extends AbstractProcessingHandler
         return null;
     }
 
-    private function createDir(string $url): void
+    protected final function createDir(string $url): void
     {
         // Do not try to create dir if it has already been tried.
         if ($this->dirCreated) {


### PR DESCRIPTION
I've included changes to both allow custom `fopen` modes, as well as change the visibility of the helper functions on this class.
I've made them final to keep the "do not touch" aspect, while still allowing subclasses to use them.