### PR TITLE
Remove Slim framework integration suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ Bugs and feature request are tracked on [GitHub](https://github.com/Seldaek/mono
 - [Lumen](http://lumen.laravel.com/) comes out of the box with Monolog.
 - [PPI](https://github.com/ppi/framework) comes out of the box with Monolog.
 - [CakePHP](http://cakephp.org/) is usable with Monolog via the [cakephp-monolog](https://github.com/jadb/cakephp-monolog) plugin.
-- [Slim](http://www.slimframework.com/) is usable with Monolog via the [Slim-Monolog](https://github.com/Flynsarmy/Slim-Monolog) log writer.
 - [XOOPS 2.6](http://xoops.org/) comes out of the box with Monolog.
 - [Aura.Web_Project](https://github.com/auraphp/Aura.Web_Project) comes out of the box with Monolog.
 - [Nette Framework](http://nette.org/en/) is usable with Monolog via the [contributte/monolog](https://github.com/contributte/monolog) or [orisai/nette-monolog](https://github.com/orisai/nette-monolog) extensions.


### PR DESCRIPTION
The suggested library (https://github.com/Flynsarmy/Slim-Monolog) only supports Slim 2, which has not been maintained for a long time. Monolog can be integrated with Slim v4 directly, without the need for any additional libraries.