### PR TITLE
Fix return type `normalizeException`

### DIFF
--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -248,7 +248,7 @@ class NormalizerFormatter implements FormatterInterface
     }
 
     /**
-     * @return array<string, string|int|array<string|int|array<string>>>|string
+     * @return array<array-key, string|int|array<string|int|array<string>>>
      */
     protected function normalizeException(Throwable $e, int $depth = 0)
     {


### PR DESCRIPTION
I dont see how `normalizeException` can return a string.
