### PR TITLE
Fix broken url

### DIFF
--- a/doc/02-handlers-formatters-processors.md
+++ b/doc/02-handlers-formatters-processors.md
@@ -22,7 +22,7 @@
   setups though, this is just meant as a quick and dirty solution.
 - [_SyslogHandler_](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/SyslogHandler.php): Logs records to the syslog.
 - [_ErrorLogHandler_](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/ErrorLogHandler.php): Logs records to PHP's
-  [`error_log()`](http://docs.php.net/manual/en/function.error-log.php) function.
+  [`error_log()`](https://www.php.net/manual/en/function.error-log.php) function.
 - [_ProcessHandler_](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/ProcessHandler.php): Logs records to the [STDIN](https://en.wikipedia.org/wiki/Standard_streams#Standard_input_.28stdin.29) of any process, specified by a command.
 
 ### Send alerts and emails


### PR DESCRIPTION
Minor fix in documentation where the url to php documentation website was broken