### PR TITLE
Change visibility of handler classes to protected

### DIFF
--- a/src/Monolog/Handler/AmqpHandler.php
+++ b/src/Monolog/Handler/AmqpHandler.php
@@ -25,7 +25,7 @@ class AmqpHandler extends AbstractProcessingHandler
     protected AMQPExchange|AMQPChannel $exchange;
 
     /** @var array<string, mixed> */
-    private array $extraAttributes = [];
+    protected array $extraAttributes = [];
 
     protected string $exchangeName;
 
@@ -147,7 +147,7 @@ class AmqpHandler extends AbstractProcessingHandler
         return strtolower($routingKey);
     }
 
-    private function createAmqpMessage(string $data): AMQPMessage
+    protected function createAmqpMessage(string $data): AMQPMessage
     {
         $attributes = [
             'delivery_mode' => 2,

--- a/src/Monolog/Handler/BrowserConsoleHandler.php
+++ b/src/Monolog/Handler/BrowserConsoleHandler.php
@@ -165,7 +165,7 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
         return self::FORMAT_UNKNOWN;
     }
 
-    private static function generateScript(): string
+    protected static function generateScript(): string
     {
         $script = [];
         foreach (static::$records as $record) {
@@ -188,7 +188,7 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
         return "(function (c) {if (c && c.groupCollapsed) {\n" . implode("\n", $script) . "\n}})(console);";
     }
 
-    private static function getConsoleMethodForLevel(Level $level): string
+    protected static function getConsoleMethodForLevel(Level $level): string
     {
         return match ($level) {
             Level::Debug => 'debug',
@@ -201,7 +201,7 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
     /**
      * @return string[]
      */
-    private static function handleStyles(string $formatted): array
+    protected static function handleStyles(string $formatted): array
     {
         $args = [];
         $format = '%c' . $formatted;
@@ -221,7 +221,7 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
         return array_reverse($args);
     }
 
-    private static function handleCustomStyles(string $style, string $string): string
+    protected static function handleCustomStyles(string $style, string $string): string
     {
         static $colors = ['blue', 'green', 'red', 'magenta', 'orange', 'black', 'grey'];
         static $labels = [];
@@ -253,7 +253,7 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
      * @param  mixed[] $dict
      * @return mixed[]
      */
-    private static function dump(string $title, array $dict): array
+    protected static function dump(string $title, array $dict): array
     {
         $script = [];
         $dict = array_filter($dict, fn ($value) => $value !== null);
@@ -272,7 +272,7 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
         return $script;
     }
 
-    private static function quote(string $arg): string
+    protected static function quote(string $arg): string
     {
         return '"' . addcslashes($arg, "\"\n\\") . '"';
     }
@@ -280,7 +280,7 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
     /**
      * @param mixed $args
      */
-    private static function call(...$args): string
+    protected static function call(...$args): string
     {
         $method = array_shift($args);
         if (!\is_string($method)) {
@@ -293,7 +293,7 @@ class BrowserConsoleHandler extends AbstractProcessingHandler
     /**
      * @param mixed[] $args
      */
-    private static function call_array(string $method, array $args): string
+    protected static function call_array(string $method, array $args): string
     {
         return 'c.' . $method . '(' . implode(', ', $args) . ');';
     }

--- a/src/Monolog/Handler/CouchDBHandler.php
+++ b/src/Monolog/Handler/CouchDBHandler.php
@@ -41,7 +41,7 @@ class CouchDBHandler extends AbstractProcessingHandler
      * @var mixed[]
      * @phpstan-var Options
      */
-    private array $options;
+    protected array $options;
 
     /**
      * @param mixed[] $options

--- a/src/Monolog/Handler/CubeHandler.php
+++ b/src/Monolog/Handler/CubeHandler.php
@@ -24,13 +24,13 @@ use Monolog\LogRecord;
  */
 class CubeHandler extends AbstractProcessingHandler
 {
-    private ?\Socket $udpConnection = null;
-    private ?\CurlHandle $httpConnection = null;
-    private string $scheme;
-    private string $host;
-    private int $port;
+    protected ?\Socket $udpConnection = null;
+    protected ?\CurlHandle $httpConnection = null;
+    protected string $scheme;
+    protected string $host;
+    protected int $port;
     /** @var string[] */
-    private array $acceptedSchemes = ['http', 'udp'];
+    protected array $acceptedSchemes = ['http', 'udp'];
 
     /**
      * Create a Cube handler
@@ -133,7 +133,7 @@ class CubeHandler extends AbstractProcessingHandler
         }
     }
 
-    private function writeUdp(string $data): void
+    protected function writeUdp(string $data): void
     {
         if (null === $this->udpConnection) {
             $this->connectUdp();
@@ -146,7 +146,7 @@ class CubeHandler extends AbstractProcessingHandler
         socket_send($this->udpConnection, $data, \strlen($data), 0);
     }
 
-    private function writeHttp(string $data): void
+    protected function writeHttp(string $data): void
     {
         if (null === $this->httpConnection) {
             $this->connectHttp();

--- a/src/Monolog/Handler/Curl/Util.php
+++ b/src/Monolog/Handler/Curl/Util.php
@@ -21,7 +21,7 @@ use CurlHandle;
 final class Util
 {
     /** @var array<int> */
-    private static array $retriableErrorCodes = [
+    protected static array $retriableErrorCodes = [
         CURLE_COULDNT_RESOLVE_HOST,
         CURLE_COULDNT_CONNECT,
         CURLE_HTTP_NOT_FOUND,

--- a/src/Monolog/Handler/DeduplicationHandler.php
+++ b/src/Monolog/Handler/DeduplicationHandler.php
@@ -136,7 +136,7 @@ class DeduplicationHandler extends BufferHandler
         return $record->datetime->getTimestamp() . ':' . $record->level->getName() . ':' . preg_replace('{[\r\n].*}', '', $record->message);
     }
 
-    private function collectLogs(): void
+    protected function collectLogs(): void
     {
         if (!file_exists($this->deduplicationStore)) {
             return;

--- a/src/Monolog/Handler/DoctrineCouchDBHandler.php
+++ b/src/Monolog/Handler/DoctrineCouchDBHandler.php
@@ -24,7 +24,7 @@ use Monolog\LogRecord;
  */
 class DoctrineCouchDBHandler extends AbstractProcessingHandler
 {
-    private CouchDBClient $client;
+    protected CouchDBClient $client;
 
     public function __construct(CouchDBClient $client, int|string|Level $level = Level::Debug, bool $bubble = true)
     {

--- a/src/Monolog/Handler/ElasticsearchHandler.php
+++ b/src/Monolog/Handler/ElasticsearchHandler.php
@@ -70,7 +70,7 @@ class ElasticsearchHandler extends AbstractProcessingHandler
     /**
      * @var bool
      */
-    private $needsType;
+    protected $needsType;
 
     /**
      * @param Client|Client8 $client  Elasticsearch Client object

--- a/src/Monolog/Handler/FingersCrossed/ChannelLevelActivationStrategy.php
+++ b/src/Monolog/Handler/FingersCrossed/ChannelLevelActivationStrategy.php
@@ -38,12 +38,12 @@ use Monolog\LogRecord;
  */
 class ChannelLevelActivationStrategy implements ActivationStrategyInterface
 {
-    private Level $defaultActionLevel;
+    protected Level $defaultActionLevel;
 
     /**
      * @var array<string, Level>
      */
-    private array $channelToActionLevel;
+    protected array $channelToActionLevel;
 
     /**
      * @param int|string|Level|LogLevel::*                $defaultActionLevel   The default action level to be used if the record's category doesn't match any

--- a/src/Monolog/Handler/FingersCrossed/ErrorLevelActivationStrategy.php
+++ b/src/Monolog/Handler/FingersCrossed/ErrorLevelActivationStrategy.php
@@ -23,7 +23,7 @@ use Psr\Log\LogLevel;
  */
 class ErrorLevelActivationStrategy implements ActivationStrategyInterface
 {
-    private Level $actionLevel;
+    protected Level $actionLevel;
 
     /**
      * @param int|string|Level $actionLevel Level or name or value

--- a/src/Monolog/Handler/FingersCrossedHandler.php
+++ b/src/Monolog/Handler/FingersCrossedHandler.php
@@ -178,7 +178,7 @@ class FingersCrossedHandler extends Handler implements ProcessableHandlerInterfa
     /**
      * Resets the state of the handler. Stops forwarding records to the wrapped handler.
      */
-    private function flushBuffer(): void
+    protected function flushBuffer(): void
     {
         if (null !== $this->passthruLevel) {
             $passthruLevel = $this->passthruLevel;

--- a/src/Monolog/Handler/FleepHookHandler.php
+++ b/src/Monolog/Handler/FleepHookHandler.php
@@ -107,7 +107,7 @@ class FleepHookHandler extends SocketHandler
     /**
      * Builds the header of the API Call
      */
-    private function buildHeader(string $content): string
+    protected function buildHeader(string $content): string
     {
         $header = "POST " . static::FLEEP_HOOK_URI . $this->token . " HTTP/1.1\r\n";
         $header .= "Host: " . static::FLEEP_HOST . "\r\n";
@@ -121,7 +121,7 @@ class FleepHookHandler extends SocketHandler
     /**
      * Builds the body of API call
      */
-    private function buildContent(LogRecord $record): string
+    protected function buildContent(LogRecord $record): string
     {
         $dataArray = [
             'message' => $record->formatted,

--- a/src/Monolog/Handler/FlowdockHandler.php
+++ b/src/Monolog/Handler/FlowdockHandler.php
@@ -106,7 +106,7 @@ class FlowdockHandler extends SocketHandler
     /**
      * Builds the body of API call
      */
-    private function buildContent(LogRecord $record): string
+    protected function buildContent(LogRecord $record): string
     {
         return Utils::jsonEncode($record->formatted);
     }
@@ -114,7 +114,7 @@ class FlowdockHandler extends SocketHandler
     /**
      * Builds the header of the API Call
      */
-    private function buildHeader(string $content): string
+    protected function buildHeader(string $content): string
     {
         $header = "POST /v1/messages/team_inbox/" . $this->apiToken . " HTTP/1.1\r\n";
         $header .= "Host: api.flowdock.com\r\n";

--- a/src/Monolog/Handler/IFTTTHandler.php
+++ b/src/Monolog/Handler/IFTTTHandler.php
@@ -28,8 +28,8 @@ use Monolog\LogRecord;
  */
 class IFTTTHandler extends AbstractProcessingHandler
 {
-    private string $eventName;
-    private string $secretKey;
+    protected string $eventName;
+    protected string $secretKey;
 
     /**
      * @param string $eventName The name of the IFTTT Maker event that should be triggered

--- a/src/Monolog/Handler/LogglyHandler.php
+++ b/src/Monolog/Handler/LogglyHandler.php
@@ -73,7 +73,7 @@ class LogglyHandler extends AbstractProcessingHandler
     /**
      * Starts a fresh curl session for the given endpoint and returns its handler.
      */
-    private function loadCurlHandle(string $endpoint): CurlHandle
+    protected function loadCurlHandle(string $endpoint): CurlHandle
     {
         $url = sprintf("https://%s/%s/%s/", static::HOST, $endpoint, $this->token);
 

--- a/src/Monolog/Handler/LogmaticHandler.php
+++ b/src/Monolog/Handler/LogmaticHandler.php
@@ -21,11 +21,11 @@ use Monolog\LogRecord;
  */
 class LogmaticHandler extends SocketHandler
 {
-    private string $logToken;
+    protected string $logToken;
 
-    private string $hostname;
+    protected string $hostname;
 
-    private string $appName;
+    protected string $appName;
 
     /**
      * @param string $token    Log token supplied by Logmatic.

--- a/src/Monolog/Handler/MongoDBHandler.php
+++ b/src/Monolog/Handler/MongoDBHandler.php
@@ -34,11 +34,11 @@ use Monolog\LogRecord;
  */
 class MongoDBHandler extends AbstractProcessingHandler
 {
-    private \MongoDB\Collection $collection;
+    protected \MongoDB\Collection $collection;
 
-    private Client|Manager $manager;
+    protected Client|Manager $manager;
 
-    private string|null $namespace = null;
+    protected string|null $namespace = null;
 
     /**
      * Constructor.

--- a/src/Monolog/Handler/NullHandler.php
+++ b/src/Monolog/Handler/NullHandler.php
@@ -26,7 +26,7 @@ use Monolog\LogRecord;
  */
 class NullHandler extends Handler
 {
-    private Level $level;
+    protected Level $level;
 
     /**
      * @param string|int|Level $level The minimum logging level at which this handler will be triggered

--- a/src/Monolog/Handler/OverflowHandler.php
+++ b/src/Monolog/Handler/OverflowHandler.php
@@ -37,17 +37,17 @@ use Monolog\LogRecord;
  */
 class OverflowHandler extends AbstractHandler implements FormattableHandlerInterface
 {
-    private HandlerInterface $handler;
+    protected HandlerInterface $handler;
 
     /** @var array<int, int> */
-    private array $thresholdMap = [];
+    protected array $thresholdMap = [];
 
     /**
      * Buffer of all messages passed to the handler before the threshold was reached
      *
      * @var mixed[][]
      */
-    private array $buffer = [];
+    protected array $buffer = [];
 
     /**
      * @param array<int, int> $thresholdMap Dictionary of log level value => threshold

--- a/src/Monolog/Handler/PHPConsoleHandler.php
+++ b/src/Monolog/Handler/PHPConsoleHandler.php
@@ -91,7 +91,7 @@ class PHPConsoleHandler extends AbstractProcessingHandler
     /**
      * @phpstan-var Options
      */
-    private array $options = [
+    protected array $options = [
         'enabled' => true, // bool Is PHP Console server enabled
         'classesPartialsTraceIgnore' => ['Monolog\\'], // array Hide calls of classes started with...
         'debugTagsKeysInContext' => [0, 'tag'], // bool Is PHP Console server enabled
@@ -114,7 +114,7 @@ class PHPConsoleHandler extends AbstractProcessingHandler
         'dataStorage' => null, // \PhpConsole\Storage|null Fixes problem with custom $_SESSION handler (see https://github.com/barbushin/php-console#troubleshooting-with-_session-handler-overridden-in-some-frameworks)
     ];
 
-    private Connector $connector;
+    protected Connector $connector;
 
     /**
      * @param  array<string, mixed> $options   See \Monolog\Handler\PHPConsoleHandler::$options for more details
@@ -139,7 +139,7 @@ class PHPConsoleHandler extends AbstractProcessingHandler
      * @phpstan-param InputOptions $options
      * @phpstan-return Options
      */
-    private function initOptions(array $options): array
+    protected function initOptions(array $options): array
     {
         $wrongOptions = array_diff(array_keys($options), array_keys($this->options));
         if (\count($wrongOptions) > 0) {
@@ -149,7 +149,7 @@ class PHPConsoleHandler extends AbstractProcessingHandler
         return array_replace($this->options, $options);
     }
 
-    private function initConnector(?Connector $connector = null): Connector
+    protected function initConnector(?Connector $connector = null): Connector
     {
         if (null === $connector) {
             if ($this->options['dataStorage'] instanceof Storage) {
@@ -240,7 +240,7 @@ class PHPConsoleHandler extends AbstractProcessingHandler
         }
     }
 
-    private function handleDebugRecord(LogRecord $record): void
+    protected function handleDebugRecord(LogRecord $record): void
     {
         [$tags, $filteredContext] = $this->getRecordTags($record);
         $message = $record->message;
@@ -250,12 +250,12 @@ class PHPConsoleHandler extends AbstractProcessingHandler
         $this->connector->getDebugDispatcher()->dispatchDebug($message, $tags, $this->options['classesPartialsTraceIgnore']);
     }
 
-    private function handleExceptionRecord(LogRecord $record): void
+    protected function handleExceptionRecord(LogRecord $record): void
     {
         $this->connector->getErrorsDispatcher()->dispatchException($record->context['exception']);
     }
 
-    private function handleErrorRecord(LogRecord $record): void
+    protected function handleErrorRecord(LogRecord $record): void
     {
         $context = $record->context;
 
@@ -271,7 +271,7 @@ class PHPConsoleHandler extends AbstractProcessingHandler
     /**
      * @return array{string, mixed[]}
      */
-    private function getRecordTags(LogRecord $record): array
+    protected function getRecordTags(LogRecord $record): array
     {
         $tags = null;
         $filteredContext = [];

--- a/src/Monolog/Handler/ProcessHandler.php
+++ b/src/Monolog/Handler/ProcessHandler.php
@@ -32,18 +32,18 @@ class ProcessHandler extends AbstractProcessingHandler
      *
      * @var resource|bool|null
      */
-    private $process;
+    protected $process;
 
-    private string $command;
+    protected string $command;
 
-    private ?string $cwd;
+    protected ?string $cwd;
 
     /**
      * @var resource[]
      */
-    private array $pipes = [];
+    protected array $pipes = [];
 
-    private float $timeout;    
+    protected float $timeout;
 
     /**
      * @var array<int, string[]>
@@ -98,7 +98,7 @@ class ProcessHandler extends AbstractProcessingHandler
      * Makes sure that the process is actually started, and if not, starts it,
      * assigns the stream pipes, and handles startup errors, if any.
      */
-    private function ensureProcessIsStarted(): void
+    protected function ensureProcessIsStarted(): void
     {
         if (\is_resource($this->process) === false) {
             $this->startProcess();
@@ -110,7 +110,7 @@ class ProcessHandler extends AbstractProcessingHandler
     /**
      * Starts the actual process and sets all streams to non-blocking.
      */
-    private function startProcess(): void
+    protected function startProcess(): void
     {
         $this->process = proc_open($this->command, static::DESCRIPTOR_SPEC, $this->pipes, $this->cwd);
 
@@ -124,7 +124,7 @@ class ProcessHandler extends AbstractProcessingHandler
      *
      * @throws \UnexpectedValueException
      */
-    private function handleStartupErrors(): void
+    protected function handleStartupErrors(): void
     {
         $selected = $this->selectErrorStream();
         if (false === $selected) {

--- a/src/Monolog/Handler/PsrHandler.php
+++ b/src/Monolog/Handler/PsrHandler.php
@@ -33,7 +33,7 @@ class PsrHandler extends AbstractHandler implements FormattableHandlerInterface
     protected LoggerInterface $logger;
 
     protected FormatterInterface|null $formatter = null;
-    private bool $includeExtra;
+    protected bool $includeExtra;
 
     /**
      * @param LoggerInterface $logger The underlying PSR-3 compliant logger to which messages will be proxied

--- a/src/Monolog/Handler/PushoverHandler.php
+++ b/src/Monolog/Handler/PushoverHandler.php
@@ -25,31 +25,31 @@ use Monolog\LogRecord;
  */
 class PushoverHandler extends SocketHandler
 {
-    private string $token;
+    protected string $token;
 
     /** @var array<int|string> */
-    private array $users;
+    protected array $users;
 
-    private string $title;
+    protected string $title;
 
-    private string|int|null $user = null;
+    protected string|int|null $user = null;
 
-    private int $retry;
+    protected int $retry;
 
-    private int $expire;
+    protected int $expire;
 
-    private Level $highPriorityLevel;
+    protected Level $highPriorityLevel;
 
-    private Level $emergencyLevel;
+    protected Level $emergencyLevel;
 
-    private bool $useFormattedMessage = false;
+    protected bool $useFormattedMessage = false;
 
     /**
      * All parameters that can be sent to Pushover
      * @see https://pushover.net/api
      * @var array<string, bool>
      */
-    private array $parameterNames = [
+    protected array $parameterNames = [
         'token' => true,
         'user' => true,
         'message' => true,
@@ -70,7 +70,7 @@ class PushoverHandler extends SocketHandler
      * @see https://pushover.net/api#sounds
      * @var string[]
      */
-    private array $sounds = [
+    protected array $sounds = [
         'pushover', 'bike', 'bugle', 'cashregister', 'classical', 'cosmic', 'falling', 'gamelan', 'incoming',
         'intermission', 'magic', 'mechanical', 'pianobar', 'siren', 'spacealarm', 'tugboat', 'alien', 'climb',
         'persistent', 'echo', 'updown', 'none',
@@ -142,7 +142,7 @@ class PushoverHandler extends SocketHandler
         return $this->buildHeader($content) . $content;
     }
 
-    private function buildContent(LogRecord $record): string
+    protected function buildContent(LogRecord $record): string
     {
         // Pushover has a limit of 512 characters on title and message combined.
         $maxMessageLength = 512 - \strlen($this->title);
@@ -183,7 +183,7 @@ class PushoverHandler extends SocketHandler
         return http_build_query($dataArray);
     }
 
-    private function buildHeader(string $content): string
+    protected function buildHeader(string $content): string
     {
         $header = "POST /1/messages.json HTTP/1.1\r\n";
         $header .= "Host: api.pushover.net\r\n";

--- a/src/Monolog/Handler/RedisHandler.php
+++ b/src/Monolog/Handler/RedisHandler.php
@@ -32,8 +32,8 @@ use Redis;
 class RedisHandler extends AbstractProcessingHandler
 {
     /** @var Predis<Predis>|Redis */
-    private Predis|Redis $redisClient;
-    private string $redisKey;
+    protected Predis|Redis $redisClient;
+    protected string $redisKey;
     protected int $capSize;
 
     /**

--- a/src/Monolog/Handler/RedisPubSubHandler.php
+++ b/src/Monolog/Handler/RedisPubSubHandler.php
@@ -32,8 +32,8 @@ use Redis;
 class RedisPubSubHandler extends AbstractProcessingHandler
 {
     /** @var Predis<Predis>|Redis */
-    private Predis|Redis $redisClient;
-    private string $channelKey;
+    protected Predis|Redis $redisClient;
+    protected string $channelKey;
 
     /**
      * @param Predis<Predis>|Redis $redis The redis instance

--- a/src/Monolog/Handler/RollbarHandler.php
+++ b/src/Monolog/Handler/RollbarHandler.php
@@ -39,7 +39,7 @@ class RollbarHandler extends AbstractProcessingHandler
     /**
      * Records whether any log records have been added since the last flush of the rollbar notifier
      */
-    private bool $hasRecords = false;
+    protected bool $hasRecords = false;
 
     protected bool $initialized = false;
 

--- a/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/src/Monolog/Handler/Slack/SlackRecord.php
@@ -38,42 +38,42 @@ class SlackRecord
     /**
      * Slack channel (encoded ID or name)
      */
-    private string|null $channel;
+    protected string|null $channel;
 
     /**
      * Name of a bot
      */
-    private string|null $username;
+    protected string|null $username;
 
     /**
      * User icon e.g. 'ghost', 'http://example.com/user.png'
      */
-    private string|null $userIcon;
+    protected string|null $userIcon;
 
     /**
      * Whether the message should be added to Slack as attachment (plain text otherwise)
      */
-    private bool $useAttachment;
+    protected bool $useAttachment;
 
     /**
      * Whether the the context/extra messages added to Slack as attachments are in a short style
      */
-    private bool $useShortAttachment;
+    protected bool $useShortAttachment;
 
     /**
      * Whether the attachment should include context and extra data
      */
-    private bool $includeContextAndExtra;
+    protected bool $includeContextAndExtra;
 
     /**
      * Dot separated list of fields to exclude from slack message. E.g. ['context.field1', 'extra.field2']
      * @var string[]
      */
-    private array $excludeFields;
+    protected array $excludeFields;
 
-    private FormatterInterface|null $formatter;
+    protected FormatterInterface|null $formatter;
 
-    private NormalizerFormatter $normalizerFormatter;
+    protected NormalizerFormatter $normalizerFormatter;
 
     /**
      * @param string[] $excludeFields
@@ -319,7 +319,7 @@ class SlackRecord
      *
      * @return array{title: string, value: string, short: false}
      */
-    private function generateAttachmentField(string $title, $value): array
+    protected function generateAttachmentField(string $title, $value): array
     {
         $value = \is_array($value)
             ? sprintf('```%s```', substr($this->stringify($value), 0, 1990))
@@ -339,7 +339,7 @@ class SlackRecord
      *
      * @return array<array{title: string, value: string, short: false}>
      */
-    private function generateAttachmentFields(array $data): array
+    protected function generateAttachmentFields(array $data): array
     {
         /** @var array<array<mixed>|string> $normalized */
         $normalized = $this->normalizerFormatter->normalizeValue($data);
@@ -357,7 +357,7 @@ class SlackRecord
      *
      * @return mixed[]
      */
-    private function removeExcludedFields(LogRecord $record): array
+    protected function removeExcludedFields(LogRecord $record): array
     {
         $recordData = $record->toArray();
         foreach ($this->excludeFields as $field) {

--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -28,12 +28,12 @@ class SlackHandler extends SocketHandler
     /**
      * Slack API token
      */
-    private string $token;
+    protected string $token;
 
     /**
      * Instance of the SlackRecord util class preparing data for Slack API.
      */
-    private SlackRecord $slackRecord;
+    protected SlackRecord $slackRecord;
 
     /**
      * @param  string                    $token                  Slack API token
@@ -114,7 +114,7 @@ class SlackHandler extends SocketHandler
     /**
      * Builds the body of API call
      */
-    private function buildContent(LogRecord $record): string
+    protected function buildContent(LogRecord $record): string
     {
         $dataArray = $this->prepareContentData($record);
 
@@ -139,7 +139,7 @@ class SlackHandler extends SocketHandler
     /**
      * Builds the header of the API Call
      */
-    private function buildHeader(string $content): string
+    protected function buildHeader(string $content): string
     {
         $header = "POST /api/chat.postMessage HTTP/1.1\r\n";
         $header .= "Host: slack.com\r\n";

--- a/src/Monolog/Handler/SlackWebhookHandler.php
+++ b/src/Monolog/Handler/SlackWebhookHandler.php
@@ -28,12 +28,12 @@ class SlackWebhookHandler extends AbstractProcessingHandler
     /**
      * Slack Webhook token
      */
-    private string $webhookUrl;
+    protected string $webhookUrl;
 
     /**
      * Instance of the SlackRecord util class preparing data for Slack API.
      */
-    private SlackRecord $slackRecord;
+    protected SlackRecord $slackRecord;
 
     /**
      * @param string      $webhookUrl             Slack Webhook URL

--- a/src/Monolog/Handler/SocketHandler.php
+++ b/src/Monolog/Handler/SocketHandler.php
@@ -22,18 +22,18 @@ use Monolog\LogRecord;
  */
 class SocketHandler extends AbstractProcessingHandler
 {
-    private string $connectionString;
-    private float $connectionTimeout;
+    protected string $connectionString;
+    protected float $connectionTimeout;
     /** @var resource|null */
-    private $resource;
-    private float $timeout;
-    private float $writingTimeout;
-    private int|null $lastSentBytes = null;
-    private int|null $chunkSize;
-    private bool $persistent;
-    private int|null $errno = null;
-    private string|null $errstr = null;
-    private float|null $lastWritingAt = null;
+    protected $resource;
+    protected float $timeout;
+    protected float $writingTimeout;
+    protected int|null $lastSentBytes = null;
+    protected int|null $chunkSize;
+    protected bool $persistent;
+    protected int|null $errno = null;
+    protected string|null $errstr = null;
+    protected float|null $lastWritingAt = null;
 
     /**
      * @param string     $connectionString  Socket connection string
@@ -318,14 +318,14 @@ class SocketHandler extends AbstractProcessingHandler
         return stream_get_meta_data($this->resource);
     }
 
-    private function validateTimeout(float $value): void
+    protected function validateTimeout(float $value): void
     {
         if ($value < 0) {
             throw new \InvalidArgumentException("Timeout must be 0 or a positive float (got $value)");
         }
     }
 
-    private function connectIfNotConnected(): void
+    protected function connectIfNotConnected(): void
     {
         if ($this->isConnected()) {
             return;
@@ -346,14 +346,14 @@ class SocketHandler extends AbstractProcessingHandler
         return $this->resource;
     }
 
-    private function connect(): void
+    protected function connect(): void
     {
         $this->createSocketResource();
         $this->setSocketTimeout();
         $this->setStreamChunkSize();
     }
 
-    private function createSocketResource(): void
+    protected function createSocketResource(): void
     {
         if ($this->isPersistent()) {
             $resource = $this->pfsockopen();
@@ -366,21 +366,21 @@ class SocketHandler extends AbstractProcessingHandler
         $this->resource = $resource;
     }
 
-    private function setSocketTimeout(): void
+    protected function setSocketTimeout(): void
     {
         if (!$this->streamSetTimeout()) {
             throw new \UnexpectedValueException("Failed setting timeout with stream_set_timeout()");
         }
     }
 
-    private function setStreamChunkSize(): void
+    protected function setStreamChunkSize(): void
     {
         if (null !== $this->chunkSize && false === $this->streamSetChunkSize()) {
             throw new \UnexpectedValueException("Failed setting chunk size with stream_set_chunk_size()");
         }
     }
 
-    private function writeToSocket(string $data): void
+    protected function writeToSocket(string $data): void
     {
         $length = \strlen($data);
         $sent = 0;
@@ -409,7 +409,7 @@ class SocketHandler extends AbstractProcessingHandler
         }
     }
 
-    private function writingIsTimedOut(int $sent): bool
+    protected function writingIsTimedOut(int $sent): bool
     {
         // convert to ms
         if (0.0 === $this->writingTimeout) {

--- a/src/Monolog/Handler/SqsHandler.php
+++ b/src/Monolog/Handler/SqsHandler.php
@@ -28,8 +28,8 @@ class SqsHandler extends AbstractProcessingHandler
     /** 100 KB in bytes - head message size for new error log */
     protected const HEAD_MESSAGE_SIZE = 102400;
 
-    private SqsClient $client;
-    private string $queueUrl;
+    protected SqsClient $client;
+    protected string $queueUrl;
 
     public function __construct(SqsClient $sqsClient, string $queueUrl, int|string|Level $level = Level::Debug, bool $bubble = true)
     {

--- a/src/Monolog/Handler/StreamHandler.php
+++ b/src/Monolog/Handler/StreamHandler.php
@@ -31,13 +31,13 @@ class StreamHandler extends AbstractProcessingHandler
     /** @var resource|null */
     protected $stream;
     protected string|null $url = null;
-    private string|null $errorMessage = null;
+    protected string|null $errorMessage = null;
     protected int|null $filePermission;
     protected bool $useLocking;
     protected string $fileOpenMode;
     /** @var true|null */
-    private bool|null $dirCreated = null;
-    private bool $retrying = false;
+    protected bool|null $dirCreated = null;
+    protected bool $retrying = false;
 
     /**
      * @param resource|string $stream         If a missing path can't be created, an UnexpectedValueException will be thrown on first write
@@ -201,14 +201,14 @@ class StreamHandler extends AbstractProcessingHandler
         fwrite($stream, (string) $record->formatted);
     }
 
-    private function customErrorHandler(int $code, string $msg): bool
+    protected function customErrorHandler(int $code, string $msg): bool
     {
         $this->errorMessage = preg_replace('{^(fopen|mkdir|fwrite)\(.*?\): }', '', $msg);
 
         return true;
     }
 
-    private function getDirFromStream(string $stream): ?string
+    protected function getDirFromStream(string $stream): ?string
     {
         $pos = strpos($stream, '://');
         if ($pos === false) {
@@ -222,7 +222,7 @@ class StreamHandler extends AbstractProcessingHandler
         return null;
     }
 
-    private function createDir(string $url): void
+    protected function createDir(string $url): void
     {
         // Do not try to create dir if it has already been tried.
         if (true === $this->dirCreated) {

--- a/src/Monolog/Handler/SymfonyMailerHandler.php
+++ b/src/Monolog/Handler/SymfonyMailerHandler.php
@@ -30,7 +30,7 @@ class SymfonyMailerHandler extends MailHandler
 {
     protected MailerInterface|TransportInterface $mailer;
     /** @var Email|Closure(string, LogRecord[]): Email */
-    private Email|Closure $emailTemplate;
+    protected Email|Closure $emailTemplate;
 
     /**
      * @phpstan-param Email|Closure(string, LogRecord[]): Email $email

--- a/src/Monolog/Handler/SyslogUdpHandler.php
+++ b/src/Monolog/Handler/SyslogUdpHandler.php
@@ -30,7 +30,7 @@ class SyslogUdpHandler extends AbstractSyslogHandler
     const RFC5424e = 2;
 
     /** @var array<self::RFC*, string> */
-    private array $dateFormats = [
+    protected array $dateFormats = [
         self::RFC3164 => 'M d H:i:s',
         self::RFC5424 => \DateTime::RFC3339,
         self::RFC5424e => \DateTime::RFC3339_EXTENDED,
@@ -86,7 +86,7 @@ class SyslogUdpHandler extends AbstractSyslogHandler
      * @param  string|string[] $message
      * @return string[]
      */
-    private function splitMessageIntoLines($message): array
+    protected function splitMessageIntoLines($message): array
     {
         if (\is_array($message)) {
             $message = implode("\n", $message);

--- a/src/Monolog/Handler/TelegramBotHandler.php
+++ b/src/Monolog/Handler/TelegramBotHandler.php
@@ -36,12 +36,12 @@ use Monolog\LogRecord;
  */
 class TelegramBotHandler extends AbstractProcessingHandler
 {
-    private const BOT_API = 'https://api.telegram.org/bot';
+    protected const BOT_API = 'https://api.telegram.org/bot';
 
     /**
      * The available values of parseMode according to the Telegram api documentation
      */
-    private const AVAILABLE_PARSE_MODES = [
+    protected const AVAILABLE_PARSE_MODES = [
         'HTML',
         'MarkdownV2',
         'Markdown', // legacy mode without underline and strikethrough, use MarkdownV2 instead
@@ -50,53 +50,53 @@ class TelegramBotHandler extends AbstractProcessingHandler
     /**
      * The maximum number of characters allowed in a message according to the Telegram api documentation
      */
-    private const MAX_MESSAGE_LENGTH = 4096;
+    protected const MAX_MESSAGE_LENGTH = 4096;
 
     /**
      * Telegram bot access token provided by BotFather.
      * Create telegram bot with https://telegram.me/BotFather and use access token from it.
      */
-    private string $apiKey;
+    protected string $apiKey;
 
     /**
      * Telegram channel name.
      * Since to start with '@' symbol as prefix.
      */
-    private string $channel;
+    protected string $channel;
 
     /**
      * The kind of formatting that is used for the message.
      * See available options at https://core.telegram.org/bots/api#formatting-options
      * or in AVAILABLE_PARSE_MODES
      */
-    private string|null $parseMode;
+    protected string|null $parseMode;
 
     /**
      * Disables link previews for links in the message.
      */
-    private bool|null $disableWebPagePreview;
+    protected bool|null $disableWebPagePreview;
 
     /**
      * Sends the message silently. Users will receive a notification with no sound.
      */
-    private bool|null $disableNotification;
+    protected bool|null $disableNotification;
 
     /**
      * True - split a message longer than MAX_MESSAGE_LENGTH into parts and send in multiple messages.
      * False - truncates a message that is too long.
      */
-    private bool $splitLongMessages;
+    protected bool $splitLongMessages;
 
     /**
      * Adds 1-second delay between sending a split message (according to Telegram API to avoid 429 Too Many Requests).
      */
-    private bool $delayBetweenMessages;
+    protected bool $delayBetweenMessages;
 
     /**
      * Telegram message thread id, unique identifier for the target message thread (topic) of the forum; for forum supergroups only
      * See how to get the `message_thread_id` https://stackoverflow.com/a/75178418
      */
-    private int|null $topic;
+    protected int|null $topic;
 
     /**
      * @param  string                    $apiKey               Telegram bot access token provided by BotFather
@@ -285,7 +285,7 @@ class TelegramBotHandler extends AbstractProcessingHandler
      * Handle a message that is too long: truncates or splits into several
      * @return string[]
      */
-    private function handleMessageLength(string $message): array
+    protected function handleMessageLength(string $message): array
     {
         $truncatedMarker = ' (...truncated)';
         if (!$this->splitLongMessages && \strlen($message) > self::MAX_MESSAGE_LENGTH) {

--- a/src/Monolog/Handler/TestHandler.php
+++ b/src/Monolog/Handler/TestHandler.php
@@ -74,7 +74,7 @@ class TestHandler extends AbstractProcessingHandler
     protected array $records = [];
     /** @phpstan-var array<value-of<Level::VALUES>, LogRecord[]> */
     protected array $recordsByLevel = [];
-    private bool $skipReset = false;
+    protected bool $skipReset = false;
 
     /**
      * @return array<LogRecord>


### PR DESCRIPTION
Some properties and methods of the handler classes are set to private and some others to protected.

I change the visibility of all of them to protected. I believe this is a better practice, as it allows us to extend the handler.

If there are any security concerns of why this is the way it is, please do let me know.



### Example

The `MongoDBHandler` stores the configuration private as shown:

https://github.com/Seldaek/monolog/blob/d97d5e9468aa7d10f95b2e0468f39afdbd08a4d1/src/Monolog/Handler/MongoDBHandler.php#L37-L41

But the `DynamoDBHandler` stores the configuration protected as shown:

https://github.com/Seldaek/monolog/blob/d97d5e9468aa7d10f95b2e0468f39afdbd08a4d1/src/Monolog/Handler/DynamoDbHandler.php#L32-L36

With how is the code right now, I can extend the `DynamoDbHandler` to add querying functionality, all without having to create a new configuration object (aka `Aws\DynamoDb\DynamoDbClient`).

But with `MongoDBHandler`, I have to redo the argument parsing in its construct function to include this functionality, creating also two copies of the same exact object in memory (aka `MongoDB\Driver\Manager` or `\MongoDB\Collection`).