### PR TITLE
Feature/clock interface issue 1902

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     ],
     "require": {
         "php": ">=8.1",
+        "psr/clock": "^1.0",
         "psr/log": "^2.0 || ^3.0"
     },
     "require-dev": {

--- a/src/Monolog/Clock.php
+++ b/src/Monolog/Clock.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Monolog;
+
+use Psr\Clock\ClockInterface;
+use Monolog\JsonSerializableDateTimeImmutable;
+
+class Clock implements ClockInterface
+{
+    private bool $useMicroseconds;
+    private ?\DateTimeZone $timezone;
+    private ?JsonSerializableDateTimeImmutable $fixedTime;
+
+    public function __construct(bool $useMicroseconds = true, ?\DateTimeZone $timezone = null)
+    {
+        $this->useMicroseconds = $useMicroseconds;
+        $this->timezone = $timezone;
+    }
+
+    public function now(): JsonSerializableDateTimeImmutable
+    {
+        return $this->fixedTime ?? new JsonSerializableDateTimeImmutable($this->useMicroseconds, $this->timezone);
+    }
+
+    public function setUseMicroseconds(bool $useMicroseconds): void
+    {
+        $this->useMicroseconds = $useMicroseconds;
+    }
+
+    public function setTimezone(?\DateTimeZone $timezone): void
+    {
+        $this->timezone = $timezone;
+    }
+
+    public function setFixedTime(JsonSerializableDateTimeImmutable $fixedTime): void
+    {
+        $this->fixedTime = $fixedTime;
+    }
+}

--- a/src/Monolog/Clock.php
+++ b/src/Monolog/Clock.php
@@ -9,7 +9,7 @@ class Clock implements ClockInterface
 {
     private bool $useMicroseconds;
     private ?\DateTimeZone $timezone;
-    private ?JsonSerializableDateTimeImmutable $fixedTime;
+    private JsonSerializableDateTimeImmutable $fixedTime;
 
     public function __construct(bool $useMicroseconds = true, ?\DateTimeZone $timezone = null)
     {


### PR DESCRIPTION
This PR introduces a new feature to allow users to specify a custom time for log records in Monolog. The enhancement involves integrating a Clock service that implements the PSR-20 ClockInterface, enabling more flexible and testable timestamp management.

Clock Integration: Added a Clock class that provides timestamps using JsonSerializableDateTimeImmutable. This allows for consistent and customizable time handling.

Logger Modification: Updated the Logger class to accept an optional ClockInterface parameter. The addRecord method now uses this clock to fetch timestamps when specified.

@Seldaek https://github.com/Seldaek/monolog/issues/1902 I saw this issue and I'm sending this PR 