### PR TITLE
Feature/clock interface implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     ],
     "require": {
         "php": ">=8.1",
+        "psr/clock": "^1.0",
         "psr/log": "^2.0 || ^3.0"
     },
     "require-dev": {

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -361,7 +361,7 @@ class Logger implements LoggerInterface, ResettableInterface
             $recordInitialized = \count($this->processors) === 0;
 
             $record = new LogRecord(
-                datetime: $datetime ?? ($this->clock ? $this->clock->now() : new JsonSerializableDateTimeImmutable($this->microsecondTimestamps, $this->timezone)),
+                datetime: $datetime ?? ($this->clock instanceof ClockInterface ? $this->clock->now() : new JsonSerializableDateTimeImmutable($this->microsecondTimestamps, $this->timezone)),
                 channel: $this->name,
                 level: self::toMonologLevel($level),
                 message: $message,

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -23,7 +23,6 @@ use Psr\Clock\ClockInterface;
 use Throwable;
 use Stringable;
 use WeakMap;
-use Monolog\LoggerClock;
 
 /**
  * Monolog log channel
@@ -151,7 +150,7 @@ class Logger implements LoggerInterface, ResettableInterface
     protected Closure|null $exceptionHandler = null;
 
     protected ClockInterface|null $clock = null;
-
+    
     /**
      * Keeps track of depth to prevent infinite logging loops
      */

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -19,9 +19,11 @@ use Monolog\Processor\ProcessorInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\InvalidArgumentException;
 use Psr\Log\LogLevel;
+use Psr\Clock\ClockInterface;
 use Throwable;
 use Stringable;
 use WeakMap;
+use Monolog\LoggerClock;
 
 /**
  * Monolog log channel
@@ -148,6 +150,8 @@ class Logger implements LoggerInterface, ResettableInterface
 
     protected Closure|null $exceptionHandler = null;
 
+    protected ClockInterface|null $clock = null;
+
     /**
      * Keeps track of depth to prevent infinite logging loops
      */
@@ -169,16 +173,17 @@ class Logger implements LoggerInterface, ResettableInterface
      * @param list<HandlerInterface> $handlers   Optional stack of handlers, the first one in the array is called first, etc.
      * @param callable[]         $processors Optional array of processors
      * @param DateTimeZone|null  $timezone   Optional timezone, if not provided date_default_timezone_get() will be used
-     *
+     * @param ClockInterface|null   $clock      Optional clock for timestamp generation
      * @phpstan-param array<(callable(LogRecord): LogRecord)|ProcessorInterface> $processors
      */
-    public function __construct(string $name, array $handlers = [], array $processors = [], DateTimeZone|null $timezone = null)
+    public function __construct(string $name, array $handlers = [], array $processors = [], DateTimeZone|null $timezone = null, ClockInterface|null $clock = null)
     {
         $this->name = $name;
         $this->setHandlers($handlers);
         $this->processors = $processors;
         $this->timezone = $timezone ?? new DateTimeZone(date_default_timezone_get());
         $this->fiberLogDepth = new \WeakMap();
+        $this->clock = $clock;
     }
 
     public function getName(): string
@@ -357,7 +362,7 @@ class Logger implements LoggerInterface, ResettableInterface
             $recordInitialized = \count($this->processors) === 0;
 
             $record = new LogRecord(
-                datetime: $datetime ?? new JsonSerializableDateTimeImmutable($this->microsecondTimestamps, $this->timezone),
+                datetime: $datetime ?? ($this->clock ? $this->clock->now() : new JsonSerializableDateTimeImmutable($this->microsecondTimestamps, $this->timezone)),
                 channel: $this->name,
                 level: self::toMonologLevel($level),
                 message: $message,

--- a/src/Monolog/LoggerClock.php
+++ b/src/Monolog/LoggerClock.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Monolog;
+
+use Psr\Clock\ClockInterface;
+use Monolog\JsonSerializableDateTimeImmutable;
+
+class LoggerClock implements ClockInterface
+{
+    private bool $useMicroseconds;
+    private ?\DateTimeZone $timezone;
+    private JsonSerializableDateTimeImmutable $fixedTime;
+
+    public function __construct(bool $useMicroseconds = true, ?\DateTimeZone $timezone = null)
+    {
+        $this->useMicroseconds = $useMicroseconds;
+        $this->timezone = $timezone;
+    }
+
+    public function now(): JsonSerializableDateTimeImmutable
+    {
+        return $this->fixedTime ?? new JsonSerializableDateTimeImmutable($this->useMicroseconds, $this->timezone);
+    }
+
+    public function setUseMicroseconds(bool $useMicroseconds): void
+    {
+        $this->useMicroseconds = $useMicroseconds;
+    }
+
+    public function setTimezone(?\DateTimeZone $timezone): void
+    {
+        $this->timezone = $timezone;
+    }
+
+    public function setFixedTime(JsonSerializableDateTimeImmutable $fixedTime): void
+    {
+        $this->fixedTime = $fixedTime;
+    }
+}


### PR DESCRIPTION
After  @stof  review I did some changes on the PR.
This PR introduces a new feature to allow users to specify a custom time for log records in Monolog. The enhancement involves integrating a Clock service that implements the PSR-20 ClockInterface,