### PR TITLE
Change datetime format from ISO 8601 to ATOM in ElasticsearchFormatter

### DIFF
--- a/src/Monolog/Formatter/ElasticsearchFormatter.php
+++ b/src/Monolog/Formatter/ElasticsearchFormatter.php
@@ -38,7 +38,7 @@ class ElasticsearchFormatter extends NormalizerFormatter
     public function __construct(string $index, string $type)
     {
         // Elasticsearch requires an ISO 8601 format date with optional millisecond precision.
-        parent::__construct(DateTimeInterface::ISO8601);
+        parent::__construct(DateTimeInterface::ATOM);
 
         $this->index = $index;
         $this->type = $type;

--- a/tests/Monolog/Handler/ElasticaHandlerTest.php
+++ b/tests/Monolog/Handler/ElasticaHandlerTest.php
@@ -167,7 +167,7 @@ class ElasticaHandlerTest extends TestCase
         $msg = $this->getRecord(Level::Error, 'log', context: ['foo' => 7, 'bar', 'class' => new \stdClass], datetime: new \DateTimeImmutable("@0"));
 
         $expected = (array) $msg;
-        $expected['datetime'] = $msg['datetime']->format(\DateTime::ISO8601);
+        $expected['datetime'] = $msg['datetime']->format(\DateTime::ATOM);
         $expected['context'] = [
             'class' => '[object] (stdClass: {})',
             'foo' => 7,

--- a/tests/Monolog/Handler/ElasticsearchHandlerTest.php
+++ b/tests/Monolog/Handler/ElasticsearchHandlerTest.php
@@ -138,7 +138,7 @@ class ElasticsearchHandlerTest extends TestCase
         $msg = $this->getRecord(Level::Error, 'log', context: ['foo' => 7, 'bar', 'class' => new \stdClass], datetime: new \DateTimeImmutable("@0"));
 
         $expected = $msg->toArray();
-        $expected['datetime'] = $msg['datetime']->format(\DateTime::ISO8601);
+        $expected['datetime'] = $msg['datetime']->format(\DateTime::ATOM);
         $expected['context'] = [
             'class' => ["stdClass" => []],
             'foo' => 7,


### PR DESCRIPTION
ISO8601 is deprecated.