### PR TITLE
Fix PHP 8.4 E_STRICT deprecation notices (2.x backport)

### DIFF
--- a/src/Monolog/ErrorHandler.php
+++ b/src/Monolog/ErrorHandler.php
@@ -168,7 +168,7 @@ class ErrorHandler
             E_USER_ERROR        => LogLevel::ERROR,
             E_USER_WARNING      => LogLevel::WARNING,
             E_USER_NOTICE       => LogLevel::NOTICE,
-            E_STRICT            => LogLevel::NOTICE,
+            2048                => LogLevel::NOTICE,  // E_STRICT
             E_RECOVERABLE_ERROR => LogLevel::ERROR,
             E_DEPRECATED        => LogLevel::NOTICE,
             E_USER_DEPRECATED   => LogLevel::NOTICE,
@@ -292,7 +292,7 @@ class ErrorHandler
                 return 'E_USER_WARNING';
             case E_USER_NOTICE:
                 return 'E_USER_NOTICE';
-            case E_STRICT:
+            case 2048:
                 return 'E_STRICT';
             case E_RECOVERABLE_ERROR:
                 return 'E_RECOVERABLE_ERROR';

--- a/tests/Monolog/ErrorHandlerTest.php
+++ b/tests/Monolog/ErrorHandlerTest.php
@@ -120,7 +120,7 @@ class ErrorHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('E_USER_ERROR', $method->invokeArgs(null, [E_USER_ERROR]));
         $this->assertEquals('E_USER_WARNING', $method->invokeArgs(null, [E_USER_WARNING]));
         $this->assertEquals('E_USER_NOTICE', $method->invokeArgs(null, [E_USER_NOTICE]));
-        $this->assertEquals('E_STRICT', $method->invokeArgs(null, [E_STRICT]));
+        $this->assertEquals('E_STRICT', $method->invokeArgs(null, [2048]));
         $this->assertEquals('E_RECOVERABLE_ERROR', $method->invokeArgs(null, [E_RECOVERABLE_ERROR]));
         $this->assertEquals('E_DEPRECATED', $method->invokeArgs(null, [E_DEPRECATED]));
         $this->assertEquals('E_USER_DEPRECATED', $method->invokeArgs(null, [E_USER_DEPRECATED]));


### PR DESCRIPTION
This back-ports https://github.com/Seldaek/monolog/pull/1921 to 2.x for PHP 8.4 compatibility. Thanks!