### PR TITLE
feat: add support to push processor to the bottom of the stack

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -265,6 +265,19 @@ class Logger implements LoggerInterface, ResettableInterface
     }
 
     /**
+     * Adds a processor to the bottom of the stack.
+     *
+     * @phpstan-param ProcessorInterface|(callable(LogRecord): LogRecord) $callback
+     * @return $this
+     */
+    public function prependProcessor(ProcessorInterface|callable $callback): self
+    {
+        $this->processors[] = $callback;
+
+        return $this;
+    }
+
+    /**
      * Removes the processor on top of the stack and returns it.
      *
      * @phpstan-return ProcessorInterface|(callable(LogRecord): LogRecord)

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -258,6 +258,25 @@ class LoggerTest extends MonologTestCase
     }
 
     /**
+     * @covers Logger::prependProcessor
+     */
+    public function testPrependProcessor()
+    {
+        $logger = new Logger(__METHOD__);
+
+        $processor1 = new WebProcessor;
+        $processor2 = new WebProcessor;
+
+        $logger->pushProcessor($processor1);
+        $logger->prependProcessor($processor2);
+
+        $this->assertEquals($processor1, $logger->popProcessor());
+        $this->assertEquals($processor2, $logger->popProcessor());
+
+        $this->assertEmpty($logger->getProcessors());
+    }
+
+    /**
      * @covers Logger::addRecord
      */
     public function testProcessorsAreExecuted()


### PR DESCRIPTION
It was painful to add a processor to the bottom of the stack since we need to first pop all the processors then push it and popped processors back leading to O(N).

I believe it's just better to provide support for adding a processor to the bottom of the stack in just O(1).

Usecase: Let's say we have a processor which masks sensitive fields from the log record and it just makes sense to mask the details at the end after going through all previous processors, if we don't do it this way then the latter processors could add sensitive fields which won't be masked in that case.

Let me know any suggestions for improvements.

@Seldaek Also I believe we should dockerize the development environment, I'd like to work on the same too.
