### PR TITLE
fix: convert boolean values to integers in GelfMessageFormatter

### DIFF
--- a/src/Monolog/Formatter/GelfMessageFormatter.php
+++ b/src/Monolog/Formatter/GelfMessageFormatter.php
@@ -116,7 +116,12 @@ class GelfMessageFormatter extends NormalizerFormatter
 
         foreach ($extra as $key => $val) {
             $key = (string) preg_replace('#[^\w.-]#', '-', (string) $key);
-            $val = \is_scalar($val) || null === $val ? $val : $this->toJson($val);
+  
+                    if (is_bool($val)) {
+    
+                        $val = $val ? 1 : 0;
+        }
+$val = \is_scalar($val) || null === $val ? $val : $this->toJson($val);
             $len = \strlen($this->extraPrefix . $key . $val);
             if ($len > $this->maxLength) {
                 $message->setAdditional($this->extraPrefix . $key, Utils::substr((string) $val, 0, $this->maxLength));
@@ -128,7 +133,11 @@ class GelfMessageFormatter extends NormalizerFormatter
 
         foreach ($context as $key => $val) {
             $key = (string) preg_replace('#[^\w.-]#', '-', (string) $key);
-            $val = \is_scalar($val) || null === $val ? $val : $this->toJson($val);
+  
+                    if (is_bool($val)) {
+            $val = $val ? 1 : 0;
+        }
+$val = \is_scalar($val) || null === $val ? $val : $this->toJson($val);
             $len = \strlen($this->contextPrefix . $key . $val);
             if ($len > $this->maxLength) {
                 $message->setAdditional($this->contextPrefix . $key, Utils::substr((string) $val, 0, $this->maxLength));


### PR DESCRIPTION
This commit converts boolean values to integers (0/1) before adding them to extra/context fields in GELF messages. This ensures bool values are not dropped by Graylog. Fixes Seldaek/monolog#1972.