### PR TITLE
feat: add GooglePubSubHandler for Google Cloud Pub/Sub

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     ],
     "require": {
         "php": ">=8.1",
+        "google/cloud-pubsub": "^2.13",
         "psr/log": "^2.0 || ^3.0"
     },
     "require-dev": {
@@ -47,6 +48,7 @@
         "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
         "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
         "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+        "google/cloud-pubsub": "Allow sending log messages to Google Cloud Pub/Sub",
         "rollbar/rollbar": "Allow sending log messages to Rollbar",
         "ext-mbstring": "Allow to work properly with unicode symbols",
         "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",

--- a/doc/02-handlers-formatters-processors.md
+++ b/doc/02-handlers-formatters-processors.md
@@ -59,6 +59,7 @@
 - [_InsightOpsHandler_](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/InsightOpsHandler.php): Logs records to an [InsightOps](https://www.rapid7.com/products/insightops/) account.
 - [_LogmaticHandler_](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/LogmaticHandler.php): Logs records to a [Logmatic](http://logmatic.io/) account.
 - [_SqsHandler_](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/SqsHandler.php): Logs records to an [AWS SQS](http://docs.aws.amazon.com/aws-sdk-php/v2/guide/service-sqs.html) queue.
+- [_GooglePubSubHandler_](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/GooglePubSubHandler.php): Logs records to a [Google Cloud Pub/Sub](https://cloud.google.com/pubsub) topic.
 - [_RavenHandler_](https://github.com/Seldaek/monolog/blob/1.x/src/Monolog/Handler/RavenHandler.php): Logs records to a [Sentry](http://getsentry.com/) server using
   [raven](https://packagist.org/packages/raven/raven). **Deprecated** and removed in Monolog 2.0, use sentry/sentry 2.x and the [Sentry\Monolog\Handler](https://github.com/getsentry/sentry-php/blob/master/src/Monolog/Handler.php) class instead.
 

--- a/src/Monolog/Handler/GooglePubSubHandler.php
+++ b/src/Monolog/Handler/GooglePubSubHandler.php
@@ -1,0 +1,118 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Google\Cloud\PubSub\PubSubClient;
+use Google\Cloud\PubSub\Topic;
+use Monolog\Level;
+use Monolog\Utils;
+use Monolog\LogRecord;
+
+/**
+ * Writes to Google Cloud Pub/Sub topic.
+ *
+ * @author Helio Dantas <helio.dantas@outlook.com>
+ */
+class GooglePubSubHandler extends AbstractProcessingHandler
+{
+    /** 10 MB in bytes - maximum message size in Pub/Sub */
+    protected const MAX_MESSAGE_SIZE = 10485760;
+    /** 1 MB in bytes - head message size for truncated messages */
+    protected const HEAD_MESSAGE_SIZE = 1048576;
+
+    private PubSubClient $client;
+    private Topic $topic;
+    private string $topicName;
+    private array $attributes;
+
+    public function __construct(
+        PubSubClient $pubSubClient,
+        string $topicName,
+        array $attributes = [],
+        int|string|Level $level = Level::Debug,
+        bool $bubble = true
+    ) {
+        parent::__construct($level, $bubble);
+
+        $this->client = $pubSubClient;
+        $this->topicName = $topicName;
+        $this->attributes = $attributes;
+        $this->topic = $this->client->topic($topicName);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        if (!isset($record->formatted) || 'string' !== \gettype($record->formatted)) {
+            throw new \InvalidArgumentException('GooglePubSubHandler accepts only formatted records as a string' . Utils::getRecordMessageForException($record));
+        }
+
+        $messageBody = $record->formatted;
+        $messageAttributes = $this->attributes;
+
+        // Add log level as attribute
+        $messageAttributes['log_level'] = $record->level->getName();
+        $messageAttributes['channel'] = $record->channel;
+        $messageAttributes['datetime'] = $record->datetime->format('c');
+
+        // Add context and extra data as attributes if they exist
+        if (!empty($record->context)) {
+            $messageAttributes['context'] = json_encode($record->context);
+        }
+        if (!empty($record->extra)) {
+            $messageAttributes['extra'] = json_encode($record->extra);
+        }
+
+        // Truncate message if it exceeds maximum size
+        if (\strlen($messageBody) >= static::MAX_MESSAGE_SIZE) {
+            $messageBody = Utils::substr($messageBody, 0, static::HEAD_MESSAGE_SIZE);
+            $messageAttributes['truncated'] = 'true';
+            $messageAttributes['original_size'] = (string) \strlen($record->formatted);
+        }
+
+        try {
+            $this->topic->publish([
+                'data' => $messageBody,
+                'attributes' => $messageAttributes,
+            ]);
+        } catch (\Exception $e) {
+            // Log the error but don't throw to avoid breaking the application
+            error_log('GooglePubSubHandler failed to publish message: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Get the topic name
+     */
+    public function getTopicName(): string
+    {
+        return $this->topicName;
+    }
+
+    /**
+     * Get the current attributes
+     */
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * Set additional attributes for messages
+     */
+    public function setAttributes(array $attributes): void
+    {
+        $this->attributes = $attributes;
+    }
+}

--- a/tests/Monolog/Handler/GooglePubSubHandlerTest.php
+++ b/tests/Monolog/Handler/GooglePubSubHandlerTest.php
@@ -1,0 +1,195 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Google\Cloud\PubSub\PubSubClient;
+use Google\Cloud\PubSub\Topic;
+use Monolog\Level;
+use Monolog\LogRecord;
+use Monolog\Formatter\LineFormatter;
+
+class GooglePubSubHandlerTest extends \Monolog\Test\MonologTestCase
+{
+    private PubSubClient $pubSubClient;
+    private Topic $topic;
+
+    protected function setUp(): void
+    {
+        $this->pubSubClient = $this->createMock(PubSubClient::class);
+        $this->topic = $this->createMock(Topic::class);
+        
+        $this->pubSubClient
+            ->expects($this->any())
+            ->method('topic')
+            ->willReturn($this->topic);
+    }
+
+    public function testConstruct()
+    {
+        $handler = new GooglePubSubHandler($this->pubSubClient, 'test-topic');
+        $this->assertInstanceOf(GooglePubSubHandler::class, $handler);
+        $this->assertEquals('test-topic', $handler->getTopicName());
+        $this->assertEquals([], $handler->getAttributes());
+    }
+
+    public function testConstructWithAttributes()
+    {
+        $attributes = ['service' => 'test-service', 'environment' => 'test'];
+        $handler = new GooglePubSubHandler($this->pubSubClient, 'test-topic', $attributes);
+        $this->assertEquals($attributes, $handler->getAttributes());
+    }
+
+    public function testWrite()
+    {
+        $handler = new GooglePubSubHandler($this->pubSubClient, 'test-topic');
+        $handler->setFormatter(new LineFormatter());
+
+        $record = $this->getRecord(Level::Warning, 'test message', ['context' => 'data']);
+
+        $this->topic
+            ->expects($this->once())
+            ->method('publish')
+            ->with($this->callback(function ($message) {
+                return $message['data'] !== '' &&
+                       $message['attributes']['log_level'] === 'WARNING' &&
+                       $message['attributes']['channel'] === 'test' &&
+                       isset($message['attributes']['datetime']) &&
+                       $message['attributes']['context'] === '{"context":"data"}';
+            }));
+
+        $handler->handle($record);
+    }
+
+    public function testWriteWithCustomAttributes()
+    {
+        $attributes = ['service' => 'test-service'];
+        $handler = new GooglePubSubHandler($this->pubSubClient, 'test-topic', $attributes);
+        $handler->setFormatter(new LineFormatter());
+
+        $record = $this->getRecord(Level::Info, 'test message');
+
+        $this->topic
+            ->expects($this->once())
+            ->method('publish')
+            ->with($this->callback(function ($message) {
+                return $message['data'] !== '' &&
+                       $message['attributes']['service'] === 'test-service' &&
+                       $message['attributes']['log_level'] === 'INFO';
+            }));
+
+        $handler->handle($record);
+    }
+
+    public function testWriteWithLargeMessage()
+    {
+        $handler = new GooglePubSubHandler($this->pubSubClient, 'test-topic');
+        $handler->setFormatter(new LineFormatter());
+
+        // Create a message larger than MAX_MESSAGE_SIZE (10MB)
+        $largeMessage = str_repeat('a', 10485760 + 1000); // 10MB + 1KB
+        $record = $this->getRecord(Level::Error, $largeMessage);
+        $record->formatted = $largeMessage;
+
+        $this->topic
+            ->expects($this->once())
+            ->method('publish')
+            ->with($this->callback(function ($message) {
+                return strlen($message['data']) === 1048576 && // 1MB
+                       $message['attributes']['truncated'] === 'true' &&
+                       isset($message['attributes']['original_size']);
+            }));
+
+        $handler->handle($record);
+    }
+
+    public function testWriteWithException()
+    {
+        $handler = new GooglePubSubHandler($this->pubSubClient, 'test-topic');
+        $handler->setFormatter(new LineFormatter());
+
+        $record = $this->getRecord(Level::Error, 'test message');
+        $record->formatted = 'formatted message';
+
+        $this->topic
+            ->expects($this->once())
+            ->method('publish')
+            ->willThrowException(new \Exception('Publish failed'));
+
+        // Should not throw exception, but log error
+        $handler->handle($record);
+    }
+
+    public function testWriteWithInvalidFormattedRecord()
+    {
+        $handler = new GooglePubSubHandler($this->pubSubClient, 'test-topic');
+
+        $record = $this->getRecord(Level::Error, 'test message');
+        // Don't set formatted property
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('GooglePubSubHandler accepts only formatted records as a string');
+
+        // Use reflection to call the protected write method
+        $reflection = new \ReflectionClass($handler);
+        $writeMethod = $reflection->getMethod('write');
+        $writeMethod->setAccessible(true);
+        $writeMethod->invoke($handler, $record);
+    }
+
+    public function testSetAttributes()
+    {
+        $handler = new GooglePubSubHandler($this->pubSubClient, 'test-topic');
+        $newAttributes = ['new' => 'attribute'];
+        
+        $handler->setAttributes($newAttributes);
+        $this->assertEquals($newAttributes, $handler->getAttributes());
+    }
+
+    public function testWriteWithExtraData()
+    {
+        $handler = new GooglePubSubHandler($this->pubSubClient, 'test-topic');
+        $handler->setFormatter(new LineFormatter());
+
+        $record = $this->getRecord(Level::Info, 'test message');
+        $record->formatted = 'formatted message';
+        $record->extra = ['extra_key' => 'extra_value'];
+
+        $this->topic
+            ->expects($this->once())
+            ->method('publish')
+            ->with($this->callback(function ($message) {
+                return $message['attributes']['extra'] === '{"extra_key":"extra_value"}';
+            }));
+
+        $handler->handle($record);
+    }
+
+    public function testWriteWithContextAndExtra()
+    {
+        $handler = new GooglePubSubHandler($this->pubSubClient, 'test-topic');
+        $handler->setFormatter(new LineFormatter());
+
+        $record = $this->getRecord(Level::Info, 'test message', ['context_key' => 'context_value']);
+        $record->formatted = 'formatted message';
+        $record->extra = ['extra_key' => 'extra_value'];
+
+        $this->topic
+            ->expects($this->once())
+            ->method('publish')
+            ->with($this->callback(function ($message) {
+                return $message['attributes']['context'] === '{"context_key":"context_value"}' &&
+                       $message['attributes']['extra'] === '{"extra_key":"extra_value"}';
+            }));
+
+        $handler->handle($record);
+    }
+}


### PR DESCRIPTION
- Add new handler to send logs to Google Cloud Pub/Sub topics
- Include automatic attributes and message truncation support
- Add comprehensive test suite (10 tests, 18 assertions)
- Update composer.json with google/cloud-pubsub dependency
- Update documentation with new handler entry
- Support custom attributes and error handling