### PR TITLE
TelegramBotHandler: three dots replacement…

### DIFF
--- a/src/Monolog/Handler/TelegramBotHandler.php
+++ b/src/Monolog/Handler/TelegramBotHandler.php
@@ -287,7 +287,7 @@ class TelegramBotHandler extends AbstractProcessingHandler
      */
     private function handleMessageLength(string $message): array
     {
-        $truncatedMarker = ' (...truncated)';
+        $truncatedMarker = ' (…truncated)';
         if (!$this->splitLongMessages && \strlen($message) > self::MAX_MESSAGE_LENGTH) {
             return [Utils::substr($message, 0, self::MAX_MESSAGE_LENGTH - \strlen($truncatedMarker)) . $truncatedMarker];
         }


### PR DESCRIPTION
`…` instead of `...` makes the truncation part of the message 2 characters shorter, allowing for a bit longer actual message xd