### PR TITLE
Add file rotation by hour

### DIFF
--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -196,7 +196,7 @@ class RotatingFileHandler extends StreamHandler
             ['{filename}', '{date}'],
             [$fileInfo['filename'], str_replace(
                 ['Y', 'y', 'm', 'd', 'H'],
-                ['[0-9][0-9][0-9][0-9][0-9]', '[0-9][0-9][0-9][0-9]', '[0-9][0-9]', '[0-9][0-9]', '[0-9][0-9]'],
+                ['[0-9][0-9][0-9][0-9]', '[0-9][0-9]', '[0-9][0-9]', '[0-9][0-9]', '[0-9][0-9]'],
                 $this->dateFormat
             )],
             ($fileInfo['dirname'] ?? '') . '/' . $this->filenameFormat

--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -27,6 +27,7 @@ use Monolog\LogRecord;
  */
 class RotatingFileHandler extends StreamHandler
 {
+    public const FILE_PER_HOUR = 'Y-m-d-H';
     public const FILE_PER_DAY = 'Y-m-d';
     public const FILE_PER_MONTH = 'Y-m';
     public const FILE_PER_YEAR = 'Y';
@@ -194,8 +195,8 @@ class RotatingFileHandler extends StreamHandler
         $glob = str_replace(
             ['{filename}', '{date}'],
             [$fileInfo['filename'], str_replace(
-                ['Y', 'y', 'm', 'd'],
-                ['[0-9][0-9][0-9][0-9]', '[0-9][0-9]', '[0-9][0-9]', '[0-9][0-9]'],
+                ['Y', 'y', 'm', 'd', 'H'],
+                ['[0-9][0-9][0-9][0-9][0-9]', '[0-9][0-9][0-9][0-9]', '[0-9][0-9]', '[0-9][0-9]', '[0-9][0-9]'],
                 $this->dateFormat
             )],
             ($fileInfo['dirname'] ?? '') . '/' . $this->filenameFormat
@@ -203,20 +204,21 @@ class RotatingFileHandler extends StreamHandler
         if (isset($fileInfo['extension'])) {
             $glob .= '.'.$fileInfo['extension'];
         }
-
+    
         return $glob;
     }
 
     protected function setDateFormat(string $dateFormat): void
     {
-        if (0 === preg_match('{^[Yy](([/_.-]?m)([/_.-]?d)?)?$}', $dateFormat)) {
+        if (0 === preg_match('{^[Yy](([/_.-]?m)([/_.-]?d)([/_.-]?H)?)?$}', $dateFormat)) {
             throw new InvalidArgumentException(
-                'Invalid date format - format must be one of '.
+                'Invalid date format - format must be one of RotatingFileHandler::FILE_PER_HOUR ("Y-m-d-H"), '.
                 'RotatingFileHandler::FILE_PER_DAY ("Y-m-d"), RotatingFileHandler::FILE_PER_MONTH ("Y-m") '.
                 'or RotatingFileHandler::FILE_PER_YEAR ("Y"), or you can set one of the '.
                 'date formats using slashes, underscores and/or dots instead of dashes.'
             );
         }
+    
         $this->dateFormat = $dateFormat;
     }
 


### PR DESCRIPTION
Hello,

I suggest rotating log files hourly. Large logs are often difficult to load into the IDE, view and analyze. At the user's discretion, it would be useful to separate by specifying a format like 'Y-m-d-H' in the settings. I will give an example of a php configuration:

```php
    $config
        ->handler('request')
        ->formatter('monolog.formatter.standard')
        ->type('rotating_file')
        ->maxFiles(168)
        ->dateFormat('Y-m-d-H')
        ->filenameFormat('{filename}-{date}')
        ->path('%kernel.logs_dir%/request-%kernel.environment%.log')
        ->level('debug')
        ->channels()
        ->elements(['request']);
```