### PR TITLE
deps: remove ext-json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "psr/log": "^2.0 || ^3.0"
     },
     "require-dev": {
-        "ext-json": "*",
         "aws/aws-sdk-php": "^3.0",
         "doctrine/couchdb": "~1.0@dev",
         "elasticsearch/elasticsearch": "^7 || ^8",


### PR DESCRIPTION
This extension is always active since PHP 8.0: https://www.php.net/manual/en/json.installation.php

sebastianbergmann added a warning though:

> The fact that an extension cannot be disabled without modifying the PHP source code does not mean it is always available, as binary vendors have previously modified the PHP source code to disable extensions that should not be disabled. I prefer to err on the side of caution and explicitly state that an extension is required, even if this information is not necessary in the best-case scenario.

- Source: https://github.com/sebastianbergmann/phpunit/pull/6428#issuecomment-3596393039

---

I _stole_ the idea from: 

- https://github.com/VincentLanglet/Twig-CS-Fixer/issues/416