### PR TITLE
Remove deprecated curl_close() usage for PHP 8.5 compatibility

### DIFF
--- a/src/Monolog/Handler/Curl/Util.php
+++ b/src/Monolog/Handler/Curl/Util.php
@@ -37,7 +37,7 @@ final class Util
      * @param  CurlHandle  $ch curl handler
      * @return bool|string @see curl_exec
      */
-    public static function execute(CurlHandle $ch, int $retries = 5, bool $closeAfterDone = true): bool|string
+    public static function execute(CurlHandle $ch, int $retries = 5): bool|string
     {
         while ($retries > 0) {
             $retries--;
@@ -48,17 +48,9 @@ final class Util
                 if (false === \in_array($curlErrno, self::$retriableErrorCodes, true) || $retries === 0) {
                     $curlError = curl_error($ch);
 
-                    if ($closeAfterDone) {
-                        curl_close($ch);
-                    }
-
                     throw new \RuntimeException(sprintf('Curl error (code %d): %s', $curlErrno, $curlError));
                 }
                 continue;
-            }
-
-            if ($closeAfterDone) {
-                curl_close($ch);
             }
 
             return $curlResponse;

--- a/src/Monolog/Handler/LogglyHandler.php
+++ b/src/Monolog/Handler/LogglyHandler.php
@@ -146,7 +146,7 @@ class LogglyHandler extends AbstractProcessingHandler
         curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 
-        Curl\Util::execute($ch, 5, false);
+        Curl\Util::execute($ch, 5);
     }
 
     protected function getDefaultFormatter(): FormatterInterface


### PR DESCRIPTION
This PR removes calls to `curl_close()`, which is deprecated in PHP 8.5 and has no effect anymore on CurlHandle objects since PHP 8.0.
The behavior remains unchanged while preventing deprecation warnings on recent PHP versions.
Happy to adjust the patch if needed.