### PR TITLE
Add generic webhook handler using HTTP(S) POST requests with a JSON payload

### DIFF
--- a/doc/02-handlers-formatters-processors.md
+++ b/doc/02-handlers-formatters-processors.md
@@ -45,6 +45,7 @@
 
 - [_SocketHandler_](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/SocketHandler.php): Logs records to [sockets](http://php.net/fsockopen), use this
   for UNIX and TCP sockets. See an [example](sockets.md).
+- [_WebhookHandler_](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/WebhookHandler.php): Logs records to a generic webhook URL using HTTP(S) POST requests with a JSON payload.
 - [_AmqpHandler_](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/AmqpHandler.php): Logs records to an [AMQP](http://www.amqp.org/) compatible
   server. Requires the [php-amqp](http://pecl.php.net/package/amqp) extension (1.0+) or
   [php-amqplib](https://github.com/php-amqplib/php-amqplib) library.

--- a/src/Monolog/Handler/WebhookHandler.php
+++ b/src/Monolog/Handler/WebhookHandler.php
@@ -1,0 +1,112 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\LogRecord;
+use Monolog\Utils;
+
+/**
+ * Sends logs to a generic webhook URL using HTTP(S) POST requests with a JSON payload
+ *
+ * @author Raphael Portmann <github@i.raphaelportmann.com>
+ */
+class WebhookHandler extends SocketHandler
+{
+    /**
+     * @var array Webhook URL components
+     */
+    protected array $url;
+
+    /**
+     * Construct a new Webhook Handler.
+     *
+     * @param  string                    $url Webhook URL
+     * @throws \InvalidArgumentException if the provided URL is not valid
+     * @throws MissingExtensionException if OpenSSL is missing for HTTPS URLs
+     */
+    public function __construct(
+        string $url,
+        $level = Level::Debug,
+        bool $bubble = true,
+        bool $persistent = false,
+        float $timeout = 0.0,
+        float $writingTimeout = 10.0,
+        ?float $connectionTimeout = null,
+        ?int $chunkSize = null
+    ) {
+        $this->url = parse_url($url);
+
+        if ($this->url === false || !isset($this->url['scheme'], $this->url['host'])) {
+            throw new \InvalidArgumentException('The provided URL is not valid.');
+        }
+
+        $isSSL = $this->url['scheme'] === 'https';
+
+        if ($isSSL && !\extension_loaded('openssl')) {
+            throw new MissingExtensionException('The OpenSSL PHP extension is required when using an HTTPS webhook URL.');
+        }
+
+        $connectionString = ($isSSL ? 'ssl://' : 'tcp://') . $this->url['host'] . ':' . ($this->url['port'] ?? ($isSSL ? 443 : 80));
+        parent::__construct(
+            $connectionString,
+            $level,
+            $bubble,
+            $persistent,
+            $timeout,
+            $writingTimeout,
+            $connectionTimeout,
+            $chunkSize
+        );
+    }
+
+    /**
+     * Handles a log record
+     */
+    public function write(LogRecord $record): void
+    {
+        parent::write($record);
+        $this->closeSocket();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function generateDataStream(LogRecord $record): string
+    {
+        $content = $this->buildContent($record);
+
+        return $this->buildHeader($content) . $content;
+    }
+
+    /**
+     * Builds the header of the API Call
+     */
+    private function buildHeader(string $content): string
+    {
+        $header = "POST " . ($this->url['path'] ?? '/') . " HTTP/1.1\r\n";
+        $header .= "Host: " . $this->url['host'] . "\r\n";
+        $header .= "Content-Type: application/json\r\n";
+        $header .= "Content-Length: " . \strlen($content) . "\r\n";
+        $header .= "\r\n";
+
+        return $header;
+    }
+
+    /**
+     * Builds the body of API call
+     */
+    private function buildContent(LogRecord $record): string
+    {
+        return Utils::jsonEncode($record->toArray());
+    }
+}

--- a/tests/Monolog/Handler/WebhookHandlerTest.php
+++ b/tests/Monolog/Handler/WebhookHandlerTest.php
@@ -1,0 +1,171 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+
+/**
+ * @coversDefaultClass \Monolog\Handler\WebhookHandler
+ */
+class WebhookHandlerTest extends \Monolog\Test\MonologTestCase
+{
+    /**
+     * Default URLs to use in tests
+     */
+    const URL_HTTP = 'http://example.com/webhook';
+    const URL_HTTP_NO_PATH = 'http://sub.example.com';
+    const URL_HTTPS = 'https://example.com/webhook';
+    const URL_HTTPS_NO_PATH = 'https://sub.example.com';
+    const URL_INVALID = '.ht!tp:/\invalid-url';
+
+    /**
+     * @covers ::__construct
+     */
+    public function testConstructorSetsExpectedDefaults()
+    {
+        [$handler, $output] = $this->createHandler(self::URL_HTTP);
+
+        $level = $handler->getLevel();
+        $bubble = $handler->getBubble();
+        $persistent = $handler->isPersistent();
+        $timeout = $handler->getTimeout();
+        $writingTimeout = $handler->getWritingTimeout();
+
+        fclose($output);
+
+        $this->assertEquals(Level::Debug, $level);
+        $this->assertEquals(true, $bubble);
+        $this->assertEquals(false, $persistent);
+        $this->assertEquals(0.0, $timeout);
+        $this->assertEquals(10.0, $writingTimeout);
+    }
+
+    /**
+     * @covers ::__construct
+     */
+    public function testThrowsUrlInvalidArgumentException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The provided URL is not valid.');
+
+        $this->createHandler(self::URL_INVALID);
+    }
+
+    /**
+     * @covers ::__construct
+     */
+    public function testThrowsOpensslMissingExtensionException()
+    {
+        if (\extension_loaded('openssl')) {
+            $this->markTestSkipped('This test requires openssl to be missing to run');
+        }
+        $this->expectException(MissingExtensionException::class);
+        $this->expectExceptionMessage('The OpenSSL PHP extension is required when using an HTTPS webhook URL.');
+
+        $this->createHandler(self::URL_HTTPS);
+    }
+
+    /**
+     * @covers ::__construct
+     */
+    public function testHttpConnectionString()
+    {
+        [$httpHandler, $httpOutput] = $this->createHandler(self::URL_HTTP);
+        [$httpNoPathHandler, $httpNoPathOutput] = $this->createHandler(self::URL_HTTP_NO_PATH);
+
+        $httpConnectionString = $httpHandler->getConnectionString();
+        $httpNoPathConnectionString = $httpNoPathHandler->getConnectionString();
+
+        fclose($httpOutput);
+        fclose($httpNoPathOutput);
+
+        $this->assertEquals('tcp://example.com:80', $httpConnectionString);
+        $this->assertEquals('tcp://sub.example.com:80', $httpNoPathConnectionString);
+    }
+
+    /**
+     * @covers ::__construct
+     */
+    public function testHttpsConnectionString()
+    {
+        if (!\extension_loaded('openssl')) {
+            $this->markTestSkipped('This test requires openssl to run');
+        }
+
+        [$httpsHandler, $httpsOutput] = $this->createHandler(self::URL_HTTPS);
+        [$httpsNoPathHandler, $httpsNoPathOutput] = $this->createHandler(self::URL_HTTPS_NO_PATH);
+
+        $httpsConnectionString = $httpsHandler->getConnectionString();
+        $httpsNoPathConnectionString = $httpsNoPathHandler->getConnectionString();
+
+        fclose($httpsOutput);
+        fclose($httpsNoPathOutput);
+
+        $this->assertEquals('ssl://example.com:443', $httpsConnectionString);
+        $this->assertEquals('ssl://sub.example.com:443', $httpsNoPathConnectionString);
+    }
+
+    /**
+     * @covers ::write
+     */
+    public function testWriteOutput()
+    {
+        [$handler, $output] = $this->createHandler(self::URL_HTTP);
+
+        $record = $this->getRecord(Level::Error, 'test message');
+        $handler->handle($record);
+
+        rewind($output);
+        $written = stream_get_contents($output);
+        fclose($output);
+
+        $this->assertMatchesRegularExpression('/POST \/webhook HTTP\/1.1\\r\\nHost: example\.com\\r\\nContent-Type: application\/json\\r\\nContent-Length: \d{2,4}\\r\\n\\r\\n{"message":"test message","context":\[\],"level":400,"level_name":"ERROR","channel":"test","datetime":".*","extra":\[\]}/', $written);
+    }
+
+    /**
+     * @covers ::write
+     */
+    public function testWriteOutputNoPath()
+    {
+        [$handler, $output] = $this->createHandler(self::URL_HTTP_NO_PATH);
+
+        $record = $this->getRecord(Level::Error, 'test message');
+        $handler->handle($record);
+
+        rewind($output);
+        $written = stream_get_contents($output);
+        fclose($output);
+
+        $this->assertMatchesRegularExpression('/POST \/ HTTP\/1.1\\r\\nHost: sub.example\.com\\r\\nContent-Type: application\/json\\r\\nContent-Length: \d{2,4}\\r\\n\\r\\n{"message":"test message","context":\[\],"level":400,"level_name":"ERROR","channel":"test","datetime":".*","extra":\[\]}/', $written);
+    }
+
+    private function createHandler($url)
+    {
+        $handler = $this->getMockBuilder('Monolog\Handler\WebhookHandler')
+            ->setConstructorArgs([$url])
+            ->onlyMethods(['fsockopen', 'streamSetTimeout', 'closeSocket'])
+            ->getMock();
+        
+        $output = fopen('php://memory', 'a');
+
+        $handler->expects($this->any())
+            ->method('fsockopen')
+            ->willReturn($output);
+        $handler->expects($this->any())
+            ->method('streamSetTimeout')
+            ->willReturn(true);
+        $handler->expects($this->any())
+            ->method('closeSocket');
+
+        return [$handler, $output];
+    }
+}


### PR DESCRIPTION
I tried to implement a generic webhook handler using HTTP(S) POST requests with a JSON payload.
I have seen an old [discussion regarding the implementation of generic handlers](https://github.com/Seldaek/monolog/issues/306) and [using third-party packages for more specific handlers](https://github.com/Seldaek/monolog/pull/1526#issuecomment-756611693), but believe this handler would be a good addition to the monolog core package.
- As mentioned [here](https://github.com/Seldaek/monolog/issues/306) there are many plattforms like zapier and n8n (or building something yourself) that provide webhook endpoints to accept data in pretty much any format. Instead of creating more and more handlers for each of these plattforms or requiring third-party packages, this handler could be used for most of these plattforms.
- The handler currently extends the SocketHandler (adapted from the [FleepHookHandler integration](https://github.com/Seldaek/monolog/pull/415)). Is this still the preferred way instead uf using curl?
- The only handler that would provide similar functionality would be the [PSR-18 HTTP client integration](https://github.com/monolog-http/monolog-http), but requires another package and looks like maintenance lags behind.
- Didn't have the time to look into more features, like supporting secrets or other forms of authentication, but in that case it would probably be better to use PSR-18 clients directly. Is there a reason why this is a separate package but very specific integrations are part of the core?

My specific use-case would be to easily send logs to external webhooks - in my case inside a Laravel application, which allows for simple monolog configuration: e.g. https://github.com/laravel/laravel/blob/12.x/config/logging.php#L85
With this handler it could look like this:
```
'webhook' => [
    'driver' => 'monolog',
    'level' => env('LOG_LEVEL', 'warning'),
    'handler' => env('LOG_WEBHOOK_HANDLER', WebhookHandler::class),
    'handler_with' => [
        'url' => env('LOG_WEBHOOK_URL'),
    ],
],
// LOG_WEBHOOK_URL="https://example.com/webhook/abc123"
```

Just wanted to make a proposal. If you recommend another approach, let me know.