### PR TITLE
Fix missing timezone support in rotation date calculations

### DIFF
--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -226,9 +226,9 @@ class RotatingFileHandler extends StreamHandler
     protected function getNextRotation(): \DateTimeImmutable
     {
         return match (str_replace(['/','_','.'], '-', $this->dateFormat)) {
-            self::FILE_PER_MONTH => (new \DateTimeImmutable('first day of next month'))->setTime(0, 0, 0),
-            self::FILE_PER_YEAR => (new \DateTimeImmutable('first day of January next year'))->setTime(0, 0, 0),
-            default => (new \DateTimeImmutable('tomorrow'))->setTime(0, 0, 0),
+            self::FILE_PER_MONTH => (new \DateTimeImmutable('first day of next month', $this->timezone))->setTime(0, 0, 0),
+            self::FILE_PER_YEAR => (new \DateTimeImmutable('first day of January next year', $this->timezone))->setTime(0, 0, 0),
+            default => (new \DateTimeImmutable('tomorrow', $this->timezone))->setTime(0, 0, 0),
         };
     }
 }


### PR DESCRIPTION
The fix for #1982 is incomplete because the `getNextRotation` method is not aware of the time zone which was set in the constructor. Consider the scenario of daily rotation where the server is set to UTC but the constructor is set to another zone. This results in log entries being recorded unexpectedly to a different day's file during the time period where midnight has been reached in one zone but not the other.

This fix simply adds the existing time zone variable to the existing calculations.