### PR TITLE
Fix HTTP status code modification while exception handling (#2027)

### DIFF
--- a/src/Monolog/ErrorHandler.php
+++ b/src/Monolog/ErrorHandler.php
@@ -194,8 +194,8 @@ class ErrorHandler
             ($this->previousExceptionHandler)($e);
         }
 
-        if (!headers_sent() && \in_array(strtolower((string) \ini_get('display_errors')), ['0', '', 'false', 'off', 'none', 'no'], true)) {
-            http_response_code(500);
+        if (\in_array(strtolower((string) \ini_get('display_errors')), ['0', '', 'false', 'off', 'none', 'no'], true)) {
+            @http_response_code(500);
         }
 
         exit(255);


### PR DESCRIPTION
Fixes #2027

The `headers_sent()` guard does not prevent the `E_WARNING` from `http_response_code()`. The warning is emitted when `header('HTTP/...')` has already been called, but `headers_sent()` only becomes `true` after output is flushed to the stream — these are independent states. 

`headers_list()` might seem like an alternative to detect a previously set status line, but it intentionally excludes the HTTP status line.

Dropping the `headers_sent()` check and suppressing the warning with `@` is the most correct approach available: it sets 500 when possible and silently does nothing when it cannot.