### PR TITLE
Add extension hooks to TelegramBotHandler for URL and curl headers

### DIFF
--- a/src/Monolog/Handler/TelegramBotHandler.php
+++ b/src/Monolog/Handler/TelegramBotHandler.php
@@ -278,7 +278,7 @@ class TelegramBotHandler extends AbstractProcessingHandler
         }
 
         $ch = curl_init();
-        $url = self::BOT_API . $this->apiKey . '/SendMessage';
+        $url = $this->botApiUrl() . $this->apiKey . '/SendMessage';
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);

--- a/src/Monolog/Handler/TelegramBotHandler.php
+++ b/src/Monolog/Handler/TelegramBotHandler.php
@@ -251,17 +251,41 @@ class TelegramBotHandler extends AbstractProcessingHandler
         }
     }
 
+    /**
+     * Returns the Telegram Bot API base URL.
+     * Override in a subclass to point to a self-hosted Bot API server.
+     */
+    protected function botApiUrl(): string
+    {
+        return self::BOT_API;
+    }
+
+    /**
+     * Returns extra HTTP headers to send with every Telegram API request.
+     * Override in a subclass to inject custom headers (e.g. auth tokens, tracing).
+     *
+     * @return string[]
+     */
+    protected function getCurlHeaders(): array
+    {
+        return [];
+    }
+
     protected function sendCurl(string $message): void
     {
         if ('' === trim($message)) {
             return;
         }
-        
+
         $ch = curl_init();
         $url = self::BOT_API . $this->apiKey . '/SendMessage';
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+        $headers = $this->getCurlHeaders();
+        if ($headers !== []) {
+            curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        }
         $params = [
             'text' => $message,
             'chat_id' => $this->channel,

--- a/src/Monolog/Handler/TelegramBotHandler.php
+++ b/src/Monolog/Handler/TelegramBotHandler.php
@@ -255,7 +255,7 @@ class TelegramBotHandler extends AbstractProcessingHandler
      * Returns the Telegram Bot API base URL.
      * Override in a subclass to point to a self-hosted Bot API server.
      */
-    protected function botApiUrl(): string
+    protected function getBotApiUrl(): string
     {
         return self::BOT_API;
     }
@@ -278,7 +278,7 @@ class TelegramBotHandler extends AbstractProcessingHandler
         }
 
         $ch = curl_init();
-        $url = $this->botApiUrl() . $this->apiKey . '/SendMessage';
+        $url = $this->getBotApiUrl() . $this->apiKey . '/SendMessage';
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);


### PR DESCRIPTION
# Add extension hooks to `TelegramBotHandler` for API URL and curl headers

## Problem

`TelegramBotHandler` used a `private const BOT_API` and hardcoded `self::BOT_API` directly inside `sendCurl()`, making it impossible to:
- point the handler at a self-hosted Telegram Bot API server
- inject custom HTTP headers (auth tokens, tracing, proxies) into the curl request

## Solution

Two `protected` hook methods added to `sendCurl()`:

| Method | Default | Purpose |
|--------|---------|---------|
| `botApiUrl(): string` | `'https://api.telegram.org/bot'` | Override to change the API base URL |
| `getCurlHeaders(): array` | `[]` | Override to add extra HTTP headers |

No changes to the public API. Fully backwards compatible.

---

## Usage example (English)

```php
// Subclass pointing to a self-hosted Bot API + custom auth header
class MyTelegramHandler extends TelegramBotHandler
{
    protected function botApiUrl(): string
    {
        return 'https://telegram-api.internal.example.com/bot';
    }

    protected function getCurlHeaders(): array
    {
        return [
            'X-Internal-Token: my-secret-token',
            'X-Request-Source: monolog',
        ];
    }
}

$handler = new MyTelegramHandler(
    apiKey: 'YOUR_BOT_TOKEN',
    channel: '@your_channel',
);
$logger = new \Monolog\Logger('app');
$logger->pushHandler($handler);
$logger->error('Something went wrong');
```

---

## Пример использования (Russian)

```php
// Наследник, использующий собственный сервер Bot API и токен авторизации
class MyTelegramHandler extends TelegramBotHandler
{
    // Меняем базовый URL на свой сервер (self-hosted Telegram Bot API)
    protected function botApiUrl(): string
    {
        return 'https://telegram-api.internal.example.com/bot';
    }

    // Добавляем произвольные HTTP-заголовки к каждому curl-запросу
    protected function getCurlHeaders(): array
    {
        return [
            'X-Internal-Token: my-secret-token',
            'X-Request-Source: monolog',
        ];
    }
}

$handler = new MyTelegramHandler(
    apiKey: 'YOUR_BOT_TOKEN',
    channel: '@your_channel',
);

$logger = new \Monolog\Logger('app');
$logger->pushHandler($handler);
$logger->error('Что-то пошло не так');
```

---

## Changes

- `src/Monolog/Handler/TelegramBotHandler.php`
  - Added `protected function botApiUrl(): string`
  - Added `protected function getCurlHeaders(): array`
  - `sendCurl()` now calls `$this->botApiUrl()` instead of `self::BOT_API`
  - `sendCurl()` applies `CURLOPT_HTTPHEADER` when `getCurlHeaders()` returns a non-empty array