### PR TITLE
Fix TelegramBotHandler swallowing errors on non-JSON responses (#2026)

### DIFF
--- a/src/Monolog/Handler/TelegramBotHandler.php
+++ b/src/Monolog/Handler/TelegramBotHandler.php
@@ -256,7 +256,7 @@ class TelegramBotHandler extends AbstractProcessingHandler
         if ('' === trim($message)) {
             return;
         }
-        
+
         $ch = curl_init();
         $url = self::BOT_API . $this->apiKey . '/SendMessage';
         curl_setopt($ch, CURLOPT_URL, $url);
@@ -274,14 +274,26 @@ class TelegramBotHandler extends AbstractProcessingHandler
         }
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($params));
 
-        $result = Curl\Util::execute($ch);
-        if (!\is_string($result)) {
+        $this->validateApiResponse(Curl\Util::execute($ch));
+    }
+
+    /**
+     * @param  string|bool      $rawResult Raw response body from the Telegram API call
+     * @throws RuntimeException When the response is missing, non-JSON, or signals failure
+     */
+    protected function validateApiResponse(string|bool $rawResult): void
+    {
+        if (!\is_string($rawResult)) {
             throw new RuntimeException('Telegram API error. Description: No response');
         }
-        $result = json_decode($result, true);
 
-        if ($result['ok'] === false) {
-            throw new RuntimeException('Telegram API error. Description: ' . $result['description']);
+        $result = json_decode($rawResult, true);
+
+        if (!\is_array($result)) {
+            throw new RuntimeException('Telegram API error. Description: Unexpected non-JSON response');
+        }
+        if (($result['ok'] ?? null) !== true) {
+            throw new RuntimeException('Telegram API error. Description: ' . ($result['description'] ?? 'Unknown error'));
         }
     }
 

--- a/tests/Monolog/Handler/TelegramBotHandlerTest.php
+++ b/tests/Monolog/Handler/TelegramBotHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Monolog\Handler;
 
 use Monolog\Level;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -66,5 +67,42 @@ class TelegramBotHandlerTest extends \Monolog\Test\MonologTestCase
     {
         $handler = new TelegramBotHandler('testKey', 'testChannel');
         $handler->setParseMode('HTML');
+    }
+
+    #[DataProvider('apiResponseFailureProvider')]
+    public function testValidateApiResponseFailures(string|bool $rawResult, string $expectedMessage): void
+    {
+        $handler = new TelegramBotHandler('testKey', 'testChannel');
+        $invoke = (new \ReflectionClass($handler))->getMethod('validateApiResponse');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $invoke->invoke($handler, $rawResult);
+    }
+
+    /**
+     * @return array<string, array{string|bool, string}>
+     */
+    public static function apiResponseFailureProvider(): array
+    {
+        return [
+            'curl returned false' => [false, 'No response'],
+            'non-JSON HTML body (e.g. Cloudflare 502)' => ['<html>502 Bad Gateway</html>', 'Unexpected non-JSON response'],
+            'empty body' => ['', 'Unexpected non-JSON response'],
+            'ok=false with description' => ['{"ok":false,"description":"Bad Request: chat not found"}', 'Bad Request: chat not found'],
+            'ok=false without description' => ['{"ok":false}', 'Unknown error'],
+            'ok key missing entirely' => ['{"error":"something else"}', 'Unknown error'],
+        ];
+    }
+
+    public function testValidateApiResponseAcceptsSuccess(): void
+    {
+        $handler = new TelegramBotHandler('testKey', 'testChannel');
+        $invoke = (new \ReflectionClass($handler))->getMethod('validateApiResponse');
+
+        $invoke->invoke($handler, '{"ok":true,"result":{"message_id":1}}');
+
+        $this->expectNotToPerformAssertions();
     }
 }


### PR DESCRIPTION
Fixes #2026

## What it solves

`TelegramBotHandler::sendCurl()` was silently swallowing errors whenever the Telegram API or an upstream proxy returned a non-JSON body (Cloudflare 502 pages, Nginx error pages, truncated responses, etc.). `json_decode()` returned `null`, the guard `$result['ok'] === false` evaluated to `false` (since `null === false` is `false`), and no exception was raised — log records were lost during the exact infrastructure outages where alerting matters most.

## How it solves

- After `json_decode()`, reject anything that isn't a JSON object via `\is_array($result)`, throwing a `RuntimeException` with a clear `"Unexpected non-JSON response"` message.
- Replaced `$result['ok'] === false` with `($result['ok'] ?? null) !== true`. This also catches valid JSON responses that simply lack the `ok` key (e.g. proxy-injected error envelopes), which the old check would silently accept.
- Fall back to `"Unknown error"` when `description` is absent, preventing the previous undefined-key warning.
- Extracted the response validation into `validateApiResponse()` so each failure mode can be tested without a live HTTP call.

## Tests

Added a data-provider-driven test covering all six failure paths (curl failure, HTML body, empty body, `ok:false` with/without description, missing `ok` key) plus a happy-path assertion. The existing tests continue to pass.
