### PR TITLE
Fix AbstractProcessingHandler::handle() to call getBubble() instead of $this->bubble

### DIFF
--- a/src/Monolog/Handler/AbstractProcessingHandler.php
+++ b/src/Monolog/Handler/AbstractProcessingHandler.php
@@ -43,7 +43,7 @@ abstract class AbstractProcessingHandler extends AbstractHandler implements Proc
 
         $this->write($record);
 
-        return false === $this->bubble;
+        return !$this->getBubble();
     }
 
     /**

--- a/tests/Monolog/Handler/AbstractProcessingHandlerTest.php
+++ b/tests/Monolog/Handler/AbstractProcessingHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Monolog\Handler;
 
 use Monolog\Level;
+use Monolog\LogRecord;
 use Monolog\Processor\WebProcessor;
 use Monolog\Formatter\LineFormatter;
 
@@ -87,6 +88,23 @@ class AbstractProcessingHandlerTest extends \Monolog\Test\MonologTestCase
         ;
         $handler->handle($this->getRecord());
         $this->assertEquals(6, \count($handledRecord['extra']));
+    }
+
+    /**
+     * @covers Monolog\Handler\AbstractProcessingHandler::handle
+     */
+    public function testHandleRespectsGetBubbleOverride(): void
+    {
+        $handler = new class(Level::Debug, false) extends AbstractProcessingHandler {
+            protected function write(LogRecord $record): void {}
+
+            public function getBubble(): bool
+            {
+                return true;
+            }
+        };
+
+        $this->assertFalse($handler->handle($this->getRecord()));
     }
 
     /**


### PR DESCRIPTION
## Summary

- `AbstractProcessingHandler::handle()` was reading the protected `$bubble` property directly (`false === $this->bubble`) rather than calling `getBubble()`
- This means subclasses that override `getBubble()` to dynamically control bubbling behaviour are silently bypassed
- Fix: replace with `!$this->getBubble()` so the getter is always honoured

## Context

This was discovered while working on a Symfony MonologBridge fix where a handler needed to override `getBubble()` to conditionally suppress propagation based on runtime state. The Symfony maintainers suggested the fix belongs upstream in Monolog: symfony/symfony#64207