### PR TITLE
Add zizmor security analysis + dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,6 +10,10 @@ permissions:
 env:
   COMPOSER_ROOT_VERSION: dev-main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: "CI (PHP ${{ matrix.php-version }}, ${{ matrix.dependencies }} deps)"
@@ -45,11 +49,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run CouchDB
         timeout-minutes: 3
         continue-on-error: true
-        uses: cobot/couchdb-action@eaaa17cf8baf421e7fb07e2d869f5457bb6a4de5 # main
+        uses: cobot/couchdb-action@716f8ccff36d9ee08e27f094d842ff8955f83c66 # v5.0.1
         with:
           couchdb version: '2.3.1'
 
@@ -58,7 +64,7 @@ jobs:
         with:
           mongodb-version: 5.0
 
-      - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
+      - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
@@ -113,6 +119,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # required for elasticsearch
       - name: Configure sysctl limits
@@ -124,13 +132,15 @@ jobs:
 
       - name: Run Elasticsearch
         timeout-minutes: 3
+        env:
+          ES_VERSION: ${{ matrix.es-version }}
         run: |
           docker run -d --name elasticsearch \
             -p 9200:9200 \
             -e discovery.type=single-node \
             -e xpack.security.enabled=false \
             -e ES_JAVA_OPTS="-Xms256m -Xmx512m" \
-            docker.elastic.co/elasticsearch/elasticsearch:${{ matrix.es-version }}
+            docker.elastic.co/elasticsearch/elasticsearch:$ES_VERSION
           until curl -s http://127.0.0.1:9200 | grep -q '"tagline"'; do
             if ! docker inspect -f '{{.State.Running}}' elasticsearch 2>/dev/null | grep -q true; then
               docker logs elasticsearch
@@ -141,7 +151,7 @@ jobs:
           done
           echo "Elasticsearch is up"
 
-      - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
+      - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
@@ -150,7 +160,9 @@ jobs:
           ini-values: "memory_limit=-1"
 
       - name: "Change dependencies"
-        run: "composer require --no-update --no-interaction --dev elasticsearch/elasticsearch:^${{ matrix.es-version }}"
+        env:
+          ES_VERSION: ${{ matrix.es-version }}
+        run: "composer require --no-update --no-interaction --dev elasticsearch/elasticsearch:^$ES_VERSION"
 
       - uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
         with:
@@ -195,6 +207,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # required for elasticsearch
       - name: Configure sysctl limits
@@ -206,6 +220,8 @@ jobs:
 
       - name: Run Elasticsearch
         timeout-minutes: 3
+        env:
+          ES_VERSION: ${{ matrix.es-version }}
         run: |
           docker run -d --name elasticsearch \
             -p 9200:9200 \
@@ -215,7 +231,7 @@ jobs:
             -e xpack.security.transport.ssl.enabled=false \
             -e ELASTIC_PASSWORD=changeme \
             -e ES_JAVA_OPTS="-Xms256m -Xmx512m" \
-            docker.elastic.co/elasticsearch/elasticsearch:${{ matrix.es-version }}
+            docker.elastic.co/elasticsearch/elasticsearch:$ES_VERSION
           until curl -s -u elastic:changeme http://127.0.0.1:9200 | grep -q '"tagline"'; do
             if ! docker inspect -f '{{.State.Running}}' elasticsearch 2>/dev/null | grep -q true; then
               docker logs elasticsearch
@@ -226,7 +242,7 @@ jobs:
           done
           echo "Elasticsearch is up"
 
-      - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
+      - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: "Lint"
@@ -21,8 +25,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
+      - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -10,6 +10,10 @@ permissions:
 env:
   COMPOSER_ROOT_VERSION: dev-main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: "PHPStan"
@@ -24,15 +28,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
+      - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
           extensions: mongodb, redis, amqp
 
       - name: Add require for mongodb/mongodb to make tests runnable
-        run: "composer require ${{ env.COMPOSER_FLAGS }} mongodb/mongodb --dev --no-update"
+        run: "composer require $COMPOSER_FLAGS mongodb/mongodb --dev --no-update"
 
       - uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,35 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - '.github/**.yml'
+    pull_request:
+        paths:
+            - '.github/**.yml'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    zizmor:
+        name: Run zizmor 🌈
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Run zizmor 🌈
+              uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+              with:
+                  advanced-security: false
+                  annotations: true
+                  persona: 'pedantic'


### PR DESCRIPTION
Adds a `zizmor` GitHub Actions security-analysis workflow (matching `composer/packagist`) and a 7-day `cooldown` on the github-actions dependabot config, and hardens the existing workflows so zizmor (pedantic) passes (actions pinned to commit SHAs, concurrency limits, `persist-credentials: false` on read-only checkouts).