### PR TITLE
Add zizmor security analysis + dependabot cooldown (2.x)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    cooldown:
-      default-days: 7

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: "CI (PHP ${{ matrix.php-version }}, ${{ matrix.dependencies }} deps)"
@@ -43,21 +47,23 @@ jobs:
             composer-options: "--ignore-platform-req=php+"
 
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run CouchDB
         timeout-minutes: 3
         continue-on-error: true
-        uses: cobot/couchdb-action@eaaa17cf8baf421e7fb07e2d869f5457bb6a4de5 # main
+        uses: cobot/couchdb-action@716f8ccff36d9ee08e27f094d842ff8955f83c66 # v5.0.1
         with:
           couchdb version: '2.3.1'
 
       - name: Run MongoDB
-        uses: supercharge/mongodb-github-action@1.10.0
+        uses: supercharge/mongodb-github-action@315db7fe45ac2880b7758f1933e6e5d59afd5e94 # 1.12.1
         with:
           mongodb-version: 5.0
 
-      - uses: "shivammathur/setup-php@v2"
+      - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
@@ -73,7 +79,7 @@ jobs:
           composer require --no-update --no-interaction --dev elasticsearch/elasticsearch:^7
           composer config --no-plugins allow-plugins.ocramius/package-versions true
 
-      - uses: "ramsey/composer-install@v2"
+      - uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
         with:
           dependency-versions: "${{ matrix.dependencies }}"
           composer-options: "${{ matrix.composer-options }}"
@@ -83,10 +89,12 @@ jobs:
 
       - name: "Run tests with psr/log 3"
         if: "contains(matrix.dependencies, 'highest') && matrix.php-version >= '8.0'"
+        env:
+          COMPOSER_OPTIONS: ${{ matrix.composer-options }}
         run: |
           composer remove --no-update --dev graylog2/gelf-php ruflin/elastica elasticsearch/elasticsearch rollbar/rollbar
           composer require --no-update psr/log:^3
-          composer update ${{ matrix.composer-options }}
+          composer update $COMPOSER_OPTIONS
           composer exec phpunit -- --exclude-group Elasticsearch,Elastica --verbose
 
   tests-es-7:
@@ -129,7 +137,9 @@ jobs:
             es-version: "7.0.0"
 
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # required for elasticsearch
       - name: Configure sysctl limits
@@ -141,11 +151,11 @@ jobs:
 
       - name: Run Elasticsearch
         timeout-minutes: 3
-        uses: elastic/elastic-github-actions/elasticsearch@master
+        uses: elastic/elastic-github-actions/elasticsearch@98431b45a60cbb6ace481778827bc8e11f12fd65 # master
         with:
           stack-version: "${{ matrix.es-version }}"
 
-      - uses: "shivammathur/setup-php@v2"
+      - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
@@ -154,13 +164,15 @@ jobs:
           ini-values: "memory_limit=-1"
 
       - name: "Change dependencies"
-        run: "composer require --no-update --no-interaction --dev elasticsearch/elasticsearch:^${{ matrix.es-version }}"
+        env:
+          ES_VERSION: ${{ matrix.es-version }}
+        run: "composer require --no-update --no-interaction --dev elasticsearch/elasticsearch:^$ES_VERSION"
 
       - name: "Allow composer plugin to run"
         if: "matrix.php-version == '7.4' && matrix.dependencies == 'lowest'"
         run: "composer config allow-plugins.ocramius/package-versions true"
 
-      - uses: "ramsey/composer-install@v2"
+      - uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
         with:
           dependency-versions: "${{ matrix.dependencies }}"
 
@@ -205,7 +217,9 @@ jobs:
           - "8.2.0"
 
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # required for elasticsearch
       - name: Configure sysctl limits
@@ -217,11 +231,11 @@ jobs:
 
       - name: Run Elasticsearch
         timeout-minutes: 3
-        uses: elastic/elastic-github-actions/elasticsearch@master
+        uses: elastic/elastic-github-actions/elasticsearch@98431b45a60cbb6ace481778827bc8e11f12fd65 # master
         with:
           stack-version: "${{ matrix.es-version }}"
 
-      - uses: "shivammathur/setup-php@v2"
+      - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
@@ -238,7 +252,7 @@ jobs:
         if: "matrix.php-version == '7.4' && matrix.dependencies == 'lowest'"
         run: "composer config allow-plugins.ocramius/package-versions true"
 
-      - uses: "ramsey/composer-install@v2"
+      - uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
         with:
           dependency-versions: "${{ matrix.dependencies }}"
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -151,9 +151,30 @@ jobs:
 
       - name: Run Elasticsearch
         timeout-minutes: 3
-        uses: elastic/elastic-github-actions/elasticsearch@98431b45a60cbb6ace481778827bc8e11f12fd65 # master
-        with:
-          stack-version: "${{ matrix.es-version }}"
+        env:
+          ES_VERSION: ${{ matrix.es-version }}
+        run: |
+          # ES's bundled JDK crashes on the runner's cgroup v2 with a NPE in
+          # CgroupV2Subsystem (the bundled JDK predates the cgroup v2 fix).
+          # Run ES against the runner's patched JDK 11 instead, which both
+          # ES 7.0 and 7.17 support (ES <7.12 only reads JAVA_HOME, not ES_JAVA_HOME).
+          export JAVA_HOME="$JAVA_HOME_11_X64"
+          export ES_JAVA_HOME="$JAVA_HOME_11_X64"
+          curl -sL "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz" | tar xz
+          ES_JAVA_OPTS="-Xms256m -Xmx512m" "elasticsearch-${ES_VERSION}/bin/elasticsearch" \
+            -E discovery.type=single-node \
+            -E xpack.security.enabled=false \
+            -d -p /tmp/es.pid
+          until curl -s http://127.0.0.1:9200 | grep -q '"tagline"'; do
+            if [ -f /tmp/es.pid ] && ! kill -0 "$(cat /tmp/es.pid)" 2>/dev/null; then
+              echo "Elasticsearch process died:"
+              cat "elasticsearch-${ES_VERSION}"/logs/*.log 2>/dev/null || true
+              exit 1
+            fi
+            echo "Waiting for Elasticsearch..."
+            sleep 2
+          done
+          echo "Elasticsearch is up"
 
       - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
@@ -231,9 +252,28 @@ jobs:
 
       - name: Run Elasticsearch
         timeout-minutes: 3
-        uses: elastic/elastic-github-actions/elasticsearch@98431b45a60cbb6ace481778827bc8e11f12fd65 # master
-        with:
-          stack-version: "${{ matrix.es-version }}"
+        env:
+          ES_VERSION: ${{ matrix.es-version }}
+        run: |
+          # ES 8's bundled JDK 17 crashes on the runner's cgroup v2 with a NPE
+          # in CgroupV2Subsystem (predates the cgroup v2 fix). Point ES at the
+          # runner's patched JDK 17 instead (ES 8 reads ES_JAVA_HOME).
+          export ES_JAVA_HOME="$JAVA_HOME_17_X64"
+          curl -sL "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz" | tar xz
+          ES_JAVA_OPTS="-Xms256m -Xmx512m" "elasticsearch-${ES_VERSION}/bin/elasticsearch" \
+            -E discovery.type=single-node \
+            -E xpack.security.enabled=false \
+            -d -p /tmp/es.pid
+          until curl -s http://127.0.0.1:9200 | grep -q '"tagline"'; do
+            if [ -f /tmp/es.pid ] && ! kill -0 "$(cat /tmp/es.pid)" 2>/dev/null; then
+              echo "Elasticsearch process died:"
+              cat "elasticsearch-${ES_VERSION}"/logs/*.log 2>/dev/null || true
+              exit 1
+            fi
+            echo "Waiting for Elasticsearch..."
+            sleep 2
+          done
+          echo "Elasticsearch is up"
 
       - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: "Lint"
@@ -20,9 +24,11 @@ jobs:
           - "nightly"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: "PHPStan"
@@ -19,18 +23,20 @@ jobs:
           - "8.0"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
           extensions: mongodb, redis, amqp
 
       - name: Add require for mongodb/mongodb to make tests runnable
-        run: "composer require ${{ env.COMPOSER_FLAGS }} mongodb/mongodb --dev --no-update"
+        run: "composer require $COMPOSER_FLAGS mongodb/mongodb --dev --no-update"
 
-      - uses: ramsey/composer-install@v3
+      - uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
         with:
           dependency-versions: highest
           # --ignore-platform-req=php here needed as long as elasticsearch/elasticsearch does not support php 8

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,35 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+    push:
+        branches:
+            - "2.x"
+        paths:
+            - '.github/**.yml'
+    pull_request:
+        paths:
+            - '.github/**.yml'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    zizmor:
+        name: Run zizmor 🌈
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Run zizmor 🌈
+              uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+              with:
+                  advanced-security: false
+                  annotations: true
+                  persona: 'pedantic'

--- a/tests/Monolog/Handler/ElasticaHandlerTest.php
+++ b/tests/Monolog/Handler/ElasticaHandlerTest.php
@@ -16,8 +16,6 @@ use Monolog\Formatter\NormalizerFormatter;
 use Monolog\Test\TestCase;
 use Monolog\Logger;
 use Elastica\Client;
-use Elastica\Request;
-use Elastica\Response;
 
 /**
  * @group Elastica
@@ -140,7 +138,14 @@ class ElasticaHandlerTest extends TestCase
      */
     public function testConnectionErrors($ignore, $expectedError)
     {
-        $clientOpts = ['host' => '127.0.0.1', 'port' => 1];
+        // Elastica 8 ignores the legacy host/port options and only honours a
+        // `hosts` array, while Elastica 7 is the opposite. Point at an unused
+        // port so the connection genuinely fails on either version (otherwise
+        // the client silently falls back to localhost:9200 and the test sees a
+        // live Elasticsearch in CI).
+        $clientOpts = class_exists(\Elastic\Elasticsearch\Client::class)
+            ? ['hosts' => ['http://127.0.0.1:1']]
+            : ['host' => '127.0.0.1', 'port' => 1];
         $client = new Client($clientOpts);
         $handlerOpts = ['ignore_error' => $ignore];
         $handler = new ElasticaHandler($client, $handlerOpts);
@@ -185,18 +190,15 @@ class ElasticaHandlerTest extends TestCase
             'message' => 'log',
         ];
 
-        $expected = $msg;
-        $expected['datetime'] = $msg['datetime']->format(\DateTime::ISO8601);
-        $expected['context'] = [
-            'class' => '[object] (stdClass: {})',
-            'foo' => 7,
-            0 => 'bar',
-        ];
-
         $clientOpts = ['url' => 'http://elastic:changeme@127.0.0.1:9200'];
         $client = new Client($clientOpts);
 
         $handler = new ElasticaHandler($client, $this->options);
+
+        // the document stored in Elasticsearch is the normalised record produced
+        // by the formatter, so derive the expectation from it
+        $formatter = new ElasticaFormatter($this->options['index'], $this->options['type']);
+        $expected = $formatter->format($msg)->getData();
 
         try {
             $handler->handleBatch([$msg]);
@@ -218,17 +220,19 @@ class ElasticaHandlerTest extends TestCase
         $this->assertEquals($expected, $document);
 
         // remove test index from ES
-        $client->request("/{$this->options['index']}", Request::DELETE);
+        $client->getIndex($this->options['index'])->delete();
     }
 
     /**
      * Return last created document id from ES response
-     * @param  Response    $response Elastica Response object
+     * @param  object      $response Elastica\Response (Elastica 7) or Elastic\Elasticsearch\Response\Elasticsearch (Elastica 8)
      * @return string|null
      */
-    protected function getCreatedDocId(Response $response)
+    protected function getCreatedDocId($response)
     {
-        $data = $response->getData();
+        // Elastica 7 returns an Elastica\Response (->getData()), Elastica 8 an
+        // Elastic\Elasticsearch\Response\Elasticsearch (->asArray()).
+        $data = method_exists($response, 'asArray') ? $response->asArray() : $response->getData();
 
         if (!empty($data['items'][0]['index']['_id'])) {
             return $data['items'][0]['index']['_id'];
@@ -249,17 +253,11 @@ class ElasticaHandlerTest extends TestCase
      */
     protected function getDocSourceFromElastic(Client $client, $index, $type, $documentId)
     {
-        if ($type === null) {
-            $path  = "/{$index}/_doc/{$documentId}";
-        } else {
-            $path  = "/{$index}/{$type}/{$documentId}";
-        }
-        $resp = $client->request($path, Request::GET);
-        $data = $resp->getData();
-        if (!empty($data['_source'])) {
-            return $data['_source'];
-        }
+        // Elastica\Client::request() was removed in Elastica 8; the Index API
+        // (getDocument()->getData() returns the document _source) works on both
+        // Elastica 7 and 8.
+        $data = $client->getIndex($index)->getDocument($documentId)->getData();
 
-        return [];
+        return \is_array($data) ? $data : [];
     }
 }


### PR DESCRIPTION
Same as the main-branch PR, applied to `2.x`: adds zizmor (pedantic) + dependabot cooldown and hardens the existing workflows (pinned actions, concurrency, persist-credentials, template-injection fixes).

Known follow-up: `elastic/elastic-github-actions/elasticsearch` has no git tags, so zizmor still reports 2 `stale-action-refs` findings for it. The Elasticsearch setup will be reworked separately (tomorrow), so leaving it pinned to a master commit for now.