### PR TITLE
Add file rotation by hour (FILE_PER_HOUR)

### DIFF
--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -28,6 +28,7 @@ use Monolog\LogRecord;
  */
 class RotatingFileHandler extends StreamHandler
 {
+    public const FILE_PER_HOUR = 'Y-m-d-H';
     public const FILE_PER_DAY = 'Y-m-d';
     public const FILE_PER_MONTH = 'Y-m';
     public const FILE_PER_YEAR = 'Y';
@@ -197,8 +198,8 @@ class RotatingFileHandler extends StreamHandler
         $glob = str_replace(
             ['{filename}', '{date}'],
             [$fileInfo['filename'], str_replace(
-                ['Y', 'y', 'm', 'd'],
-                ['[0-9][0-9][0-9][0-9]', '[0-9][0-9]', '[0-9][0-9]', '[0-9][0-9]'],
+                ['Y', 'y', 'm', 'd', 'H'],
+                ['[0-9][0-9][0-9][0-9]', '[0-9][0-9]', '[0-9][0-9]', '[0-9][0-9]', '[0-9][0-9]'],
                 $this->dateFormat
             )],
             ($fileInfo['dirname'] ?? '') . '/' . $this->filenameFormat
@@ -212,14 +213,15 @@ class RotatingFileHandler extends StreamHandler
 
     protected function setDateFormat(string $dateFormat): void
     {
-        if (0 === preg_match('{^[Yy](([/_.-]?m)([/_.-]?d)?)?$}', $dateFormat)) {
+        if (0 === preg_match('{^[Yy](([/_.-]?m)([/_.-]?d([/_.-]?H)?)?)?$}', $dateFormat)) {
             throw new InvalidArgumentException(
-                'Invalid date format - format must be one of '.
+                'Invalid date format - format must be one of RotatingFileHandler::FILE_PER_HOUR ("Y-m-d-H"), '.
                 'RotatingFileHandler::FILE_PER_DAY ("Y-m-d"), RotatingFileHandler::FILE_PER_MONTH ("Y-m") '.
                 'or RotatingFileHandler::FILE_PER_YEAR ("Y"), or you can set one of the '.
                 'date formats using slashes, underscores and/or dots instead of dashes.'
             );
         }
+
         $this->dateFormat = $dateFormat;
     }
 

--- a/tests/Monolog/Handler/RotatingFileHandlerTest.php
+++ b/tests/Monolog/Handler/RotatingFileHandlerTest.php
@@ -139,6 +139,9 @@ class RotatingFileHandlerTest extends \Monolog\Test\MonologTestCase
     public static function rotationTests()
     {
         $now = time();
+        $hourCallback = function ($ago) use ($now) {
+            return $now + 3600 * $ago;
+        };
         $dayCallback = function ($ago) use ($now) {
             return $now + 86400 * $ago;
         };
@@ -150,6 +153,11 @@ class RotatingFileHandlerTest extends \Monolog\Test\MonologTestCase
         };
 
         return [
+            'Rotation is triggered when the file of the current hour is not present'
+                => [true, RotatingFileHandler::FILE_PER_HOUR, $hourCallback],
+            'Rotation is not triggered when the file of the current hour is already present'
+                => [false, RotatingFileHandler::FILE_PER_HOUR, $hourCallback],
+
             'Rotation is triggered when the file of the current day is not present'
                 => [true, RotatingFileHandler::FILE_PER_DAY, $dayCallback],
             'Rotation is not triggered when the file of the current day is already present'
@@ -207,6 +215,9 @@ class RotatingFileHandlerTest extends \Monolog\Test\MonologTestCase
     public static function rotationWithFolderByDateTests()
     {
         $now = time();
+        $hourCallback = function ($ago) use ($now) {
+            return $now + 3600 * $ago;
+        };
         $dayCallback = function ($ago) use ($now) {
             return $now + 86400 * $ago;
         };
@@ -218,6 +229,11 @@ class RotatingFileHandlerTest extends \Monolog\Test\MonologTestCase
         };
 
         return [
+            'Rotation is triggered when the file of the current hour is not present'
+                => [true, 'Y/m/d/H', $hourCallback],
+            'Rotation is not triggered when the file of the current hour is already present'
+                => [false, 'Y/m/d/H', $hourCallback],
+
             'Rotation is triggered when the file of the current day is not present'
                 => [true, 'Y/m/d', $dayCallback],
             'Rotation is not triggered when the file of the current day is already present'
@@ -250,6 +266,7 @@ class RotatingFileHandlerTest extends \Monolog\Test\MonologTestCase
     public static function dateFormatProvider()
     {
         return [
+            [RotatingFileHandler::FILE_PER_HOUR, true],
             [RotatingFileHandler::FILE_PER_DAY, true],
             [RotatingFileHandler::FILE_PER_MONTH, true],
             [RotatingFileHandler::FILE_PER_YEAR, true],
@@ -265,6 +282,7 @@ class RotatingFileHandlerTest extends \Monolog\Test\MonologTestCase
             ['Y/md', true],
             ['', false],
             ['m-d-Y', false],
+            ['Y-m-d-H-i', false],
             ['Y-m-d-h-i', false],
             ['Y-', false],
             ['Y-m-', false],


### PR DESCRIPTION
Rebased version of #2001 with the date-format validation regex fixed so month-only formats (FILE_PER_MONTH etc.) still validate, plus test coverage for the new FILE_PER_HOUR mode.