### PR TITLE
Still dump the scalars, when the depth level is reached

### DIFF
--- a/src/Monolog/Formatter/JsonFormatter.php
+++ b/src/Monolog/Formatter/JsonFormatter.php
@@ -160,6 +160,10 @@ class JsonFormatter extends NormalizerFormatter
      */
     protected function normalize(mixed $data, int $depth = 0): mixed
     {
+        if (is_null($data) || is_scalar($data)) {
+            return $data;
+        }
+
         if ($depth > $this->maxNormalizeDepth) {
             return 'Over '.$this->maxNormalizeDepth.' levels deep, aborting normalization';
         }

--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -193,10 +193,6 @@ class NormalizerFormatter implements FormatterInterface
      */
     protected function normalize(mixed $data, int $depth = 0): mixed
     {
-        if ($depth > $this->maxNormalizeDepth) {
-            return 'Over ' . $this->maxNormalizeDepth . ' levels deep, aborting normalization';
-        }
-
         if (null === $data || \is_scalar($data)) {
             if (\is_float($data)) {
                 if (is_infinite($data)) {
@@ -208,6 +204,10 @@ class NormalizerFormatter implements FormatterInterface
             }
 
             return $data;
+        }
+
+        if ($depth > $this->maxNormalizeDepth) {
+            return 'Over ' . $this->maxNormalizeDepth . ' levels deep, aborting normalization';
         }
 
         if (\is_array($data)) {

--- a/tests/Monolog/Formatter/JsonFormatterTest.php
+++ b/tests/Monolog/Formatter/JsonFormatterTest.php
@@ -165,6 +165,36 @@ class JsonFormatterTest extends MonologTestCase
 
         $this->assertContextContainsFormattedException('"Over 1 levels deep, aborting normalization"', $message);
     }
+    
+    /**
+     * Scalars and null are leaves: they are returned verbatim even when they
+     * sit deeper than maxNormalizeDepth, while nested arrays/objects at the
+     * same depth still hit the depth guard.
+     */
+    public function testScalarsAndNullBypassMaxNormalizeDepth()
+    {
+        $formatter = new JsonFormatter(JsonFormatter::BATCH_MODE_JSON, false);
+        $formatter->setMaxNormalizeDepth(1);
+
+        // context is normalized at depth 1, its children at depth 2 (> max).
+        $formatted = $formatter->format([
+            'context' => [
+                'scalar' => 'value',
+                'int' => 42,
+                'null' => null,
+                'nested' => ['too' => 'deep'],
+            ],
+        ]);
+
+        $decoded = json_decode($formatted, true);
+        $this->assertSame('value', $decoded['context']['scalar']);
+        $this->assertSame(42, $decoded['context']['int']);
+        $this->assertNull($decoded['context']['null']);
+        $this->assertSame(
+            'Over 1 levels deep, aborting normalization',
+            $decoded['context']['nested']
+        );
+    }
 
     public function testMaxNormalizeItemCountWith0ItemsMax()
     {

--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -327,6 +327,35 @@ class NormalizerFormatterTest extends \Monolog\Test\MonologTestCase
         );
     }
 
+    /**
+     * Scalars and null are leaves: they are returned verbatim even when they
+     * sit deeper than maxNormalizeDepth, while nested arrays/objects at the
+     * same depth still hit the depth guard.
+     */
+    public function testScalarsAndNullBypassMaxNormalizeDepth()
+    {
+        $formatter = new NormalizerFormatter();
+        $formatter->setMaxNormalizeDepth(1);
+
+        // context is normalized at depth 1, its children at depth 2 (> max).
+        $formatted = $formatter->format([
+            'context' => [
+                'scalar' => 'value',
+                'int' => 42,
+                'null' => null,
+                'nested' => ['too' => 'deep'],
+            ],
+        ]);
+
+        $this->assertSame('value', $formatted['context']['scalar']);
+        $this->assertSame(42, $formatted['context']['int']);
+        $this->assertNull($formatted['context']['null']);
+        $this->assertSame(
+            'Over 1 levels deep, aborting normalization',
+            $formatted['context']['nested']
+        );
+    }
+
     public function testMaxNormalizeItemCountWith0ItemsMax()
     {
         $formatter = new NormalizerFormatter();


### PR DESCRIPTION
Hello, community!

We noticed that some of our objects are of exactly depth 9.
We though about changing the level to 10, but then I noticed that this change might be a better option.

What do you think?

Thank you, AndriyT