### PR TITLE
fix(SyslogUdp): allow configuring the max UDP datagram length

### DIFF
--- a/src/Monolog/Handler/SyslogUdp/UdpSocket.php
+++ b/src/Monolog/Handler/SyslogUdp/UdpSocket.php
@@ -20,12 +20,22 @@ class UdpSocket
 
     protected string $ip;
     protected int $port;
+    protected int $maxLength;
     protected ?Socket $socket = null;
 
-    public function __construct(string $ip, int $port = 514)
+    /**
+     * @param ?int $maxLength Maximum size in bytes of a single UDP datagram sent to $ip:$port.
+     *                        Defaults to the largest a UDP payload can theoretically be, but
+     *                        messages that size get fragmented at the IP level, and many routers
+     *                        and firewalls drop fragmented UDP packets, which silently truncates
+     *                        or loses the log entry on the receiving end. Passing a value that
+     *                        fits within the path MTU (eg. 1024) avoids that.
+     */
+    public function __construct(string $ip, int $port = 514, ?int $maxLength = null)
     {
         $this->ip = $ip;
         $this->port = $port;
+        $this->maxLength = $maxLength ?? self::DATAGRAM_MAX_LENGTH;
     }
 
     public function write(string $line, string $header = ""): void
@@ -70,7 +80,7 @@ class UdpSocket
 
     protected function assembleMessage(string $line, string $header): string
     {
-        $chunkSize = static::DATAGRAM_MAX_LENGTH - \strlen($header);
+        $chunkSize = $this->maxLength - \strlen($header);
 
         return $header . Utils::substr($line, 0, $chunkSize);
     }

--- a/src/Monolog/Handler/SyslogUdpHandler.php
+++ b/src/Monolog/Handler/SyslogUdpHandler.php
@@ -46,13 +46,18 @@ class SyslogUdpHandler extends AbstractSyslogHandler
      * @param  int                       $port     Port number, or 0 if $host is a unix socket
      * @param  string|int                $facility Either one of the names of the keys in $this->facilities, or a LOG_* facility constant
      * @param  bool                      $bubble   Whether the messages that are handled can bubble up the stack or not
-     * @param  string                    $ident    Program name or tag for each log message.
-     * @param  int                       $rfc      RFC to format the message for.
+     * @param  string                    $ident     Program name or tag for each log message.
+     * @param  int                       $rfc       RFC to format the message for.
+     * @param  ?int                      $maxLength Maximum size in bytes of a single UDP datagram. Defaults to the
+     *                                              largest a UDP payload can theoretically be, which risks getting
+     *                                              silently truncated or dropped by routers/firewalls that reject
+     *                                              fragmented UDP packets; pass a value that fits within the path
+     *                                              MTU (eg. 1024) to avoid that.
      * @throws MissingExtensionException when there is no socket extension
      *
      * @phpstan-param self::RFC* $rfc
      */
-    public function __construct(string $host, int $port = 514, string|int $facility = LOG_USER, int|string|Level $level = Level::Debug, bool $bubble = true, string $ident = 'php', int $rfc = self::RFC5424)
+    public function __construct(string $host, int $port = 514, string|int $facility = LOG_USER, int|string|Level $level = Level::Debug, bool $bubble = true, string $ident = 'php', int $rfc = self::RFC5424, ?int $maxLength = null)
     {
         if (!\extension_loaded('sockets')) {
             throw new MissingExtensionException('The sockets extension is required to use the SyslogUdpHandler');
@@ -63,7 +68,7 @@ class SyslogUdpHandler extends AbstractSyslogHandler
         $this->ident = $ident;
         $this->rfc = $rfc;
 
-        $this->socket = new UdpSocket($host, $port);
+        $this->socket = new UdpSocket($host, $port, $maxLength);
     }
 
     protected function write(LogRecord $record): void

--- a/tests/Monolog/Handler/SyslogUdpHandlerTest.php
+++ b/tests/Monolog/Handler/SyslogUdpHandlerTest.php
@@ -108,6 +108,27 @@ class SyslogUdpHandlerTest extends \Monolog\Test\MonologTestCase
         $handler->handle($this->getRecordWithMessage("hej\nlol"));
     }
 
+    public function testMaxLengthIsPassedToTheSocket()
+    {
+        $handler = new SyslogUdpHandler("127.0.0.1", 514, "authpriv", 'debug', true, "php", SyslogUdpHandler::RFC5424, 1024);
+
+        $socketProp = new \ReflectionProperty(SyslogUdpHandler::class, 'socket');
+        $maxLengthProp = new \ReflectionProperty(\Monolog\Handler\SyslogUdp\UdpSocket::class, 'maxLength');
+
+        $this->assertSame(1024, $maxLengthProp->getValue($socketProp->getValue($handler)));
+    }
+
+    public function testMaxLengthDefaultsToUdpSocketsOwnDefaultWhenNotSpecified()
+    {
+        $handler = new SyslogUdpHandler("127.0.0.1", 514, "authpriv");
+
+        $socketProp = new \ReflectionProperty(SyslogUdpHandler::class, 'socket');
+        $maxLengthProp = new \ReflectionProperty(\Monolog\Handler\SyslogUdp\UdpSocket::class, 'maxLength');
+        $defaultConst = new \ReflectionClassConstant(\Monolog\Handler\SyslogUdp\UdpSocket::class, 'DATAGRAM_MAX_LENGTH');
+
+        $this->assertSame($defaultConst->getValue(), $maxLengthProp->getValue($socketProp->getValue($handler)));
+    }
+
     protected function getRecordWithMessage($msg)
     {
         return $this->getRecord(message: $msg, level: Level::Warning, channel: 'lol', datetime: new \DateTimeImmutable('2014-01-07 12:34:56'));

--- a/tests/Monolog/Handler/UdpSocketTest.php
+++ b/tests/Monolog/Handler/UdpSocketTest.php
@@ -50,6 +50,36 @@ class UdpSocketTest extends \Monolog\Test\MonologTestCase
         $socket->write($longString, "HEADER");
     }
 
+    public function testCustomMaxLengthTruncatesEarlier()
+    {
+        $socket = $this->getMockBuilder('Monolog\Handler\SyslogUdp\UdpSocket')
+            ->onlyMethods(['send'])
+            ->setConstructorArgs(['lol', 514, 10])
+            ->getMock();
+
+        $socket->expects($this->exactly(1))
+            ->method('send')
+            ->with("HD:abcdefg");
+
+        $socket->write('abcdefghij', 'HD:');
+    }
+
+    public function testDefaultMaxLengthIsUsedWhenNotSpecified()
+    {
+        $socket = $this->getMockBuilder('Monolog\Handler\SyslogUdp\UdpSocket')
+            ->onlyMethods(['send'])
+            ->setConstructorArgs(['lol'])
+            ->getMock();
+
+        $truncatedString = str_repeat("derp", 16254).'d';
+
+        $socket->expects($this->exactly(1))
+            ->method('send')
+            ->with("HEADER" . $truncatedString);
+
+        $socket->write(str_repeat("derp", 20000), "HEADER");
+    }
+
     public function testDoubleCloseDoesNotError()
     {
         $socket = new UdpSocket('127.0.0.1', 514);


### PR DESCRIPTION
## What

`UdpSocket::DATAGRAM_MAX_LENGTH` (65023 bytes) is the largest a UDP payload can theoretically be, but a datagram that size gets fragmented at the IP level, and many routers/firewalls drop fragmented UDP packets outright. That silently truncates or loses log messages that exceed the path MTU on the way to the syslog receiver, even though nothing on the sending side reports an error.

## Why this approach

An existing test (`testLongMessagesAreTruncated`) explicitly locks in the current 65023-byte behavior, and some setups over trusted/local networks may rely on it, so I didn't want to just lower the default and risk a behavior change / BC break. Instead, this adds an optional `$maxLength` constructor parameter to `UdpSocket`, threaded through `SyslogUdpHandler`'s constructor (the entry point most users actually use), so a value that fits within the path MTU (eg. 1024) can be opted into. The default is unchanged.

## Verification

- Added regression tests covering: a custom `$maxLength` truncates at the new length, the default is preserved when not specified, and `SyslogUdpHandler` correctly threads the value through to its internal `UdpSocket` (verified via reflection, since `$socket` isn't otherwise inspectable from outside).
- Full test suite passes (1182 tests); the only pre-existing failures are 3 unrelated ones in `JsonFormatterTest`/`NormalizerFormatterTest`/`ErrorHandlerTest` (confirmed identical on unmodified `main`), plus 30 skips for missing optional extensions (mongodb, redis, etc.) unrelated to this change.
- `phpstan analyse` is clean on the changed files.

**Honest caveat**: I could not verify the actual real-world symptom (fragmented UDP getting dropped by a router/firewall) with a live network reproduction — that's not something reproducible over loopback, which doesn't share the same MTU/fragmentation-handling constraints as a real network path. Verification here is limited to code review and the unit tests described above.

## Related issue

Fixes #1826

---
Disclosure: this PR was prepared with the assistance of Claude Code (Anthropic). The investigation, fix, and verification steps described above were done and checked by me.