### PR TITLE
Make IntrospectionProcessor SKIP_FUNCTIONS extendable

### DIFF
--- a/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/src/Monolog/Processor/IntrospectionProcessor.php
@@ -86,7 +86,7 @@ class IntrospectionProcessor implements ProcessorInterface
                         continue 2;
                     }
                 }
-            } elseif (\in_array($trace[$i]['function'], self::SKIP_FUNCTIONS, true)) {
+            } elseif (\in_array($trace[$i]['function'], static::SKIP_FUNCTIONS, true)) {
                 $i++;
 
                 continue;
@@ -121,6 +121,6 @@ class IntrospectionProcessor implements ProcessorInterface
             return false;
         }
 
-        return isset($trace[$index]['class']) || \in_array($trace[$index]['function'], self::SKIP_FUNCTIONS, true);
+        return isset($trace[$index]['class']) || \in_array($trace[$index]['function'], static::SKIP_FUNCTIONS, true);
     }
 }


### PR DESCRIPTION
SKIP_FUNCTIONS was made protected in https://github.com/Seldaek/monolog/pull/1899, so subclasses could override it, but IntrospectionProcessor still referenced it via `self::`, which resolves the constant at the declaring class and ignores any override. 