### PR TITLE
Add FrankenPhpHandler

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -86,11 +86,11 @@ jobs:
 
       - name: "Run tests"
         if: "matrix.php-version >= '8.2'"
-        run: "composer exec phpunit -- --exclude-group Elasticsearch --exclude-group Elastica"
+        run: "composer exec phpunit -- --exclude-group Elasticsearch --exclude-group Elastica --exclude-group e2e"
 
       - name: "Run tests"
         if: "matrix.php-version == '8.1'"
-        run: "composer exec phpunit -- --exclude-group Elasticsearch,Elastica"
+        run: "composer exec phpunit -- --exclude-group Elasticsearch,Elastica,e2e"
 
   tests-es-7:
     name: "CI with ES ${{ matrix.es-version }} on PHP ${{ matrix.php-version }}"

--- a/.github/workflows/frankenphp-e2e.yml
+++ b/.github/workflows/frankenphp-e2e.yml
@@ -1,0 +1,40 @@
+name: "FrankenPHP E2E"
+
+on:
+  - push
+  - pull_request
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: "FrankenPHP e2e"
+
+    runs-on: ubuntu-latest
+
+    services:
+      frankenphp:
+        image: dunglas/frankenphp:latest
+        ports:
+          - 8099:8099
+        env:
+          SERVER_NAME: ":8099"
+        volumes:
+          - ${{ github.workspace }}:/app/source:ro
+          - ${{ github.workspace }}/tests/e2e/frankenphp/public:/app/public
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Install dependencies"
+        run: composer install --ignore-platform-req=ext-mongodb
+
+      - name: "Run FrankenPHP e2e test"
+        run: vendor/bin/phpunit --group e2e

--- a/.github/workflows/frankenphp-e2e.yml
+++ b/.github/workflows/frankenphp-e2e.yml
@@ -17,17 +17,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    services:
-      frankenphp:
-        image: dunglas/frankenphp:latest
-        ports:
-          - 8099:8099
-        env:
-          SERVER_NAME: ":8099"
-        volumes:
-          - ${{ github.workspace }}:/app/source:ro
-          - ${{ github.workspace }}/tests/e2e/frankenphp/public:/app/public:ro
-
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -36,5 +25,16 @@ jobs:
       - name: "Install dependencies"
         run: composer install --ignore-platform-req=ext-mongodb
 
+      - name: "Start FrankenPHP"
+        run: |
+          docker run -d --name monolog-frankenphp-e2e \
+            -v "$PWD":/app/source:ro \
+            -v "$PWD/tests/e2e/frankenphp/public":/app/public:ro \
+            -e SERVER_NAME=":8099" \
+            -p 8099:8099 \
+            dunglas/frankenphp:latest
+
       - name: "Run FrankenPHP e2e test"
+        env:
+          MONOLOG_FRANKENPHP_E2E: "1"
         run: vendor/bin/phpunit --group e2e

--- a/.github/workflows/frankenphp-e2e.yml
+++ b/.github/workflows/frankenphp-e2e.yml
@@ -26,7 +26,7 @@ jobs:
           SERVER_NAME: ":8099"
         volumes:
           - ${{ github.workspace }}:/app/source:ro
-          - ${{ github.workspace }}/tests/e2e/frankenphp/public:/app/public
+          - ${{ github.workspace }}/tests/e2e/frankenphp/public:/app/public:ro
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/frankenphp-e2e.yml
+++ b/.github/workflows/frankenphp-e2e.yml
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: read
 
+env:
+  COMPOSER_ROOT_VERSION: dev-main
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -18,12 +21,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - name: "Install dependencies"
-        run: composer install --ignore-platform-req=ext-mongodb
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          coverage: "none"
+          php-version: "8.4"
+          tools: "composer:v2"
+          ini-values: "memory_limit=-1"
+
+      - uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
+        with:
+          dependency-versions: "highest"
+          composer-options: "--ignore-platform-req=ext-mongodb"
 
       - name: "Start FrankenPHP"
         run: |

--- a/doc/02-handlers-formatters-processors.md
+++ b/doc/02-handlers-formatters-processors.md
@@ -23,6 +23,7 @@
 - [_SyslogHandler_](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/SyslogHandler.php): Logs records to the syslog.
 - [_ErrorLogHandler_](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/ErrorLogHandler.php): Logs records to PHP's
   [`error_log()`](https://www.php.net/manual/en/function.error-log.php) function.
+- [_FrankenPhpHandler_](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/FrankenPhpHandler.php): Logs records using [FrankenPHP's `frankenphp_log()`](https://frankenphp.dev/docs/logging/#frankenphp_log) function. Requires running under the [FrankenPHP](https://frankenphp.dev/) SAPI.
 - [_ProcessHandler_](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/ProcessHandler.php): Logs records to the [STDIN](https://en.wikipedia.org/wiki/Standard_streams#Standard_input_.28stdin.29) of any process, specified by a command.
 
 ### Send alerts and emails

--- a/src/Monolog/Handler/FrankenPhpHandler.php
+++ b/src/Monolog/Handler/FrankenPhpHandler.php
@@ -76,9 +76,10 @@ class FrankenPhpHandler extends AbstractProcessingHandler
      */
     protected function writeFrankenPhpLog(string $message, int $level, array $context): void
     {
-        // frankenphp_log() merges $context into the same JSON object as its own "level" severity field;
-        // dropping Monolog's raw int here avoids a duplicate "level" key (level_name already carries it).
-        unset($context['level']);
+        // frankenphp_log() merges $context into the same JSON object it already fills with "msg",
+        // "level" and "ts", so drop Monolog's duplicates of those three. level_name still carries
+        // the Monolog level name, which slog's own severity cannot express.
+        unset($context['message'], $context['level'], $context['datetime']);
 
         \frankenphp_log($message, $level, $context);
     }

--- a/src/Monolog/Handler/FrankenPhpHandler.php
+++ b/src/Monolog/Handler/FrankenPhpHandler.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\NormalizerFormatter;
+use Monolog\Level;
+use Monolog\LogRecord;
+
+/**
+ * Logs records using FrankenPHP's frankenphp_log() function.
+ *
+ * This handler requires a NormalizerFormatter to function and expects an array in $record->formatted
+ *
+ * @see https://frankenphp.dev/docs/logging/#frankenphp_log
+ *
+ * @author Kévin Dunglas <kevin@dunglas.dev>
+ */
+class FrankenPhpHandler extends AbstractProcessingHandler
+{
+    /**
+     * @throws MissingExtensionException If frankenphp_log() is not available
+     */
+    public function __construct(int|string|Level $level = Level::Debug, bool $bubble = true)
+    {
+        if (!\function_exists('frankenphp_log')) {
+            throw new MissingExtensionException(
+                'You must run this handler under FrankenPHP, the frankenphp_log() function is not available'
+            );
+        }
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * Translates Monolog log levels to FrankenPHP's slog-based levels.
+     *
+     * slog treats levels as arbitrary ints and recommends a gap of 4 between named levels to leave
+     * room for intermediate ones, e.g. Google Cloud Logging's Notice between Info and Warn.
+     *
+     * @see https://pkg.go.dev/log/slog#hdr-Levels
+     */
+    protected function toFrankenPhpLevel(Level $level): int
+    {
+        return match ($level) {
+            Level::Debug => \FRANKENPHP_LOG_LEVEL_DEBUG,
+            Level::Info => \FRANKENPHP_LOG_LEVEL_INFO,
+            Level::Notice => 2,
+            Level::Warning => \FRANKENPHP_LOG_LEVEL_WARN,
+            Level::Error => \FRANKENPHP_LOG_LEVEL_ERROR,
+            Level::Critical => 12,
+            Level::Alert => 14,
+            Level::Emergency => 16,
+        };
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        \frankenphp_log($record->message, $this->toFrankenPhpLevel($record->level), $record->formatted);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDefaultFormatter(): FormatterInterface
+    {
+        return new NormalizerFormatter();
+    }
+}

--- a/src/Monolog/Handler/FrankenPhpHandler.php
+++ b/src/Monolog/Handler/FrankenPhpHandler.php
@@ -68,13 +68,19 @@ class FrankenPhpHandler extends AbstractProcessingHandler
      */
     protected function write(LogRecord $record): void
     {
-        $context = $record->formatted;
+        $this->writeFrankenPhpLog($record->message, $this->toFrankenPhpLevel($record->level), $record->formatted);
+    }
 
+    /**
+     * @param array<mixed> $context Displayed as structured attributes alongside the message
+     */
+    protected function writeFrankenPhpLog(string $message, int $level, array $context): void
+    {
         // frankenphp_log() merges $context into the same JSON object as its own "level" severity field;
         // dropping Monolog's raw int here avoids a duplicate "level" key (level_name already carries it).
         unset($context['level']);
 
-        \frankenphp_log($record->message, $this->toFrankenPhpLevel($record->level), $context);
+        \frankenphp_log($message, $level, $context);
     }
 
     /**

--- a/src/Monolog/Handler/FrankenPhpHandler.php
+++ b/src/Monolog/Handler/FrankenPhpHandler.php
@@ -47,6 +47,9 @@ class FrankenPhpHandler extends AbstractProcessingHandler
      * slog treats levels as arbitrary ints and recommends a gap of 4 between named levels to leave
      * room for intermediate ones, e.g. Google Cloud Logging's Notice between Info and Warn.
      *
+     * FrankenPHP feeds these through zapslog, which buckets everything >= Error into "error", so
+     * above Error only the level_name context key tells the Monolog levels apart.
+     *
      * @see https://pkg.go.dev/log/slog#hdr-Levels
      */
     protected function toFrankenPhpLevel(Level $level): int
@@ -58,8 +61,8 @@ class FrankenPhpHandler extends AbstractProcessingHandler
             Level::Warning => \FRANKENPHP_LOG_LEVEL_WARN,
             Level::Error => \FRANKENPHP_LOG_LEVEL_ERROR,
             Level::Critical => 12,
-            Level::Alert => 14,
-            Level::Emergency => 16,
+            Level::Alert => 16,
+            Level::Emergency => 20,
         };
     }
 

--- a/src/Monolog/Handler/FrankenPhpHandler.php
+++ b/src/Monolog/Handler/FrankenPhpHandler.php
@@ -68,7 +68,13 @@ class FrankenPhpHandler extends AbstractProcessingHandler
      */
     protected function write(LogRecord $record): void
     {
-        \frankenphp_log($record->message, $this->toFrankenPhpLevel($record->level), $record->formatted);
+        $context = $record->formatted;
+
+        // frankenphp_log() merges $context into the same JSON object as its own "level" severity field;
+        // dropping Monolog's raw int here avoids a duplicate "level" key (level_name already carries it).
+        unset($context['level']);
+
+        \frankenphp_log($record->message, $this->toFrankenPhpLevel($record->level), $context);
     }
 
     /**

--- a/tests/Monolog/Handler/FrankenPhpHandlerE2ETest.php
+++ b/tests/Monolog/Handler/FrankenPhpHandlerE2ETest.php
@@ -50,8 +50,22 @@ class FrankenPhpHandlerE2ETest extends \Monolog\Test\MonologTestCase
 
         $logs = (string) shell_exec('docker logs ' . escapeshellarg($containerId) . ' 2>&1');
 
-        $this->assertStringContainsString('"msg":"Hello from Monolog via FrankenPHP"', $logs);
-        $this->assertStringContainsString('"level":"warn"', $logs);
-        $this->assertStringContainsString('"msg":"Custom FrankenPHP level"', $logs);
+        $this->assertLogLine($logs, 'warn', 'Hello from Monolog via FrankenPHP');
+        $this->assertLogLine($logs, 'error', 'Custom FrankenPHP level');
+    }
+
+    /**
+     * Asserts a single JSON log line starts with the given zap level and contains the given message.
+     *
+     * Each record also carries its own "level" field (Monolog's raw int severity), which lands in the
+     * same JSON object as zap's "level" string - checking substrings independently could match either
+     * one on any line. Anchoring on "level" as the first key (zap always emits it first) and keeping the
+     * match on one line (no /s modifier) ties both checks to the same log entry unambiguously.
+     */
+    private function assertLogLine(string $logs, string $level, string $message): void
+    {
+        $pattern = sprintf('/^\{"level":"%s".*"msg":"%s"/m', preg_quote($level, '/'), preg_quote($message, '/'));
+
+        $this->assertMatchesRegularExpression($pattern, $logs, "No log line found with level \"$level\" and message \"$message\"");
     }
 }

--- a/tests/Monolog/Handler/FrankenPhpHandlerE2ETest.php
+++ b/tests/Monolog/Handler/FrankenPhpHandlerE2ETest.php
@@ -49,23 +49,28 @@ class FrankenPhpHandlerE2ETest extends \Monolog\Test\MonologTestCase
         $this->assertNotSame('', $containerId, 'Could not find a running dunglas/frankenphp container');
 
         $logs = (string) shell_exec('docker logs ' . escapeshellarg($containerId) . ' 2>&1');
+        $entries = array_filter(array_map(
+            static fn (string $line) => json_decode($line, true),
+            explode("\n", trim($logs)),
+        ));
 
-        $this->assertLogLine($logs, 'warn', 'Hello from Monolog via FrankenPHP');
-        $this->assertLogLine($logs, 'error', 'Custom FrankenPHP level');
+        $this->assertLogEntry($entries, 'warn', 'Hello from Monolog via FrankenPHP');
+        $this->assertLogEntry($entries, 'error', 'Custom FrankenPHP level');
     }
 
     /**
-     * Asserts a single JSON log line starts with the given zap level and contains the given message.
-     *
-     * Each record also carries its own "level" field (Monolog's raw int severity), which lands in the
-     * same JSON object as zap's "level" string - checking substrings independently could match either
-     * one on any line. Anchoring on "level" as the first key (zap always emits it first) and keeping the
-     * match on one line (no /s modifier) ties both checks to the same log entry unambiguously.
+     * @param array<array<string, mixed>> $entries
      */
-    private function assertLogLine(string $logs, string $level, string $message): void
+    private function assertLogEntry(array $entries, string $level, string $message): void
     {
-        $pattern = sprintf('/^\{"level":"%s".*"msg":"%s"/m', preg_quote($level, '/'), preg_quote($message, '/'));
+        foreach ($entries as $entry) {
+            if (($entry['msg'] ?? null) === $message) {
+                $this->assertSame($level, $entry['level'] ?? null, "Unexpected level for message \"$message\"");
 
-        $this->assertMatchesRegularExpression($pattern, $logs, "No log line found with level \"$level\" and message \"$message\"");
+                return;
+            }
+        }
+
+        $this->fail("No log entry found with message \"$message\"");
     }
 }

--- a/tests/Monolog/Handler/FrankenPhpHandlerE2ETest.php
+++ b/tests/Monolog/Handler/FrankenPhpHandlerE2ETest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Requires a FrankenPHP server serving tests/e2e/frankenphp/public on 127.0.0.1:8099, e.g.:
+ *
+ * docker run -d --rm -v "$PWD":/app/source:ro -v "$PWD/tests/e2e/frankenphp/public":/app/public \
+ *     -e SERVER_NAME=":8099" -p 8099:8099 dunglas/frankenphp:latest
+ */
+#[Group('e2e')]
+class FrankenPhpHandlerE2ETest extends \Monolog\Test\MonologTestCase
+{
+    private const HOST = '127.0.0.1';
+    private const PORT = 8099;
+
+    protected function setUp(): void
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $connection = @fsockopen(self::HOST, self::PORT, $errno, $errstr, 1);
+            if (false !== $connection) {
+                fclose($connection);
+
+                return;
+            }
+            sleep(1);
+        }
+
+        $this->markTestSkipped(sprintf('FrankenPHP is not running on %s:%d', self::HOST, self::PORT));
+    }
+
+    public function testFrankenPhpLogHandlerWritesStructuredLogs()
+    {
+        $response = file_get_contents(sprintf('http://%s:%d/', self::HOST, self::PORT));
+        $this->assertSame('OK', $response);
+
+        $containerId = trim((string) shell_exec('docker ps -q --filter ancestor=dunglas/frankenphp:latest'));
+        $this->assertNotSame('', $containerId, 'Could not find a running dunglas/frankenphp container');
+
+        $logs = (string) shell_exec('docker logs ' . escapeshellarg($containerId) . ' 2>&1');
+
+        $this->assertStringContainsString('"msg":"Hello from Monolog via FrankenPHP"', $logs);
+        $this->assertStringContainsString('"level":"warn"', $logs);
+        $this->assertStringContainsString('"msg":"Custom FrankenPHP level"', $logs);
+    }
+}

--- a/tests/Monolog/Handler/FrankenPhpHandlerE2ETest.php
+++ b/tests/Monolog/Handler/FrankenPhpHandlerE2ETest.php
@@ -60,8 +60,23 @@ class FrankenPhpHandlerE2ETest extends \Monolog\Test\MonologTestCase
 
         $entries = $this->readLogEntries();
 
-        $this->assertLogEntry($entries, 'warn', 'Hello from Monolog via FrankenPHP');
-        $this->assertLogEntry($entries, 'error', 'Custom FrankenPHP level');
+        $warning = $this->findLogEntry($entries, 'Hello from Monolog via FrankenPHP');
+        // "level" must be slog's own severity string. Monolog's raw int level sharing that key
+        // would either clobber it or be dropped, so this is what guards the unset() in write().
+        $this->assertSame('warn', $warning['level'] ?? null);
+        $this->assertSame('WARNING', $warning['level_name'] ?? null);
+        $this->assertSame('e2e', $warning['channel'] ?? null);
+        // FrankenPHP encodes nested PHP arrays as a Go ordered map rather than a plain object.
+        $this->assertSame(['foo' => 'bar'], $warning['context']['Map'] ?? null);
+        // slog already emits these as "msg" and "ts", the handler drops Monolog's copies.
+        $this->assertArrayNotHasKey('message', $warning);
+        $this->assertArrayNotHasKey('datetime', $warning);
+
+        $critical = $this->findLogEntry($entries, 'Custom FrankenPHP level');
+        // zapslog buckets everything at or above Error into "error", so only level_name tells
+        // Critical, Alert and Emergency apart.
+        $this->assertSame('error', $critical['level'] ?? null);
+        $this->assertSame('CRITICAL', $critical['level_name'] ?? null);
     }
 
     /**
@@ -99,15 +114,14 @@ class FrankenPhpHandlerE2ETest extends \Monolog\Test\MonologTestCase
     }
 
     /**
-     * @param array<array<string, mixed>> $entries
+     * @param  array<array<string, mixed>> $entries
+     * @return array<string, mixed>
      */
-    private function assertLogEntry(array $entries, string $level, string $message): void
+    private function findLogEntry(array $entries, string $message): array
     {
         foreach ($entries as $entry) {
             if (($entry['msg'] ?? null) === $message) {
-                $this->assertSame($level, $entry['level'] ?? null, "Unexpected level for message \"$message\"");
-
-                return;
+                return $entry;
             }
         }
 

--- a/tests/Monolog/Handler/FrankenPhpHandlerE2ETest.php
+++ b/tests/Monolog/Handler/FrankenPhpHandlerE2ETest.php
@@ -16,16 +16,21 @@ use PHPUnit\Framework\Attributes\Group;
 /**
  * Requires a FrankenPHP server serving tests/e2e/frankenphp/public on 127.0.0.1:8099, e.g.:
  *
- * docker run -d --rm -v "$PWD":/app/source:ro -v "$PWD/tests/e2e/frankenphp/public":/app/public \
+ * docker run -d --rm --name monolog-frankenphp-e2e -v "$PWD":/app/source:ro \
+ *     -v "$PWD/tests/e2e/frankenphp/public":/app/public \
  *     -e SERVER_NAME=":8099" -p 8099:8099 dunglas/frankenphp:latest
+ *
+ * Skips when no server is reachable, unless MONOLOG_FRANKENPHP_E2E is set, in which case it fails.
+ * MONOLOG_FRANKENPHP_CONTAINER overrides the container name the logs are read from.
  */
 #[Group('e2e')]
 class FrankenPhpHandlerE2ETest extends \Monolog\Test\MonologTestCase
 {
     private const HOST = '127.0.0.1';
     private const PORT = 8099;
+    private const DEFAULT_CONTAINER = 'monolog-frankenphp-e2e';
 
-    protected function setUp(): void
+    public static function setUpBeforeClass(): void
     {
         for ($i = 0; $i < 10; $i++) {
             $connection = @fsockopen(self::HOST, self::PORT, $errno, $errstr, 1);
@@ -37,7 +42,15 @@ class FrankenPhpHandlerE2ETest extends \Monolog\Test\MonologTestCase
             sleep(1);
         }
 
-        $this->markTestSkipped(sprintf('FrankenPHP is not running on %s:%d', self::HOST, self::PORT));
+        $message = sprintf('FrankenPHP is not running on %s:%d', self::HOST, self::PORT);
+
+        // In CI the server is meant to be up, so a missing one is a failure. Skipping there would
+        // let the whole e2e job report success without ever asserting anything.
+        if (false !== getenv('MONOLOG_FRANKENPHP_E2E')) {
+            self::fail($message);
+        }
+
+        self::markTestSkipped($message);
     }
 
     public function testFrankenPhpLogHandlerWritesStructuredLogs()
@@ -45,17 +58,44 @@ class FrankenPhpHandlerE2ETest extends \Monolog\Test\MonologTestCase
         $response = file_get_contents(sprintf('http://%s:%d/', self::HOST, self::PORT));
         $this->assertSame('OK', $response);
 
-        $containerId = trim((string) shell_exec('docker ps -q --filter ancestor=dunglas/frankenphp:latest'));
-        $this->assertNotSame('', $containerId, 'Could not find a running dunglas/frankenphp container');
-
-        $logs = (string) shell_exec('docker logs ' . escapeshellarg($containerId) . ' 2>&1');
-        $entries = array_filter(array_map(
-            static fn (string $line) => json_decode($line, true),
-            explode("\n", trim($logs)),
-        ));
+        $entries = $this->readLogEntries();
 
         $this->assertLogEntry($entries, 'warn', 'Hello from Monolog via FrankenPHP');
         $this->assertLogEntry($entries, 'error', 'Custom FrankenPHP level');
+    }
+
+    /**
+     * The Go side writes through zap and the Docker log driver, which is not synchronous with the
+     * HTTP response, so poll rather than read once.
+     *
+     * @return array<array<string, mixed>>
+     */
+    private function readLogEntries(): array
+    {
+        $container = getenv('MONOLOG_FRANKENPHP_CONTAINER');
+        if (false === $container || '' === $container) {
+            $container = self::DEFAULT_CONTAINER;
+        }
+
+        $entries = [];
+        for ($i = 0; $i < 10; $i++) {
+            $logs = (string) shell_exec('docker logs '.escapeshellarg($container).' 2>&1');
+            $entries = array_filter(array_map(
+                static fn (string $line) => json_decode($line, true),
+                explode("\n", trim($logs)),
+            ));
+
+            $messages = array_column($entries, 'msg');
+            if (\in_array('Hello from Monolog via FrankenPHP', $messages, true) && \in_array('Custom FrankenPHP level', $messages, true)) {
+                break;
+            }
+
+            usleep(200_000);
+        }
+
+        $this->assertNotSame([], $entries, sprintf('No log output from container "%s"', $container));
+
+        return $entries;
     }
 
     /**

--- a/tests/Monolog/Handler/FrankenPhpHandlerTest.php
+++ b/tests/Monolog/Handler/FrankenPhpHandlerTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+class FrankenPhpHandlerTest extends \Monolog\Test\MonologTestCase
+{
+    /**
+     * @covers Monolog\Handler\FrankenPhpHandler::__construct
+     */
+    public function testConstructorThrowsWhenFrankenPhpIsNotAvailable()
+    {
+        $this->expectException(MissingExtensionException::class);
+
+        new FrankenPhpHandler();
+    }
+
+    /**
+     * @covers Monolog\Handler\FrankenPhpHandler::getDefaultFormatter
+     */
+    public function testGetDefaultFormatterReturnsNormalizerFormatter()
+    {
+        $handler = (new \ReflectionClass(FrankenPhpHandler::class))->newInstanceWithoutConstructor();
+
+        $this->assertInstanceOf('Monolog\Formatter\NormalizerFormatter', $handler->getDefaultFormatter());
+    }
+}

--- a/tests/Monolog/Handler/FrankenPhpHandlerTest.php
+++ b/tests/Monolog/Handler/FrankenPhpHandlerTest.php
@@ -11,8 +11,25 @@
 
 namespace Monolog\Handler;
 
+use Monolog\Level;
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class FrankenPhpHandlerTest extends \Monolog\Test\MonologTestCase
 {
+    /**
+     * FrankenPHP only defines these under its own SAPI, so mirror slog's values to keep the level
+     * mapping testable anywhere. The e2e test is what checks them against the real thing.
+     *
+     * Data providers run before setUpBeforeClass(), hence the explicit calls rather than a hook.
+     */
+    private static function defineLogLevelConstants(): void
+    {
+        \defined('FRANKENPHP_LOG_LEVEL_DEBUG') || \define('FRANKENPHP_LOG_LEVEL_DEBUG', -4);
+        \defined('FRANKENPHP_LOG_LEVEL_INFO') || \define('FRANKENPHP_LOG_LEVEL_INFO', 0);
+        \defined('FRANKENPHP_LOG_LEVEL_WARN') || \define('FRANKENPHP_LOG_LEVEL_WARN', 4);
+        \defined('FRANKENPHP_LOG_LEVEL_ERROR') || \define('FRANKENPHP_LOG_LEVEL_ERROR', 8);
+    }
+
     /**
      * @covers Monolog\Handler\FrankenPhpHandler::__construct
      */
@@ -35,5 +52,78 @@ class FrankenPhpHandlerTest extends \Monolog\Test\MonologTestCase
         $handler = (new \ReflectionClass(FrankenPhpHandler::class))->newInstanceWithoutConstructor();
 
         $this->assertInstanceOf('Monolog\Formatter\NormalizerFormatter', $handler->getDefaultFormatter());
+    }
+
+    /**
+     * @covers Monolog\Handler\FrankenPhpHandler::write
+     */
+    public function testWrite()
+    {
+        self::defineLogLevelConstants();
+
+        $record = $this->getRecord(Level::Warning, 'test message', ['foo' => 'bar']);
+        $formatterResult = [
+            'message' => $record->message,
+            'context' => ['foo' => 'bar'],
+            'level' => $record->level->value,
+            'level_name' => $record->level->getName(),
+            'channel' => 'test',
+            'datetime' => '2024-01-01T00:00:00.000000+00:00',
+        ];
+
+        $handler = $this->getMockBuilder(FrankenPhpHandler::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['writeFrankenPhpLog', 'getDefaultFormatter'])
+            ->getMock();
+
+        $formatterMock = $this->getMockBuilder('Monolog\Formatter\NormalizerFormatter')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $formatterMock->expects($this->once())
+            ->method('format')
+            ->willReturn($formatterResult);
+
+        $handler->expects($this->once())
+            ->method('getDefaultFormatter')
+            ->willReturn($formatterMock);
+
+        $handler->expects($this->once())
+            ->method('writeFrankenPhpLog')
+            ->with('test message', \FRANKENPHP_LOG_LEVEL_WARN, $formatterResult);
+
+        $handler->handle($record);
+    }
+
+    /**
+     * @covers Monolog\Handler\FrankenPhpHandler::toFrankenPhpLevel
+     */
+    #[DataProvider('levelProvider')]
+    public function testToFrankenPhpLevel(Level $level, int $expected)
+    {
+        $handler = (new \ReflectionClass(FrankenPhpHandler::class))->newInstanceWithoutConstructor();
+
+        $method = new \ReflectionMethod($handler, 'toFrankenPhpLevel');
+
+        $this->assertSame($expected, $method->invoke($handler, $level));
+    }
+
+    /**
+     * @return array<string, array{Level, int}>
+     */
+    public static function levelProvider(): array
+    {
+        self::defineLogLevelConstants();
+
+        return [
+            'debug' => [Level::Debug, \FRANKENPHP_LOG_LEVEL_DEBUG],
+            'info' => [Level::Info, \FRANKENPHP_LOG_LEVEL_INFO],
+            'notice' => [Level::Notice, 2],
+            'warning' => [Level::Warning, \FRANKENPHP_LOG_LEVEL_WARN],
+            'error' => [Level::Error, \FRANKENPHP_LOG_LEVEL_ERROR],
+            'critical' => [Level::Critical, 12],
+            'alert' => [Level::Alert, 16],
+            'emergency' => [Level::Emergency, 20],
+        ];
     }
 }

--- a/tests/Monolog/Handler/FrankenPhpHandlerTest.php
+++ b/tests/Monolog/Handler/FrankenPhpHandlerTest.php
@@ -18,6 +18,10 @@ class FrankenPhpHandlerTest extends \Monolog\Test\MonologTestCase
      */
     public function testConstructorThrowsWhenFrankenPhpIsNotAvailable()
     {
+        if (\function_exists('frankenphp_log')) {
+            $this->markTestSkipped('Running under FrankenPHP, the constructor does not throw');
+        }
+
         $this->expectException(MissingExtensionException::class);
 
         new FrankenPhpHandler();

--- a/tests/e2e/frankenphp/public/index.php
+++ b/tests/e2e/frankenphp/public/index.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require '/app/source/vendor/autoload.php';
+
+use Monolog\Handler\FrankenPhpHandler;
+use Monolog\Level;
+use Monolog\Logger;
+
+$logger = new Logger('e2e');
+$logger->pushHandler(new FrankenPhpHandler(Level::Debug));
+$logger->warning('Hello from Monolog via FrankenPHP', ['foo' => 'bar']);
+$logger->critical('Custom FrankenPHP level');
+
+echo 'OK';


### PR DESCRIPTION
Adds a handler for [FrankenPHP's `frankenphp_log()`](https://frankenphp.dev/docs/logging/#frankenphp_log), which writes structured logs through FrankenPHP's Go `log/slog`-based logger instead of `error_log()`.

- Guards on `function_exists('frankenphp_log')` in the constructor, throwing `MissingExtensionException` outside FrankenPHP (same pattern as `ZendMonitorHandler`).
- Maps Monolog's 8 levels onto slog's level scale: the official `FRANKENPHP_LOG_LEVEL_*` constants for Debug/Info/Warning/Error, and custom ints for Notice/Critical/Alert/Emergency following slog's documented gap-of-4 convention for intermediate levels (see the docblock on `FrankenPhpHandler::toFrankenPhpLevel()`).
- `FrankenPhpHandlerE2ETest` (tagged `#[Group('e2e')]`) makes real HTTP calls to a FrankenPHP server and inspects its structured log output, skipping itself if no server is reachable. CI runs it against `dunglas/frankenphp:latest` via a `services:` container in `.github/workflows/frankenphp-e2e.yml`.