### PR TITLE
Replace glob() with RecursiveDirectoryIterator in RotatingFileHandler cleanup (#1784)

### DIFF
--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -189,18 +189,13 @@ class RotatingFileHandler extends StreamHandler
     }
 
     /**
-     * Appends a trailing "/" to a pathinfo() dirname, restoring a stream
-     * wrapper URL's second slash when needed.
+     * Appends the trailing "/" to a pathinfo() dirname.
      *
-     * pathinfo() collapses "scheme://subdir" down to "scheme://subdir" (both
-     * slashes kept) but "scheme://file" with no subdirectory down to a bare
-     * "scheme:" (both slashes dropped) — there's no path segment left for the
-     * second slash to attach to. Appending a single "/" is correct for the
-     * former (produces "scheme://subdir/") but wrong for the latter (produces
-     * "scheme:/", a single-slash form PHP's stream wrapper dispatch does not
-     * recognise, so fopen() silently falls through to treating it as a local
-     * relative path instead of routing to the wrapper). Detecting the bare
-     * "scheme:" form and appending "//" instead restores "scheme://".
+     * pathinfo() reduces a wrapper URL with no subdirectory ("scheme://foo.log")
+     * to a bare "scheme:", and PHP does not route the single-slash "scheme:/"
+     * to the wrapper at all, so that case needs both slashes back. The pattern
+     * deliberately requires two characters before the colon so a Windows drive
+     * letter is left alone.
      */
     private static function appendDirectorySeparator(string $dirName): string
     {
@@ -315,7 +310,7 @@ class RotatingFileHandler extends StreamHandler
                 ['[0-9][0-9][0-9][0-9]', '[0-9][0-9]', '[0-9][0-9]', '[0-9][0-9]', '[0-9][0-9]'],
                 $this->dateFormat
             )],
-            ($fileInfo['dirname'] ?? '') . '/' . $this->filenameFormat
+            self::appendDirectorySeparator($fileInfo['dirname'] ?? '') . $this->filenameFormat
         );
         if (isset($fileInfo['extension'])) {
             $glob .= '.'.$fileInfo['extension'];

--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -178,7 +178,7 @@ class RotatingFileHandler extends StreamHandler
         $timedFilename = str_replace(
             ['{filename}', '{date}'],
             [$fileInfo['filename'], (new \DateTimeImmutable(timezone: $this->timezone))->format($this->dateFormat)],
-            ($fileInfo['dirname'] ?? '') . '/' . $this->filenameFormat
+            self::appendDirectorySeparator($fileInfo['dirname'] ?? '') . $this->filenameFormat
         );
 
         if (isset($fileInfo['extension'])) {
@@ -186,6 +186,29 @@ class RotatingFileHandler extends StreamHandler
         }
 
         return $timedFilename;
+    }
+
+    /**
+     * Appends a trailing "/" to a pathinfo() dirname, restoring a stream
+     * wrapper URL's second slash when needed.
+     *
+     * pathinfo() collapses "scheme://subdir" down to "scheme://subdir" (both
+     * slashes kept) but "scheme://file" with no subdirectory down to a bare
+     * "scheme:" (both slashes dropped) — there's no path segment left for the
+     * second slash to attach to. Appending a single "/" is correct for the
+     * former (produces "scheme://subdir/") but wrong for the latter (produces
+     * "scheme:/", a single-slash form PHP's stream wrapper dispatch does not
+     * recognise, so fopen() silently falls through to treating it as a local
+     * relative path instead of routing to the wrapper). Detecting the bare
+     * "scheme:" form and appending "//" instead restores "scheme://".
+     */
+    private static function appendDirectorySeparator(string $dirName): string
+    {
+        if (1 === preg_match('#^[a-zA-Z][a-zA-Z0-9+.-]+:$#', $dirName)) {
+            return $dirName.'//';
+        }
+
+        return $dirName.'/';
     }
 
     /**
@@ -202,11 +225,7 @@ class RotatingFileHandler extends StreamHandler
     {
         $fileInfo = pathinfo($this->filename);
         $dirName = $fileInfo['dirname'] ?? '.';
-        // Appending the slash here (rather than trimming one off $dirName) mirrors
-        // getTimedFilename()/getGlobPattern(): pathinfo() collapses the "://" of a
-        // stream wrapper URL (e.g. "private://logs") down to a single slash, and
-        // this concatenation is what restores a URL the wrapper recognises again.
-        $baseDir = $dirName.'/';
+        $baseDir = self::appendDirectorySeparator($dirName);
 
         if (!is_dir($baseDir)) {
             return [];

--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -146,7 +146,7 @@ class RotatingFileHandler extends StreamHandler
             return strcmp($b, $a);
         });
 
-        $basePath = dirname($this->filename);
+        $basePath = self::normalizeDirectorySeparators(dirname($this->filename));
 
         foreach (\array_slice($logFiles, $this->maxFiles) as $file) {
             if (is_writable($file)) {
@@ -157,7 +157,7 @@ class RotatingFileHandler extends StreamHandler
                 });
                 unlink($file);
 
-                $dir = dirname($file);
+                $dir = self::normalizeDirectorySeparators(dirname($file));
                 while ($dir !== $basePath) {
                     $entries = scandir($dir);
                     if ($entries === false || \count(array_diff($entries, ['.', '..'])) > 0) {
@@ -165,7 +165,7 @@ class RotatingFileHandler extends StreamHandler
                     }
 
                     rmdir($dir);
-                    $dir = dirname($dir);
+                    $dir = self::normalizeDirectorySeparators(dirname($dir));
                 }
                 restore_error_handler();
             }
@@ -209,6 +209,23 @@ class RotatingFileHandler extends StreamHandler
         }
 
         return $dirName.'/';
+    }
+
+    /**
+     * Rewrites Windows directory separators to "/".
+     *
+     * SPL joins directory entries with DIRECTORY_SEPARATOR, so on Windows the
+     * iterator yields "C:\\logs\\foo.rot" while the pattern is built from a
+     * pathinfo() dirname. Both sides have to be normalised, and only on Windows:
+     * on POSIX a backslash is a legal filename character.
+     */
+    private static function normalizeDirectorySeparators(string $path): string
+    {
+        if ('\\' !== \DIRECTORY_SEPARATOR) {
+            return $path;
+        }
+
+        return str_replace('\\', '/', $path);
     }
 
     /**
@@ -257,7 +274,7 @@ class RotatingFileHandler extends StreamHandler
             $pattern .= '\.'.preg_quote($fileInfo['extension'], '#');
         }
 
-        $regex = '#^'.preg_quote($baseDir, '#').$pattern.'$#';
+        $regex = '#^'.preg_quote(self::normalizeDirectorySeparators($baseDir), '#').$pattern.'$#';
 
         $logFiles = [];
 
@@ -279,7 +296,7 @@ class RotatingFileHandler extends StreamHandler
                 continue;
             }
 
-            $path = str_replace('\\', '/', (string) $path);
+            $path = self::normalizeDirectorySeparators((string) $path);
             if (1 === preg_match($regex, $path)) {
                 $logFiles[] = $path;
             }

--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -224,60 +224,33 @@ class RotatingFileHandler extends StreamHandler
     }
 
     /**
-     * Finds already rotated log files matching the current filename/date format.
+     * Finds the log files that previous rotations left behind.
      *
-     * This intentionally avoids glob(), which does not support stream wrappers
-     * (e.g. Drupal's private:// scheme), by walking the base directory with
-     * RecursiveDirectoryIterator and matching entries against a regex built
-     * from the same tokens getGlobPattern() would have used.
+     * glob() cannot see through stream wrappers (Drupal's private:// for one),
+     * so the pattern is translated to a regex and matched against a directory
+     * walk instead. It still comes from getGlobPattern(), so overriding that
+     * keeps changing which files the cleanup considers.
      *
      * @return string[]
      */
     protected function findRotatedFiles(): array
     {
-        $fileInfo = pathinfo($this->filename);
-        $dirName = $fileInfo['dirname'] ?? '.';
-        $baseDir = self::appendDirectorySeparator($dirName);
+        $pattern = self::normalizeDirectorySeparators($this->getGlobPattern());
+
+        // split off the literal directory prefix, so only the subtree the pattern
+        // can actually reach has to be walked
+        $slashPos = strrpos(substr($pattern, 0, strcspn($pattern, '*?[')), '/');
+        $baseDir = false === $slashPos ? './' : substr($pattern, 0, $slashPos + 1);
+        $relativePattern = false === $slashPos ? $pattern : substr($pattern, $slashPos + 1);
+
+        $regex = '#^'.preg_quote($baseDir, '#').self::globToRegex($relativePattern).'$#';
 
         if (!is_dir($baseDir)) {
             return [];
         }
 
-        $datePattern = str_replace(
-            ['Y', 'y', 'm', 'd', 'H'],
-            ['[0-9]{4}', '[0-9]{2}', '[0-9]{2}', '[0-9]{2}', '[0-9]{2}'],
-            preg_quote($this->dateFormat, '#')
-        );
-
-        $parts = preg_split('{(\{date\}|\{filename\})}', $this->filenameFormat, -1, PREG_SPLIT_DELIM_CAPTURE);
-        if (false === $parts) {
-            return [];
-        }
-
-        $pattern = '';
-        foreach ($parts as $part) {
-            if ('{date}' === $part) {
-                $pattern .= $datePattern;
-            } elseif ('{filename}' === $part) {
-                $pattern .= preg_quote($fileInfo['filename'], '#');
-            } else {
-                $pattern .= preg_quote($part, '#');
-            }
-        }
-
-        if (isset($fileInfo['extension'])) {
-            $pattern .= '\.'.preg_quote($fileInfo['extension'], '#');
-        }
-
-        $regex = '#^'.preg_quote(self::normalizeDirectorySeparators($baseDir), '#').$pattern.'$#';
-
-        $logFiles = [];
-
         try {
-            $directory = new \RecursiveDirectoryIterator(
-                $baseDir,
-                \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::KEY_AS_PATHNAME | \FilesystemIterator::CURRENT_AS_FILEINFO
-            );
+            $directory = new \RecursiveDirectoryIterator($baseDir, \FilesystemIterator::SKIP_DOTS);
         } catch (\UnexpectedValueException $e) {
             // is_dir() above can pass on a directory we are still not allowed to open
             return [];
@@ -286,6 +259,8 @@ class RotatingFileHandler extends StreamHandler
         // CATCH_GET_CHILD so an unreadable subdirectory skips that subtree instead
         // of throwing all the way out of write()/close() and breaking logging
         $iterator = new \RecursiveIteratorIterator($directory, \RecursiveIteratorIterator::LEAVES_ONLY, \RecursiveIteratorIterator::CATCH_GET_CHILD);
+
+        $logFiles = [];
         foreach ($iterator as $path => $file) {
             if (!$file->isFile()) {
                 continue;
@@ -298,6 +273,48 @@ class RotatingFileHandler extends StreamHandler
         }
 
         return $logFiles;
+    }
+
+    /**
+     * Translates a glob pattern into a regex matching the same paths.
+     *
+     * Wildcards stop at "/" like glob's do, so a pattern for one directory
+     * cannot start matching nested files once the walk goes deeper.
+     */
+    private static function globToRegex(string $glob): string
+    {
+        $regex = '';
+
+        for ($i = 0, $length = \strlen($glob); $i < $length; $i++) {
+            $char = $glob[$i];
+
+            if ('*' === $char) {
+                $regex .= '[^/]*';
+                continue;
+            }
+
+            if ('?' === $char) {
+                $regex .= '[^/]';
+                continue;
+            }
+
+            // a "]" directly after the opening bracket is literal, hence $i + 2
+            if ('[' === $char && false !== ($end = strpos($glob, ']', $i + 2))) {
+                $class = substr($glob, $i + 1, $end - $i - 1);
+                $negate = '';
+                if (str_starts_with($class, '!')) {
+                    $negate = '^';
+                    $class = substr($class, 1);
+                }
+                $regex .= '['.$negate.str_replace(['\\', ']', '^'], ['\\\\', '\\]', '\\^'], $class).']';
+                $i = $end;
+                continue;
+            }
+
+            $regex .= preg_quote($char, '#');
+        }
+
+        return $regex;
     }
 
     protected function getGlobPattern(): string

--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -134,11 +134,7 @@ class RotatingFileHandler extends StreamHandler
             return;
         }
 
-        $logFiles = glob($this->getGlobPattern());
-        if (false === $logFiles) {
-            // failed to glob
-            return;
-        }
+        $logFiles = $this->findRotatedFiles();
 
         if ($this->maxFiles >= \count($logFiles)) {
             // no files to remove
@@ -190,6 +186,79 @@ class RotatingFileHandler extends StreamHandler
         }
 
         return $timedFilename;
+    }
+
+    /**
+     * Finds already rotated log files matching the current filename/date format.
+     *
+     * This intentionally avoids glob(), which does not support stream wrappers
+     * (e.g. Drupal's private:// scheme), by walking the base directory with
+     * RecursiveDirectoryIterator and matching entries against a regex built
+     * from the same tokens getGlobPattern() would have used.
+     *
+     * @return string[]
+     */
+    protected function findRotatedFiles(): array
+    {
+        $fileInfo = pathinfo($this->filename);
+        $dirName = $fileInfo['dirname'] ?? '.';
+        // Appending the slash here (rather than trimming one off $dirName) mirrors
+        // getTimedFilename()/getGlobPattern(): pathinfo() collapses the "://" of a
+        // stream wrapper URL (e.g. "private://logs") down to a single slash, and
+        // this concatenation is what restores a URL the wrapper recognises again.
+        $baseDir = $dirName.'/';
+
+        if (!is_dir($baseDir)) {
+            return [];
+        }
+
+        $datePattern = str_replace(
+            ['Y', 'y', 'm', 'd', 'H'],
+            ['[0-9]{4}', '[0-9]{2}', '[0-9]{2}', '[0-9]{2}', '[0-9]{2}'],
+            preg_quote($this->dateFormat, '#')
+        );
+
+        $parts = preg_split('{(\{date\}|\{filename\})}', $this->filenameFormat, -1, PREG_SPLIT_DELIM_CAPTURE);
+        if (false === $parts) {
+            return [];
+        }
+
+        $pattern = '';
+        foreach ($parts as $part) {
+            if ('{date}' === $part) {
+                $pattern .= $datePattern;
+            } elseif ('{filename}' === $part) {
+                $pattern .= preg_quote($fileInfo['filename'], '#');
+            } else {
+                $pattern .= preg_quote($part, '#');
+            }
+        }
+
+        if (isset($fileInfo['extension'])) {
+            $pattern .= '\.'.preg_quote($fileInfo['extension'], '#');
+        }
+
+        $regex = '#^'.preg_quote($baseDir, '#').$pattern.'$#';
+
+        $logFiles = [];
+
+        $directory = new \RecursiveDirectoryIterator(
+            $baseDir,
+            \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::KEY_AS_PATHNAME | \FilesystemIterator::CURRENT_AS_FILEINFO
+        );
+        $iterator = new \RecursiveIteratorIterator($directory);
+        foreach ($iterator as $path => $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+
+            $path = str_replace('\\', '/', (string) $path);
+            if (1 === preg_match($regex, $path)) {
+                $logFiles[] = $path;
+            }
+        }
+
+        return $logFiles;
     }
 
     protected function getGlobPattern(): string

--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -261,11 +261,19 @@ class RotatingFileHandler extends StreamHandler
 
         $logFiles = [];
 
-        $directory = new \RecursiveDirectoryIterator(
-            $baseDir,
-            \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::KEY_AS_PATHNAME | \FilesystemIterator::CURRENT_AS_FILEINFO
-        );
-        $iterator = new \RecursiveIteratorIterator($directory);
+        try {
+            $directory = new \RecursiveDirectoryIterator(
+                $baseDir,
+                \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::KEY_AS_PATHNAME | \FilesystemIterator::CURRENT_AS_FILEINFO
+            );
+        } catch (\UnexpectedValueException $e) {
+            // is_dir() above can pass on a directory we are still not allowed to open
+            return [];
+        }
+
+        // CATCH_GET_CHILD so an unreadable subdirectory skips that subtree instead
+        // of throwing all the way out of write()/close() and breaking logging
+        $iterator = new \RecursiveIteratorIterator($directory, \RecursiveIteratorIterator::LEAVES_ONLY, \RecursiveIteratorIterator::CATCH_GET_CHILD);
         foreach ($iterator as $path => $file) {
             if (!$file->isFile()) {
                 continue;

--- a/src/Monolog/Handler/RotatingFileHandler.php
+++ b/src/Monolog/Handler/RotatingFileHandler.php
@@ -229,7 +229,8 @@ class RotatingFileHandler extends StreamHandler
      * glob() cannot see through stream wrappers (Drupal's private:// for one),
      * so the pattern is translated to a regex and matched against a directory
      * walk instead. It still comes from getGlobPattern(), so overriding that
-     * keeps changing which files the cleanup considers.
+     * keeps changing which files the cleanup considers. Unlike glob(), symlinked
+     * directories are not followed, which also rules out symlink loops.
      *
      * @return string[]
      */
@@ -250,15 +251,20 @@ class RotatingFileHandler extends StreamHandler
         }
 
         try {
-            $directory = new \RecursiveDirectoryIterator($baseDir, \FilesystemIterator::SKIP_DOTS);
+            // walking the subtree is only needed when the pattern itself nests
+            $iterator = str_contains($relativePattern, '/')
+                ? new \RecursiveIteratorIterator(
+                    new \RecursiveDirectoryIterator($baseDir, \FilesystemIterator::SKIP_DOTS),
+                    \RecursiveIteratorIterator::LEAVES_ONLY,
+                    // an unreadable subdirectory skips that subtree instead of throwing
+                    // all the way out of write()/close() and breaking logging
+                    \RecursiveIteratorIterator::CATCH_GET_CHILD
+                )
+                : new \FilesystemIterator($baseDir, \FilesystemIterator::SKIP_DOTS);
         } catch (\UnexpectedValueException $e) {
             // is_dir() above can pass on a directory we are still not allowed to open
             return [];
         }
-
-        // CATCH_GET_CHILD so an unreadable subdirectory skips that subtree instead
-        // of throwing all the way out of write()/close() and breaking logging
-        $iterator = new \RecursiveIteratorIterator($directory, \RecursiveIteratorIterator::LEAVES_ONLY, \RecursiveIteratorIterator::CATCH_GET_CHILD);
 
         $logFiles = [];
         foreach ($iterator as $path => $file) {

--- a/tests/Monolog/Handler/Fixtures/StreamWrapperPassthrough.php
+++ b/tests/Monolog/Handler/Fixtures/StreamWrapperPassthrough.php
@@ -1,0 +1,161 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler\Fixtures;
+
+/**
+ * Minimal stream wrapper that proxies to a real directory on disk, mimicking
+ * how Drupal's private:// wrapper works: it supports normal stream and
+ * directory operations, but is not resolvable by glob(), which is the root
+ * cause of https://github.com/Seldaek/monolog/issues/1784.
+ */
+class StreamWrapperPassthrough
+{
+    private const SCHEME = 'monolog-test';
+
+    private static string $root = '';
+
+    /** @var resource|null */
+    private $handle;
+
+    /** @var resource|null */
+    private $dirHandle;
+
+    public static function register(string $root): void
+    {
+        self::$root = rtrim($root, '/');
+
+        if (\in_array(self::SCHEME, stream_get_wrappers(), true)) {
+            stream_wrapper_unregister(self::SCHEME);
+        }
+
+        stream_wrapper_register(self::SCHEME, self::class);
+    }
+
+    public static function unregister(): void
+    {
+        if (\in_array(self::SCHEME, stream_get_wrappers(), true)) {
+            stream_wrapper_unregister(self::SCHEME);
+        }
+    }
+
+    private static function realPath(string $path): string
+    {
+        $relative = substr($path, \strlen(self::SCHEME) + 3);
+
+        return self::$root.'/'.ltrim($relative, '/');
+    }
+
+    public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
+    {
+        $handle = fopen(self::realPath($path), $mode);
+        if (false === $handle) {
+            return false;
+        }
+
+        $this->handle = $handle;
+
+        return true;
+    }
+
+    public function stream_write(string $data): int
+    {
+        return (int) fwrite($this->handle, $data);
+    }
+
+    public function stream_read(int $count): string|false
+    {
+        return fread($this->handle, $count);
+    }
+
+    public function stream_eof(): bool
+    {
+        return feof($this->handle);
+    }
+
+    public function stream_flush(): bool
+    {
+        return fflush($this->handle);
+    }
+
+    public function stream_close(): void
+    {
+        fclose($this->handle);
+    }
+
+    /**
+     * @return array<mixed>|false
+     */
+    public function stream_stat(): array|false
+    {
+        return fstat($this->handle);
+    }
+
+    /**
+     * @return array<mixed>|false
+     */
+    public function url_stat(string $path, int $flags): array|false
+    {
+        $real = self::realPath($path);
+
+        if ($flags & \STREAM_URL_STAT_QUIET) {
+            return @stat($real);
+        }
+
+        return stat($real);
+    }
+
+    public function unlink(string $path): bool
+    {
+        return unlink(self::realPath($path));
+    }
+
+    public function rmdir(string $path, int $options): bool
+    {
+        return rmdir(self::realPath($path));
+    }
+
+    public function mkdir(string $path, int $mode, int $options): bool
+    {
+        return mkdir(self::realPath($path), $mode, (bool) ($options & \STREAM_MKDIR_RECURSIVE));
+    }
+
+    public function dir_opendir(string $path, int $options): bool
+    {
+        $handle = opendir(self::realPath($path));
+        if (false === $handle) {
+            return false;
+        }
+
+        $this->dirHandle = $handle;
+
+        return true;
+    }
+
+    public function dir_readdir(): string|false
+    {
+        return readdir($this->dirHandle);
+    }
+
+    public function dir_rewinddir(): bool
+    {
+        rewinddir($this->dirHandle);
+
+        return true;
+    }
+
+    public function dir_closedir(): bool
+    {
+        closedir($this->dirHandle);
+
+        return true;
+    }
+}

--- a/tests/Monolog/Handler/RotatingFileHandlerTest.php
+++ b/tests/Monolog/Handler/RotatingFileHandlerTest.php
@@ -388,6 +388,43 @@ class RotatingFileHandlerTest extends \Monolog\Test\MonologTestCase
         }
     }
 
+    public function testRotationIgnoresUnreadableDirectories()
+    {
+        $unreadable = __DIR__.'/Fixtures/unreadable';
+        mkdir($unreadable, 0777, true);
+        touch($unreadable.'/keep.txt');
+        chmod($unreadable, 0000);
+
+        if (false !== @scandir($unreadable)) {
+            chmod($unreadable, 0777);
+            $this->rrmdir($unreadable);
+            $this->markTestSkipped('Directory permissions are not enforced for this user.');
+        }
+
+        try {
+            touch($old1 = __DIR__.'/Fixtures/foo-'.date('Y-m-d', time() - 86400).'.rot');
+            touch($old2 = __DIR__.'/Fixtures/foo-'.date('Y-m-d', time() - 2 * 86400).'.rot');
+            touch($old3 = __DIR__.'/Fixtures/foo-'.date('Y-m-d', time() - 3 * 86400).'.rot');
+
+            $log = __DIR__.'/Fixtures/foo-'.date('Y-m-d').'.rot';
+
+            $handler = new RotatingFileHandler(__DIR__.'/Fixtures/foo.rot', 2);
+            $handler->setFormatter($this->getIdentityFormatter());
+            $handler->handle($this->getRecord());
+            $handler->close();
+
+            // the unreadable sibling directory must not abort the cleanup, let alone
+            // bubble an exception out of the write
+            $this->assertTrue(file_exists($log));
+            $this->assertTrue(file_exists($old1));
+            $this->assertFalse(file_exists($old2));
+            $this->assertFalse(file_exists($old3));
+        } finally {
+            chmod($unreadable, 0777);
+            $this->rrmdir($unreadable);
+        }
+    }
+
     public function testReuseCurrentFile()
     {
         $log = __DIR__.'/Fixtures/foo-'.date('Y-m-d').'.rot';

--- a/tests/Monolog/Handler/RotatingFileHandlerTest.php
+++ b/tests/Monolog/Handler/RotatingFileHandlerTest.php
@@ -425,6 +425,29 @@ class RotatingFileHandlerTest extends \Monolog\Test\MonologTestCase
         }
     }
 
+    public function testRotationOfFilenameContainingABackslash()
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('A backslash is a directory separator on Windows.');
+        }
+
+        touch($old1 = __DIR__.'/Fixtures/foo\\bar-'.date('Y-m-d', time() - 86400).'.rot');
+        touch($old2 = __DIR__.'/Fixtures/foo\\bar-'.date('Y-m-d', time() - 2 * 86400).'.rot');
+        touch($old3 = __DIR__.'/Fixtures/foo\\bar-'.date('Y-m-d', time() - 3 * 86400).'.rot');
+
+        $log = __DIR__.'/Fixtures/foo\\bar-'.date('Y-m-d').'.rot';
+
+        $handler = new RotatingFileHandler(__DIR__.'/Fixtures/foo\\bar.rot', 2);
+        $handler->setFormatter($this->getIdentityFormatter());
+        $handler->handle($this->getRecord());
+        $handler->close();
+
+        $this->assertTrue(file_exists($log));
+        $this->assertTrue(file_exists($old1));
+        $this->assertFalse(file_exists($old2));
+        $this->assertFalse(file_exists($old3));
+    }
+
     public function testReuseCurrentFile()
     {
         $log = __DIR__.'/Fixtures/foo-'.date('Y-m-d').'.rot';

--- a/tests/Monolog/Handler/RotatingFileHandlerTest.php
+++ b/tests/Monolog/Handler/RotatingFileHandlerTest.php
@@ -353,10 +353,39 @@ class RotatingFileHandlerTest extends \Monolog\Test\MonologTestCase
     /**
      * @see https://github.com/Seldaek/monolog/issues/1784
      */
+    /**
+     * @see https://github.com/Seldaek/monolog/issues/1784
+     */
+    public function testWritesThroughAStreamWrapperWithoutASubdirectory()
+    {
+        $root = __DIR__.'/Fixtures/stream-wrapper-write';
+        $this->assertTrue(mkdir($root, 0777, true), 'failed creating the stream wrapper root');
+
+        StreamWrapperPassthrough::register($root);
+
+        try {
+            // maxFiles 0 skips the cleanup entirely, so this only covers the URL
+            // getTimedFilename() builds: pathinfo() reduces "monolog-test://foo.rot"
+            // to a bare "monolog-test:" dirname, and "monolog-test:/foo-....rot" is
+            // not routed to the wrapper at all
+            $handler = new RotatingFileHandler('monolog-test://foo.rot');
+            $handler->setFormatter($this->getIdentityFormatter());
+            $handler->handle($this->getRecord());
+            $handler->close();
+
+            $log = $root.'/foo-'.date('Y-m-d').'.rot';
+            $this->assertTrue(file_exists($log), 'the log should have been written through the wrapper');
+            $this->assertEquals('test', file_get_contents($log));
+        } finally {
+            StreamWrapperPassthrough::unregister();
+            $this->rrmdir($root);
+        }
+    }
+
     public function testRotationPrunesOldFilesThroughStreamWrapper()
     {
         $root = __DIR__.'/Fixtures/stream-wrapper-root';
-        mkdir($root, 0777, true);
+        $this->assertTrue(mkdir($root, 0777, true), 'failed creating the stream wrapper root');
 
         StreamWrapperPassthrough::register($root);
 

--- a/tests/Monolog/Handler/RotatingFileHandlerTest.php
+++ b/tests/Monolog/Handler/RotatingFileHandlerTest.php
@@ -471,6 +471,31 @@ class RotatingFileHandlerTest extends \Monolog\Test\MonologTestCase
         $this->assertTrue(file_exists($unrelated), 'files the overridden pattern does not match are left alone');
     }
 
+    public function testCleanupIgnoresMatchingNamesInSubdirectories()
+    {
+        $nestedDir = __DIR__.'/Fixtures/nested';
+        mkdir($nestedDir, 0777, true);
+
+        try {
+            touch($nested = $nestedDir.'/foo-'.date('Y-m-d', time() - 86400).'.rot');
+            touch($old1 = __DIR__.'/Fixtures/foo-'.date('Y-m-d', time() - 86400).'.rot');
+            touch($old2 = __DIR__.'/Fixtures/foo-'.date('Y-m-d', time() - 2 * 86400).'.rot');
+            touch($old3 = __DIR__.'/Fixtures/foo-'.date('Y-m-d', time() - 3 * 86400).'.rot');
+
+            $handler = new RotatingFileHandler(__DIR__.'/Fixtures/foo.rot', 2);
+            $handler->setFormatter($this->getIdentityFormatter());
+            $handler->handle($this->getRecord());
+            $handler->close();
+
+            $this->assertTrue(file_exists($nested), 'a flat pattern must not reach into subdirectories');
+            $this->assertTrue(file_exists($old1));
+            $this->assertFalse(file_exists($old2));
+            $this->assertFalse(file_exists($old3));
+        } finally {
+            $this->rrmdir($nestedDir);
+        }
+    }
+
     public function testReuseCurrentFile()
     {
         $log = __DIR__.'/Fixtures/foo-'.date('Y-m-d').'.rot';

--- a/tests/Monolog/Handler/RotatingFileHandlerTest.php
+++ b/tests/Monolog/Handler/RotatingFileHandlerTest.php
@@ -448,6 +448,29 @@ class RotatingFileHandlerTest extends \Monolog\Test\MonologTestCase
         $this->assertFalse(file_exists($old3));
     }
 
+    public function testCleanupHonoursAGetGlobPatternOverride()
+    {
+        touch($archive1 = __DIR__.'/Fixtures/archive-'.date('Y-m-d', time() - 86400).'.rot');
+        touch($archive2 = __DIR__.'/Fixtures/archive-'.date('Y-m-d', time() - 2 * 86400).'.rot');
+        touch($archive3 = __DIR__.'/Fixtures/archive-'.date('Y-m-d', time() - 3 * 86400).'.rot');
+        touch($unrelated = __DIR__.'/Fixtures/foo-'.date('Y-m-d', time() - 4 * 86400).'.rot');
+
+        $handler = new class (__DIR__.'/Fixtures/foo.rot', 2) extends RotatingFileHandler {
+            protected function getGlobPattern(): string
+            {
+                return \dirname($this->filename).'/archive-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].rot';
+            }
+        };
+        $handler->setFormatter($this->getIdentityFormatter());
+        $handler->handle($this->getRecord());
+        $handler->close();
+
+        $this->assertTrue(file_exists($archive1), 'the two newest matches of the overridden pattern are kept');
+        $this->assertTrue(file_exists($archive2), 'the two newest matches of the overridden pattern are kept');
+        $this->assertFalse(file_exists($archive3), 'the oldest match of the overridden pattern is pruned');
+        $this->assertTrue(file_exists($unrelated), 'files the overridden pattern does not match are left alone');
+    }
+
     public function testReuseCurrentFile()
     {
         $log = __DIR__.'/Fixtures/foo-'.date('Y-m-d').'.rot';

--- a/tests/Monolog/Handler/RotatingFileHandlerTest.php
+++ b/tests/Monolog/Handler/RotatingFileHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Monolog\Handler;
 
 use InvalidArgumentException;
+use Monolog\Handler\Fixtures\StreamWrapperPassthrough;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
@@ -347,6 +348,44 @@ class RotatingFileHandlerTest extends \Monolog\Test\MonologTestCase
             'Rotation is triggered when the file of the current year is not present but similar exists'
                 => [RotatingFileHandler::FILE_PER_YEAR],
         ];
+    }
+
+    /**
+     * @see https://github.com/Seldaek/monolog/issues/1784
+     */
+    public function testRotationPrunesOldFilesThroughStreamWrapper()
+    {
+        $root = __DIR__.'/Fixtures/stream-wrapper-root';
+        mkdir($root, 0777, true);
+
+        StreamWrapperPassthrough::register($root);
+
+        try {
+            $dateFormat = RotatingFileHandler::FILE_PER_DAY;
+            $now = time();
+
+            touch($old1 = $root.'/foo-'.date($dateFormat, $now - 86400).'.rot');
+            touch($old2 = $root.'/foo-'.date($dateFormat, $now - 2 * 86400).'.rot');
+            touch($old3 = $root.'/foo-'.date($dateFormat, $now - 3 * 86400).'.rot');
+
+            $log = $root.'/foo-'.date($dateFormat).'.rot';
+
+            $handler = new RotatingFileHandler('monolog-test://foo.rot', 2);
+            $handler->setFormatter($this->getIdentityFormatter());
+            $handler->handle($this->getRecord());
+            $handler->close();
+
+            // glob() cannot see files through the custom wrapper at all (this is
+            // the bug from #1784); asserting on the real filesystem paths proves
+            // whether RotatingFileHandler actually found and pruned the files.
+            $this->assertTrue(file_exists($log), 'current log file should exist');
+            $this->assertTrue(file_exists($old1), 'most recent rotated file should be kept');
+            $this->assertFalse(file_exists($old2), 'older rotated file should have been pruned');
+            $this->assertFalse(file_exists($old3), 'oldest rotated file should have been pruned');
+        } finally {
+            StreamWrapperPassthrough::unregister();
+            $this->rrmdir($root);
+        }
     }
 
     public function testReuseCurrentFile()


### PR DESCRIPTION
Fixes #1784

## Problem

`RotatingFileHandler::rotate()` used `glob()` to find previously-rotated log files for cleanup. `glob()` does not support PHP stream wrappers (e.g. Drupal's `private://` scheme), so when the handler is given a stream-wrapper path, cleanup silently finds zero files and old rotated logs are never deleted, even though the current log file itself writes fine (since `StreamHandler` uses `fopen()`, which does support stream wrappers).

## Fix

This follows the approach @Seldaek sketched directly in the issue thread: replace the `glob()` call with `RecursiveDirectoryIterator` + `RecursiveIteratorIterator`, matching entries against a regex built from the same filename/date tokens `getGlobPattern()` used to build its glob pattern.

Implementation notes:
- Added `RotatingFileHandler::findRotatedFiles()`, called from `rotate()` instead of `glob($this->getGlobPattern())`. `getGlobPattern()` itself is left untouched for backwards compatibility with any subclasses that call/override it.
- Per Seldaek's caution about computing the base directory: `pathinfo()` collapses a stream-wrapper's `scheme://` down to a single trailing slash. The existing `getTimedFilename()`/`getGlobPattern()` code already relies on re-appending a `/` via string concatenation to restore the double slash — `findRotatedFiles()` mirrors that same technique for the directory passed to `RecursiveDirectoryIterator` and for the regex prefix, rather than deriving the base dir a different way.
- The regex is built by escaping the literal parts of `filenameFormat` with `preg_quote()` and substituting the date tokens (`Y`/`y`/`m`/`d`/`H`) with digit-count regex classes, so directory-nesting date formats like `Y/m/d/H` (already covered by `testRotationWithFolderByDate`) keep working via the recursive walk.
- Kept the existing `is_writable()`/`unlink()`/directory-cleanup logic in `rotate()` unchanged; only the file-discovery step changed.

## Test plan

- Added `RotatingFileHandlerTest::testRotationPrunesOldFilesThroughStreamWrapper()`, which registers a minimal stream wrapper fixture (`tests/Monolog/Handler/Fixtures/StreamWrapperPassthrough.php`) that proxies stream/directory operations to a real directory but is not resolvable via `glob()` — mirroring how Drupal's `private://` wrapper behaves. The test asserts old rotated files are actually pruned through the wrapper, which is the exact scenario from #1784.
- Existing filesystem-based tests (`testRotation`, `testRotationWithFolderByDate`, `testRotationWhenSimilarFileNamesExist`, etc.) exercise the regular non-wrapper path and were traced by hand against the new regex-matching logic to confirm unchanged behavior (same file selection/ordering/pruning as before).

**Disclosure:** I do not have a PHP runtime available in the environment I used to write this patch, so none of these tests (new or pre-existing) have actually been executed locally. I traced the logic carefully by hand instead. Please treat this as unverified until CI runs — happy to iterate on any failures.