### PR TITLE
Report stack trace frames that have no file/line instead of skipping them

### DIFF
--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -317,6 +317,20 @@ class NormalizerFormatter implements FormatterInterface
                     $file = preg_replace('{^'.preg_quote($this->basePath).'}', '', $file);
                 }
                 $data['trace'][] = $file.':'.$frame['line'];
+            } else {
+                // Frames called by the engine itself have no file/line: shutdown functions,
+                // callbacks run by internal functions, destructors. Skipping them made traces
+                // look shorter than they were, and entirely empty for fatal errors caught in a
+                // shutdown function, so they are reported by name instead.
+                $call = $frame['function'] ?? 'unknown';
+                if (isset($frame['class'])) {
+                    $call = $frame['class'].'.'.$call;
+                }
+                if ($this->basePath !== '') {
+                    // closure names embed the file they were declared in since PHP 8.4
+                    $call = preg_replace('{'.preg_quote($this->basePath).'}', '', $call);
+                }
+                $data['trace'][] = 'internal['.$call.']:0';
             }
         }
 

--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -324,8 +324,11 @@ class NormalizerFormatter implements FormatterInterface
                 // shutdown function, so they are reported by name instead.
                 $call = $frame['function'] ?? 'unknown';
                 if (isset($frame['class'])) {
-                    $call = $frame['class'].'.'.$call;
+                    $call = Utils::getClassName($frame['class']).'.'.$call;
                 }
+                // anonymous classes carry their declaration site after a NUL byte, which truncates
+                // syslog lines and is not valid JSON; PHP 8.4 embeds it in closure names too
+                $call = preg_replace('{@anonymous\x00.*?\$[0-9a-f]++(?=::|$)}s', '@anonymous', $call) ?? $call;
                 if ($this->basePath !== '') {
                     // closure names embed the file they were declared in since PHP 8.4
                     $call = preg_replace('{'.preg_quote($this->basePath).'}', '', $call);

--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -322,7 +322,7 @@ class NormalizerFormatter implements FormatterInterface
                 // callbacks run by internal functions, destructors. Skipping them made traces
                 // look shorter than they were, and entirely empty for fatal errors caught in a
                 // shutdown function, so they are reported by name instead.
-                $call = $frame['function'] ?? 'unknown';
+                $call = $frame['function'];
                 // since PHP 8.4 a closure is named after its declaring scope, which already
                 // includes the class, so prefixing it again would just repeat it
                 if (isset($frame['class']) && !str_starts_with($call, '{closure:')) {

--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -323,7 +323,9 @@ class NormalizerFormatter implements FormatterInterface
                 // look shorter than they were, and entirely empty for fatal errors caught in a
                 // shutdown function, so they are reported by name instead.
                 $call = $frame['function'] ?? 'unknown';
-                if (isset($frame['class'])) {
+                // since PHP 8.4 a closure is named after its declaring scope, which already
+                // includes the class, so prefixing it again would just repeat it
+                if (isset($frame['class']) && !str_starts_with($call, '{closure:')) {
                     $call = Utils::getClassName($frame['class']).($frame['type'] ?? '::').$call;
                 }
                 // anonymous classes carry their declaration site after a NUL byte, which truncates

--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -326,6 +326,8 @@ class NormalizerFormatter implements FormatterInterface
                 // since PHP 8.4 a closure is named after its declaring scope, which already
                 // includes the class, so prefixing it again would just repeat it
                 if (isset($frame['class']) && !str_starts_with($call, '{closure:')) {
+                    // before 8.4 the name is <namespace>\{closure}, and the class has the namespace
+                    $call = str_ends_with($call, '\{closure}') ? '{closure}' : $call;
                     $call = Utils::getClassName($frame['class']).($frame['type'] ?? '::').$call;
                 }
                 // anonymous classes carry their declaration site after a NUL byte, which truncates

--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -324,7 +324,7 @@ class NormalizerFormatter implements FormatterInterface
                 // shutdown function, so they are reported by name instead.
                 $call = $frame['function'] ?? 'unknown';
                 if (isset($frame['class'])) {
-                    $call = Utils::getClassName($frame['class']).'.'.$call;
+                    $call = Utils::getClassName($frame['class']).($frame['type'] ?? '::').$call;
                 }
                 // anonymous classes carry their declaration site after a NUL byte, which truncates
                 // syslog lines and is not valid JSON; PHP 8.4 embeds it in closure names too

--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -311,12 +311,12 @@ class NormalizerFormatter implements FormatterInterface
 
         $trace = array_slice($e->getTrace(), 0, $this->maxTraceLength);
         foreach ($trace as $frame) {
-            if (isset($frame['file'], $frame['line'])) {
+            if (isset($frame['file'])) {
                 $file = $frame['file'];
                 if ($this->basePath !== '') {
-                    $file = preg_replace('{^'.preg_quote($this->basePath).'}', '', $file);
+                    $file = preg_replace('{^'.preg_quote($this->basePath).'}', '', $file) ?? $file;
                 }
-                $data['trace'][] = $file.':'.$frame['line'];
+                $data['trace'][] = $file.':'.($frame['line'] ?? 0);
             } else {
                 // Frames called by the engine itself have no file/line: shutdown functions,
                 // callbacks run by internal functions, destructors. Skipping them made traces

--- a/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/src/Monolog/Formatter/NormalizerFormatter.php
@@ -330,8 +330,9 @@ class NormalizerFormatter implements FormatterInterface
                 // syslog lines and is not valid JSON; PHP 8.4 embeds it in closure names too
                 $call = preg_replace('{@anonymous\x00.*?\$[0-9a-f]++(?=::|$)}s', '@anonymous', $call) ?? $call;
                 if ($this->basePath !== '') {
-                    // closure names embed the file they were declared in since PHP 8.4
-                    $call = preg_replace('{'.preg_quote($this->basePath).'}', '', $call);
+                    // closure names embed the file they were declared in since PHP 8.4, so the
+                    // pattern cannot be anchored; limit it or a recurring base path is stripped twice
+                    $call = preg_replace('{'.preg_quote($this->basePath).'}', '', $call, 1) ?? $call;
                 }
                 $data['trace'][] = 'internal['.$call.']:0';
             }

--- a/src/Monolog/Utils.php
+++ b/src/Monolog/Utils.php
@@ -23,8 +23,18 @@ final class Utils
 
     public static function getClass(object $object): string
     {
-        $class = \get_class($object);
+        return self::getClassName(\get_class($object));
+    }
 
+    /**
+     * Strips the declaration site PHP appends to anonymous class names after a NUL byte
+     *
+     * Takes the name rather than the object because stack trace frames only carry the string.
+     *
+     * @param class-string $class
+     */
+    public static function getClassName(string $class): string
+    {
         if (false === ($pos = strpos($class, "@anonymous\0"))) {
             return $class;
         }

--- a/tests/Monolog/Formatter/Fixtures/InternalFrameClosure.php
+++ b/tests/Monolog/Formatter/Fixtures/InternalFrameClosure.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+// Declared at file scope on purpose: since PHP 8.4 a closure created there is named
+// after the file it comes from, which is what the base path has to be stripped from.
+return static function (): void {
+    throw new \RuntimeException('Thrown from a file scope closure');
+};

--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -482,6 +482,30 @@ class NormalizerFormatterTest extends \Monolog\Test\MonologTestCase
         $this->assertStringNotContainsString(dirname(__DIR__, 3), $formatted['exception']['trace'][0]);
     }
 
+    public function testExceptionTraceOnlyStripsTheBasePathOnceFromFramesWithoutFileAndLine()
+    {
+        if (PHP_VERSION_ID < 80400) {
+            $this->markTestSkipped('Closures are only named after their declaration site since PHP 8.4');
+        }
+
+        $closure = require __DIR__.'/Fixtures/InternalFrameClosure.php';
+
+        try {
+            array_map($closure, [1]);
+        } catch (\Throwable $e) {
+        }
+
+        $formatter = new NormalizerFormatter();
+        $formatter->setBasePath(DIRECTORY_SEPARATOR);
+        $formatted = $formatter->normalizeValue(['exception' => $e]);
+
+        // only the leading separator may go, every other occurrence has to survive
+        $this->assertStringContainsString(
+            strtr('Monolog/Formatter/Fixtures/InternalFrameClosure.php', '/', DIRECTORY_SEPARATOR),
+            $formatted['exception']['trace'][0]
+        );
+    }
+
     public function testExceptionTraceStripsTheAnonymousClassDeclarationSite()
     {
         $thrower = new class {

--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -483,6 +483,23 @@ class NormalizerFormatterTest extends \Monolog\Test\MonologTestCase
         $this->assertStringNotContainsString(dirname(__DIR__, 3), $formatted['exception']['trace'][0]);
     }
 
+    public function testExceptionTraceReportsFramesWithoutFileAndLineOrClass()
+    {
+        try {
+            // a plain function gets a frame without file/line and without a class either
+            array_map(__NAMESPACE__.'\\throwFromAPlainFunction', [1]);
+        } catch (\Throwable $e) {
+        }
+
+        $formatter = new NormalizerFormatter();
+        $formatted = $formatter->normalizeValue(['exception' => $e]);
+
+        $this->assertSame(
+            'internal['.__NAMESPACE__.'\\throwFromAPlainFunction]:0',
+            $formatted['exception']['trace'][0]
+        );
+    }
+
     public function testExceptionTraceOnlyStripsTheBasePathOnceFromFramesWithoutFileAndLine()
     {
         if (PHP_VERSION_ID < 80400) {
@@ -758,4 +775,9 @@ class TestInternalFrame
     {
         throw new \RuntimeException('Thrown');
     }
+}
+
+function throwFromAPlainFunction(): void
+{
+    throw new \RuntimeException('Thrown');
 }

--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -482,6 +482,57 @@ class NormalizerFormatterTest extends \Monolog\Test\MonologTestCase
         $this->assertStringNotContainsString(dirname(__DIR__, 3), $formatted['exception']['trace'][0]);
     }
 
+    public function testExceptionTraceStripsTheAnonymousClassDeclarationSite()
+    {
+        $thrower = new class {
+            public function boom(): void
+            {
+                throw new \RuntimeException('Thrown from an anonymous class');
+            }
+        };
+
+        try {
+            array_map([$thrower, 'boom'], [1]);
+        } catch (\Throwable $e) {
+        }
+
+        $formatter = new NormalizerFormatter();
+        $formatted = $formatter->normalizeValue(['exception' => $e]);
+
+        // PHP names the class class@anonymous\0<file>:<line>$<n>, and that NUL byte truncates
+        // syslog lines and is not valid JSON
+        $this->assertStringNotContainsString("\0", $formatted['exception']['trace'][0]);
+        $this->assertSame('internal[class@anonymous.boom]:0', $formatted['exception']['trace'][0]);
+    }
+
+    public function testExceptionTraceStripsTheAnonymousClassDeclarationSiteFromClosureNames()
+    {
+        if (PHP_VERSION_ID < 80400) {
+            $this->markTestSkipped('Closures are only named after their declaration site since PHP 8.4');
+        }
+
+        $thrower = new class {
+            public function boom(): void
+            {
+                array_map(static function (): void {
+                    throw new \RuntimeException('Thrown from a closure in an anonymous class');
+                }, [1]);
+            }
+        };
+
+        try {
+            $thrower->boom();
+        } catch (\Throwable $e) {
+        }
+
+        $formatter = new NormalizerFormatter();
+        $formatted = $formatter->normalizeValue(['exception' => $e]);
+
+        // the closure name embeds the anonymous class name, NUL byte included
+        $this->assertStringNotContainsString("\0", $formatted['exception']['trace'][0]);
+        $this->assertStringContainsString('{closure:class@anonymous::boom()', $formatted['exception']['trace'][0]);
+    }
+
     private function formatRecordWithExceptionInContext(NormalizerFormatter $formatter, \Throwable $exception): array
     {
         $message = $formatter->format($this->getRecord(

--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -483,6 +483,31 @@ class NormalizerFormatterTest extends \Monolog\Test\MonologTestCase
         $this->assertStringNotContainsString(dirname(__DIR__, 3), $formatted['exception']['trace'][0]);
     }
 
+    public function testExceptionTraceReportsAClosureCalledByAnInternalFunctionWithItsClass()
+    {
+        try {
+            (new TestInternalFrame)->viaClosure();
+        } catch (\Throwable $e) {
+        }
+
+        $formatter = new NormalizerFormatter();
+        $formatted = $formatter->normalizeValue(['exception' => $e]);
+
+        // PHP 8.4 names the closure after the method it was declared in, older versions only
+        // report <namespace>\{closure}, where the class is prefixed to keep that context
+        if (PHP_VERSION_ID >= 80400) {
+            $this->assertStringStartsWith(
+                'internal[{closure:'.TestInternalFrame::class.'::viaClosure():',
+                $formatted['exception']['trace'][0]
+            );
+        } else {
+            $this->assertSame(
+                'internal['.TestInternalFrame::class.'->{closure}]:0',
+                $formatted['exception']['trace'][0]
+            );
+        }
+    }
+
     public function testExceptionTraceReportsFramesWithoutFileAndLineOrClass()
     {
         try {
@@ -774,6 +799,13 @@ class TestInternalFrame
     public static function boom(): void
     {
         throw new \RuntimeException('Thrown');
+    }
+
+    public function viaClosure(): void
+    {
+        array_map(function (): void {
+            throw new \RuntimeException('Thrown from a closure');
+        }, [1]);
     }
 }
 

--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -475,8 +475,9 @@ class NormalizerFormatterTest extends \Monolog\Test\MonologTestCase
         $formatter->setBasePath(dirname(__DIR__, 3));
         $formatted = $formatter->normalizeValue(['exception' => $e]);
 
+        // NormalizerFormatter reports paths as the platform writes them, unlike LineFormatter
         $this->assertStringContainsString(
-            '{closure:tests/Monolog/Formatter/Fixtures/InternalFrameClosure.php:',
+            '{closure:'.strtr('tests/Monolog/Formatter/Fixtures/InternalFrameClosure.php', '/', DIRECTORY_SEPARATOR).':',
             $formatted['exception']['trace'][0]
         );
         $this->assertStringNotContainsString(dirname(__DIR__, 3), $formatted['exception']['trace'][0]);

--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -422,7 +422,7 @@ class NormalizerFormatterTest extends \Monolog\Test\MonologTestCase
         );
         // the comparison closure is called by usort itself, so its frame has no file/line
         $this->assertStringStartsWith(
-            'internal['.self::class.'.{closure',
+            'internal['.self::class.'->{closure',
             $result['context']['exception']['trace'][0]
         );
     }
@@ -439,7 +439,7 @@ class NormalizerFormatterTest extends \Monolog\Test\MonologTestCase
         $formatter = new NormalizerFormatter();
         $formatted = $formatter->normalizeValue(['exception' => $e]);
 
-        $this->assertSame('internal['.TestInternalFrame::class.'.boom]:0', $formatted['exception']['trace'][0]);
+        $this->assertSame('internal['.TestInternalFrame::class.'::boom]:0', $formatted['exception']['trace'][0]);
         $this->assertSame(__FILE__.':'.$line, $formatted['exception']['trace'][1]);
     }
 
@@ -455,7 +455,7 @@ class NormalizerFormatterTest extends \Monolog\Test\MonologTestCase
         $formatter->setMaxTraceLength(1);
         $formatted = $formatter->normalizeValue(['exception' => $e]);
 
-        $this->assertSame(['internal['.TestInternalFrame::class.'.boom]:0'], $formatted['exception']['trace']);
+        $this->assertSame(['internal['.TestInternalFrame::class.'::boom]:0'], $formatted['exception']['trace']);
     }
 
     public function testExceptionTraceStripsTheBasePathFromFramesWithoutFileAndLine()
@@ -526,7 +526,7 @@ class NormalizerFormatterTest extends \Monolog\Test\MonologTestCase
         // PHP names the class class@anonymous\0<file>:<line>$<n>, and that NUL byte truncates
         // syslog lines and is not valid JSON
         $this->assertStringNotContainsString("\0", $formatted['exception']['trace'][0]);
-        $this->assertSame('internal[class@anonymous.boom]:0', $formatted['exception']['trace'][0]);
+        $this->assertSame('internal[class@anonymous->boom]:0', $formatted['exception']['trace'][0]);
     }
 
     public function testExceptionTraceStripsTheAnonymousClassDeclarationSiteFromClosureNames()

--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -422,7 +422,7 @@ class NormalizerFormatterTest extends \Monolog\Test\MonologTestCase
         );
         // the comparison closure is called by usort itself, so its frame has no file/line
         $this->assertStringStartsWith(
-            'internal['.self::class.'->{closure',
+            PHP_VERSION_ID >= 80400 ? 'internal[{closure:' : 'internal['.self::class.'->{closure}',
             $result['context']['exception']['trace'][0]
         );
     }

--- a/tests/Monolog/Formatter/NormalizerFormatterTest.php
+++ b/tests/Monolog/Formatter/NormalizerFormatterTest.php
@@ -418,8 +418,68 @@ class NormalizerFormatterTest extends \Monolog\Test\MonologTestCase
         $offset = PHP_VERSION_ID >= 80200 ? 13 : 11;
         $this->assertSame(
             __FILE__.':'.(__LINE__ - $offset),
+            $result['context']['exception']['trace'][1]
+        );
+        // the comparison closure is called by usort itself, so its frame has no file/line
+        $this->assertStringStartsWith(
+            'internal['.self::class.'.{closure',
             $result['context']['exception']['trace'][0]
         );
+    }
+
+    public function testExceptionTraceReportsFramesWithoutFileAndLine()
+    {
+        try {
+            $line = __LINE__ + 2;
+            // the callback is called by array_map itself, so its frame has no file/line
+            array_map([TestInternalFrame::class, 'boom'], [1]);
+        } catch (\Throwable $e) {
+        }
+
+        $formatter = new NormalizerFormatter();
+        $formatted = $formatter->normalizeValue(['exception' => $e]);
+
+        $this->assertSame('internal['.TestInternalFrame::class.'.boom]:0', $formatted['exception']['trace'][0]);
+        $this->assertSame(__FILE__.':'.$line, $formatted['exception']['trace'][1]);
+    }
+
+    public function testExceptionTraceIsNotEmptiedByFramesWithoutFileAndLine()
+    {
+        try {
+            array_map([TestInternalFrame::class, 'boom'], [1]);
+        } catch (\Throwable $e) {
+        }
+
+        $formatter = new NormalizerFormatter();
+        // the only frame kept is the one without file/line, which used to leave no trace at all
+        $formatter->setMaxTraceLength(1);
+        $formatted = $formatter->normalizeValue(['exception' => $e]);
+
+        $this->assertSame(['internal['.TestInternalFrame::class.'.boom]:0'], $formatted['exception']['trace']);
+    }
+
+    public function testExceptionTraceStripsTheBasePathFromFramesWithoutFileAndLine()
+    {
+        if (PHP_VERSION_ID < 80400) {
+            $this->markTestSkipped('Closures are only named after their declaration site since PHP 8.4');
+        }
+
+        $closure = require __DIR__.'/Fixtures/InternalFrameClosure.php';
+
+        try {
+            array_map($closure, [1]);
+        } catch (\Throwable $e) {
+        }
+
+        $formatter = new NormalizerFormatter();
+        $formatter->setBasePath(dirname(__DIR__, 3));
+        $formatted = $formatter->normalizeValue(['exception' => $e]);
+
+        $this->assertStringContainsString(
+            '{closure:tests/Monolog/Formatter/Fixtures/InternalFrameClosure.php:',
+            $formatted['exception']['trace'][0]
+        );
+        $this->assertStringNotContainsString(dirname(__DIR__, 3), $formatted['exception']['trace'][0]);
     }
 
     private function formatRecordWithExceptionInContext(NormalizerFormatter $formatter, \Throwable $exception): array
@@ -613,5 +673,13 @@ class TestInfoLeak
     public function __toString()
     {
         return 'Sensitive information';
+    }
+}
+
+class TestInternalFrame
+{
+    public static function boom(): void
+    {
+        throw new \RuntimeException('Thrown');
     }
 }

--- a/tests/Monolog/Formatter/ScalarFormatterTest.php
+++ b/tests/Monolog/Formatter/ScalarFormatterTest.php
@@ -29,17 +29,13 @@ class ScalarFormatterTest extends \Monolog\Test\MonologTestCase
         unset($this->formatter);
     }
 
-    public function buildTrace(\Exception $e)
+    public function buildTrace(\Exception $e): array
     {
-        $data = [];
-        $trace = $e->getTrace();
-        foreach ($trace as $frame) {
-            if (isset($frame['file'])) {
-                $data[] = $frame['file'].':'.$frame['line'];
-            }
-        }
+        // NormalizerFormatter decides what a frame looks like, and reimplementing that here
+        // drifted from it twice; the trace shape is not what this test is checking anyway
+        $normalized = (new NormalizerFormatter())->normalizeValue($e);
 
-        return $data;
+        return $normalized['trace'] ?? [];
     }
 
     public function encodeJson($data)


### PR DESCRIPTION
Fixes #1736

`normalizeException()` only kept trace frames that have both `file` and `line`. Frames called by the engine itself have neither: shutdown functions, callbacks run by internal functions like `array_map` or `usort`, destructors. They were dropped silently, so a trace could look shorter than it was, and for a fatal error caught in a shutdown function it disappeared entirely:

```php
register_shutdown_function(function () {
    // ... catch the fatal, log it
});
```

```
before: "(no trace key at all)"
after:  ["internal[{closure:/app/src/shutdown.php:5}]:0"]
```

Those frames are now reported by name, in the shape you and @WoZ settled on in the issue: `internal[Class.function]:0`, with `.` rather than `->` or `::` as @WoZ suggested for static methods. The data type does not change, the trace stays a list of strings.

Three decisions worth your opinion rather than mine:

- **The class prefix is unconditional, closures included.** On PHP 8.4+ that reads long, `Test.{closure:Test::run():12}`, because the closure name already repeats the scope. I kept it because on 8.1 to 8.3 the name is just `{closure}` and the class is then the only context there is. Checked on 8.2, 8.3, 8.4 and 8.5.
- **The base path is stripped from the label too.** Since PHP 8.4 a closure declared at file scope is named after its file, so reporting these frames would put an absolute path in the logs of anyone using `setBasePath()`. Three lines and one test, dropped easily if you would rather keep the label verbatim.
- **One existing test had to change.** `testExceptionTraceWithArgs` asserted on `trace[0]`, which is now the `usort` comparison closure. The assertion moved to `trace[1]` and a new one covers `trace[0]`.

Tests: the suite goes from 1268 to 1271, no failure, same skips and deprecations as on `main`. PHPStan clean. The PHP 8.5 deprecation that remains is the pre-existing `ArrayObject::__construct` one in the `__PHP_Incomplete_Class` branch.
