### PR TITLE
Align FrankenPhpHandler's level scale with OpenTelemetry's mapping

### DIFF
--- a/src/Monolog/Handler/FrankenPhpHandler.php
+++ b/src/Monolog/Handler/FrankenPhpHandler.php
@@ -44,25 +44,28 @@ class FrankenPhpHandler extends AbstractProcessingHandler
     /**
      * Translates Monolog log levels to FrankenPHP's slog-based levels.
      *
-     * slog treats levels as arbitrary ints and recommends a gap of 4 between named levels to leave
-     * room for intermediate ones, e.g. Google Cloud Logging's Notice between Info and Warn.
+     * slog's docs state its gap of 4 between named levels matches OpenTelemetry's SeverityNumber
+     * mapping, converted by subtracting 9. Applying that same subtraction to OpenTelemetry's own
+     * Syslog severity mapping for the 4 extra RFC 5424 levels slog has no constant for keeps this
+     * scale traceable to that spec instead of an arbitrary choice.
      *
      * FrankenPHP feeds these through zapslog, which buckets everything >= Error into "error", so
      * above Error only the level_name context key tells the Monolog levels apart.
      *
      * @see https://pkg.go.dev/log/slog#hdr-Levels
+     * @see https://opentelemetry.io/docs/specs/otel/logs/data-model-appendix/
      */
     protected function toFrankenPhpLevel(Level $level): int
     {
         return match ($level) {
             Level::Debug => \FRANKENPHP_LOG_LEVEL_DEBUG,
             Level::Info => \FRANKENPHP_LOG_LEVEL_INFO,
-            Level::Notice => 2,
+            Level::Notice => 1,
             Level::Warning => \FRANKENPHP_LOG_LEVEL_WARN,
             Level::Error => \FRANKENPHP_LOG_LEVEL_ERROR,
-            Level::Critical => 12,
-            Level::Alert => 16,
-            Level::Emergency => 20,
+            Level::Critical => 9,
+            Level::Alert => 10,
+            Level::Emergency => 12,
         };
     }
 

--- a/tests/Monolog/Handler/FrankenPhpHandlerTest.php
+++ b/tests/Monolog/Handler/FrankenPhpHandlerTest.php
@@ -118,12 +118,12 @@ class FrankenPhpHandlerTest extends \Monolog\Test\MonologTestCase
         return [
             'debug' => [Level::Debug, \FRANKENPHP_LOG_LEVEL_DEBUG],
             'info' => [Level::Info, \FRANKENPHP_LOG_LEVEL_INFO],
-            'notice' => [Level::Notice, 2],
+            'notice' => [Level::Notice, 1],
             'warning' => [Level::Warning, \FRANKENPHP_LOG_LEVEL_WARN],
             'error' => [Level::Error, \FRANKENPHP_LOG_LEVEL_ERROR],
-            'critical' => [Level::Critical, 12],
-            'alert' => [Level::Alert, 16],
-            'emergency' => [Level::Emergency, 20],
+            'critical' => [Level::Critical, 9],
+            'alert' => [Level::Alert, 10],
+            'emergency' => [Level::Emergency, 12],
         ];
     }
 }


### PR DESCRIPTION
Follow-up to #2056.

slog's docs state its gap of 4 between named levels matches OpenTelemetry's SeverityNumber mapping, converted by subtracting 9 (verified: this reproduces `LevelDebug`/`LevelInfo`/`LevelWarn`/`LevelError` exactly from OTel's own Syslog→SeverityNumber table). That transform only covered the 4 levels slog already has constants for; this applies it to the same OTel table's `Notice`/`Critical`/`Alert`/`Emergency` entries too, so the whole scale traces back to that spec instead of a hand-picked gap for the levels beyond Error:

| RFC 5424 level | OTel `SeverityNumber` | − 9 |
|---|---|---|
| Notice | INFO2 (10) | 1 |
| Critical | ERROR2 (18) | 9 |
| Alert | ERROR3 (19) | 10 |
| Emergency | FATAL (21) | 12 |

No behavior change under zapslog (Caddy path) — it buckets everything ≥`Error` to `"error"` regardless of the exact int, `level_name` is what actually distinguishes them there. Matters for anyone using FrankenPHP as a plain Go library without Caddy, where `frankenphp_log()` falls back to stdlib `slog.Default()`, whose `Level.String()` renders the literal offset (e.g. `ERROR+1` for Critical) - these values now match what OpenTelemetry says that offset should be.