### PR TITLE
Allow reading the timestamp of log records from a PSR-20 clock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "phpstan/phpstan-strict-rules": "^2",
         "phpunit/phpunit": "^10.5.17 || ^11.0.7",
         "predis/predis": "^1.1 || ^2",
+        "psr/clock": "^1.0",
         "rollbar/rollbar": "^4.0",
         "ruflin/elastica": "^7 || ^8",
         "symfony/mailer": "^5.4 || ^6",
@@ -51,7 +52,8 @@
         "ext-mbstring": "Allow to work properly with unicode symbols",
         "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
         "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
-        "ext-openssl": "Required to send log messages using SSL"
+        "ext-openssl": "Required to send log messages using SSL",
+        "psr/clock": "Required to pass a clock to the Logger and control the timestamp of log records"
     },
     "autoload": {
         "psr-4": {"Monolog\\": "src/Monolog"}

--- a/doc/01-usage.md
+++ b/doc/01-usage.md
@@ -118,6 +118,30 @@ Note that the FirePHPHandler is called first as it is added on top of the
 stack. This allows you to temporarily add a handler with bubbling disabled if
 you want to override the handlers below it in the stack.
 
+### Controlling the timestamp of records
+
+Every record is timestamped with the current time, rendered in the timezone
+given to the logger (`date_default_timezone_get()` by default). If you need to
+decide what "now" means, for instance to freeze time in a test, pass any
+[PSR-20](https://www.php-fig.org/psr/psr-20/) clock to the logger:
+
+```php
+<?php
+
+use Monolog\Logger;
+use Symfony\Component\Clock\MockClock;
+
+$clock = new MockClock('2024-03-05 11:22:33');
+$logger = new Logger('my_logger', [$handler], [], null, $clock);
+
+// or on an existing logger, pass null to go back to reading the current time
+$logger->setClock($clock);
+```
+
+The clock only decides which instant is logged, the timezone configured on the
+logger still decides how that instant is rendered. Passing a `$datetime` to
+`Logger::addRecord()` keeps taking precedence over the clock.
+
 ## Adding extra data in the records
 
 Monolog provides two different ways to add extra information along the simple

--- a/phpstan-baseline-pre-8.4.neon
+++ b/phpstan-baseline-pre-8.4.neon
@@ -1,0 +1,6 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Call to an undefined method Monolog\\\\JsonSerializableDateTimeImmutable\\:\\:setMicrosecond\\(\\)\\.$#"
+			count: 1
+			path: src/Monolog/Logger.php

--- a/phpstan-ignore-by-php-version.neon.php
+++ b/phpstan-ignore-by-php-version.neon.php
@@ -4,6 +4,9 @@ $includes = [];
 if (PHP_VERSION_ID >= 80200) {
     $includes[] = __DIR__ . '/phpstan-baseline-8.2.neon';
 }
+if (PHP_VERSION_ID < 80400) {
+    $includes[] = __DIR__ . '/phpstan-baseline-pre-8.4.neon';
+}
 
 $config['includes'] = $includes;
 

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -16,6 +16,7 @@ use DateTimeZone;
 use Fiber;
 use Monolog\Handler\HandlerInterface;
 use Monolog\Processor\ProcessorInterface;
+use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\InvalidArgumentException;
 use Psr\Log\LogLevel;
@@ -146,6 +147,11 @@ class Logger implements LoggerInterface, ResettableInterface
 
     protected DateTimeZone $timezone;
 
+    /**
+     * Clock used to timestamp new records, or null to read the current time from the engine
+     */
+    protected ClockInterface|null $clock = null;
+
     protected Closure|null $exceptionHandler = null;
 
     /**
@@ -169,15 +175,17 @@ class Logger implements LoggerInterface, ResettableInterface
      * @param list<HandlerInterface> $handlers   Optional stack of handlers, the first one in the array is called first, etc.
      * @param callable[]         $processors Optional array of processors
      * @param DateTimeZone|null  $timezone   Optional timezone, if not provided date_default_timezone_get() will be used
+     * @param ClockInterface|null $clock     Optional clock to read the current time from, if not provided the engine's current time is used
      *
      * @phpstan-param array<(callable(LogRecord): LogRecord)|ProcessorInterface> $processors
      */
-    public function __construct(string $name, array $handlers = [], array $processors = [], DateTimeZone|null $timezone = null)
+    public function __construct(string $name, array $handlers = [], array $processors = [], DateTimeZone|null $timezone = null, ClockInterface|null $clock = null)
     {
         $this->name = $name;
         $this->setHandlers($handlers);
         $this->processors = $processors;
         $this->timezone = $timezone ?? new DateTimeZone(date_default_timezone_get());
+        $this->clock = $clock;
         $this->fiberLogDepth = new \WeakMap();
     }
 
@@ -357,7 +365,7 @@ class Logger implements LoggerInterface, ResettableInterface
             $recordInitialized = \count($this->processors) === 0;
 
             $record = new LogRecord(
-                datetime: $datetime ?? new JsonSerializableDateTimeImmutable($this->microsecondTimestamps, $this->timezone),
+                datetime: $datetime ?? $this->createDateTime(),
                 channel: $this->name,
                 level: self::toMonologLevel($level),
                 message: $message,
@@ -519,7 +527,7 @@ class Logger implements LoggerInterface, ResettableInterface
     public function isHandling(int|string|Level $level): bool
     {
         $record = new LogRecord(
-            datetime: new JsonSerializableDateTimeImmutable($this->microsecondTimestamps, $this->timezone),
+            datetime: $this->createDateTime(),
             channel: $this->name,
             message: '',
             level: self::toMonologLevel($level),
@@ -703,6 +711,60 @@ class Logger implements LoggerInterface, ResettableInterface
     public function getTimezone(): DateTimeZone
     {
         return $this->timezone;
+    }
+
+    /**
+     * Sets the clock to read the current time from when timestamping log records.
+     *
+     * Pass null to go back to reading the engine's current time. The timezone
+     * configured on the logger still decides how the timestamp is rendered.
+     *
+     * @return $this
+     */
+    public function setClock(ClockInterface|null $clock): self
+    {
+        $this->clock = $clock;
+
+        return $this;
+    }
+
+    /**
+     * Returns the clock used to timestamp log records, or null if the engine's current time is used.
+     */
+    public function getClock(): ClockInterface|null
+    {
+        return $this->clock;
+    }
+
+    /**
+     * Builds the timestamp of a new record, reading the current time from the clock if one is set.
+     */
+    private function createDateTime(): JsonSerializableDateTimeImmutable
+    {
+        $datetime = new JsonSerializableDateTimeImmutable($this->microsecondTimestamps, $this->timezone);
+
+        if (null === $this->clock) {
+            return $datetime;
+        }
+
+        $now = $this->clock->now();
+
+        // The instant is applied without ever going through a local wall clock
+        // time, which would be ambiguous across a DST transition: setTimestamp()
+        // moves to the right second, then the microseconds are added as a
+        // relative amount of time. Both keep the timezone set on the logger.
+        $datetime = $datetime->setTimestamp($now->getTimestamp());
+        $microseconds = (int) $now->format('u');
+
+        if (0 !== $microseconds) {
+            // DateInterval has no notation for microseconds, they can only be set on the property
+            $interval = new \DateInterval('PT0S');
+            $interval->f = $microseconds / 1000000;
+
+            $datetime = $datetime->add($interval);
+        }
+
+        return $datetime;
     }
 
     /**

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -741,20 +741,27 @@ class Logger implements LoggerInterface, ResettableInterface
      */
     private function createDateTime(): JsonSerializableDateTimeImmutable
     {
-        $datetime = new JsonSerializableDateTimeImmutable($this->microsecondTimestamps, $this->timezone);
-
         if (null === $this->clock) {
-            return $datetime;
+            return new JsonSerializableDateTimeImmutable($this->microsecondTimestamps, $this->timezone);
         }
 
         $now = $this->clock->now();
 
-        // The instant is applied without ever going through a local wall clock
-        // time, which would be ambiguous across a DST transition: setTimestamp()
-        // moves to the right second, then the microseconds are added as a
-        // relative amount of time. Both keep the timezone set on the logger.
+        if ($now instanceof JsonSerializableDateTimeImmutable) {
+            return $now;
+        }
+
+        $datetime = new JsonSerializableDateTimeImmutable($this->microsecondTimestamps, $this->timezone);
+
+        // The instant is applied without ever going through a local wall clock time, which
+        // is ambiguous across a DST transition, and without the "@U.u" notation, which is
+        // off by one second before 1970 and replaces the named timezone with an offset.
         $datetime = $datetime->setTimestamp($now->getTimestamp());
         $microseconds = (int) $now->format('u');
+
+        if (\PHP_VERSION_ID >= 80400) {
+            return $datetime->setMicrosecond($microseconds);
+        }
 
         if (0 !== $microseconds) {
             // DateInterval has no notation for microseconds, they can only be set on the property

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -757,12 +757,11 @@ class Logger implements LoggerInterface, ResettableInterface
         // is ambiguous across a DST transition, and without the "@U.u" notation, which is
         // off by one second before 1970 and replaces the named timezone with an offset.
         $datetime = $datetime->setTimestamp($now->getTimestamp());
-        $microseconds = (int) $now->format('u');
-
         if (\PHP_VERSION_ID >= 80400) {
-            return $datetime->setMicrosecond($microseconds);
+            return $datetime->setMicrosecond($now->getMicrosecond());
         }
 
+        $microseconds = (int) $now->format('u');
         if (0 !== $microseconds) {
             // DateInterval has no notation for microseconds, they can only be set on the property
             $interval = new \DateInterval('PT0S');

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -599,6 +599,181 @@ class LoggerTest extends MonologTestCase
         }
     }
 
+    /**
+     * @covers Logger::__construct
+     * @covers Logger::createDateTime
+     */
+    public function testClockPassedToTheConstructorTimestampsRecords()
+    {
+        $now = new \DateTimeImmutable('2024-03-05 11:22:33.456789', new \DateTimeZone('UTC'));
+        $logger = new Logger('foo', [$handler = new TestHandler()], [], new \DateTimeZone('UTC'), $this->createClock($now));
+
+        $logger->info('test');
+
+        list($record) = $handler->getRecords();
+        $this->assertInstanceOf(JsonSerializableDateTimeImmutable::class, $record->datetime);
+        $this->assertSame($now->format('U.u'), $record->datetime->format('U.u'));
+    }
+
+    /**
+     * @covers Logger::setClock
+     * @covers Logger::getClock
+     * @covers Logger::createDateTime
+     */
+    public function testClockCanBeSetAndUnsetAtRuntime()
+    {
+        $now = new \DateTimeImmutable('2024-03-05 11:22:33.456789', new \DateTimeZone('UTC'));
+        $logger = new Logger('foo', [$handler = new TestHandler()]);
+        $this->assertNull($logger->getClock());
+
+        $clock = $this->createClock($now);
+        $this->assertSame($logger, $logger->setClock($clock));
+        $this->assertSame($clock, $logger->getClock());
+        $logger->info('from the clock');
+
+        $logger->setClock(null);
+        $this->assertNull($logger->getClock());
+        $logger->info('from the engine');
+
+        list($fromClock, $fromEngine) = $handler->getRecords();
+        $this->assertSame($now->format('U.u'), $fromClock->datetime->format('U.u'));
+        $this->assertNotSame($now->format('U.u'), $fromEngine->datetime->format('U.u'));
+    }
+
+    /**
+     * The clock only decides which instant is logged. Which timezone renders it
+     * stays the logger's business, so a clock ticking in UTC must not silently
+     * move records out of the configured timezone.
+     *
+     * @covers Logger::createDateTime
+     */
+    public function testClockInstantIsRenderedInTheLoggerTimezone()
+    {
+        $now = new \DateTimeImmutable('2024-03-05 11:22:33.456789', new \DateTimeZone('UTC'));
+        $tz = new \DateTimeZone('America/New_York');
+        $logger = new Logger('foo', [$handler = new TestHandler()], [], $tz, $this->createClock($now));
+
+        $logger->info('test');
+
+        list($record) = $handler->getRecords();
+        $this->assertEquals($tz, $record->datetime->getTimezone());
+        $this->assertSame($now->format('U.u'), $record->datetime->format('U.u'));
+        $this->assertSame('2024-03-05 06:22:33.456789', $record->datetime->format('Y-m-d H:i:s.u'));
+    }
+
+    /**
+     * @covers Logger::createDateTime
+     */
+    #[DataProvider('clockInstantProvider')]
+    public function testClockInstantIsReproducedExactly($instant, $loggerTimezone)
+    {
+        $logger = new Logger('foo', [$handler = new TestHandler()], [], new \DateTimeZone($loggerTimezone), $this->createClock($instant));
+
+        $logger->info('test');
+
+        list($record) = $handler->getRecords();
+        $this->assertSame($instant->format('U.u'), $record->datetime->format('U.u'));
+        $this->assertSame($loggerTimezone, $record->datetime->getTimezone()->getName());
+    }
+
+    public static function clockInstantProvider()
+    {
+        $utc = new \DateTimeZone('UTC');
+        $paris = new \DateTimeZone('Europe/Paris');
+
+        return [
+            'no microseconds' => [new \DateTimeImmutable('2024-01-01 00:00:00.000000', $utc), 'UTC'],
+            'one microsecond' => [new \DateTimeImmutable('2024-06-01 08:00:00.000001', $utc), 'UTC'],
+            'last microsecond of the second' => [new \DateTimeImmutable('2024-06-01 08:00:00.999999', $utc), 'UTC'],
+            'the epoch itself' => [new \DateTimeImmutable('@0'), 'UTC'],
+            'before the epoch' => [new \DateTimeImmutable('1950-01-02 03:04:05.123456', $utc), 'Europe/Paris'],
+            'ambiguous hour of a DST fall back' => [new \DateTimeImmutable('2024-10-27 02:30:00.500000', $paris), 'Europe/Paris'],
+            'clock ticking in another timezone' => [new \DateTimeImmutable('2024-06-01 08:00:00.000001', new \DateTimeZone('-04:30')), 'Europe/Paris'],
+        ];
+    }
+
+    /**
+     * @covers Logger::createDateTime
+     */
+    public function testClockDoesNotOverrideAnExplicitDateTime()
+    {
+        $clockNow = new \DateTimeImmutable('2024-03-05 11:22:33.456789', new \DateTimeZone('UTC'));
+        $logger = new Logger('foo', [$handler = new TestHandler()], [], new \DateTimeZone('UTC'), $this->createClock($clockNow));
+        $explicit = new JsonSerializableDateTimeImmutable(true, new \DateTimeZone('UTC'));
+
+        $logger->addRecord(Level::Info, 'test', [], $explicit);
+
+        list($record) = $handler->getRecords();
+        $this->assertSame($explicit, $record->datetime);
+    }
+
+    /**
+     * @covers Logger::createDateTime
+     */
+    public function testClockIsUsedWhenMicrosecondTimestampsAreDisabled()
+    {
+        $now = new \DateTimeImmutable('2024-03-05 11:22:33.456789', new \DateTimeZone('UTC'));
+        $logger = new Logger('foo', [$handler = new TestHandler()], [], new \DateTimeZone('UTC'), $this->createClock($now));
+        $logger->useMicrosecondTimestamps(false);
+
+        $logger->info('test');
+
+        list($record) = $handler->getRecords();
+        $this->assertSame($now->format('U.u'), $record->datetime->format('U.u'));
+        $this->assertSame('2024-03-05T11:22:33+00:00', $record->datetime->jsonSerialize());
+    }
+
+    /**
+     * @covers Logger::isHandling
+     * @covers Logger::createDateTime
+     */
+    public function testClockIsUsedByIsHandling()
+    {
+        $now = new \DateTimeImmutable('2024-03-05 11:22:33.456789', new \DateTimeZone('UTC'));
+        $handler = new class () implements HandlerInterface {
+            public ?LogRecord $seen = null;
+
+            public function isHandling(LogRecord $record): bool
+            {
+                $this->seen = $record;
+
+                return true;
+            }
+
+            public function handle(LogRecord $record): bool
+            {
+                return true;
+            }
+
+            public function handleBatch(array $records): void
+            {
+            }
+
+            public function close(): void
+            {
+            }
+        };
+        $logger = new Logger('foo', [$handler], [], new \DateTimeZone('UTC'), $this->createClock($now));
+
+        $this->assertTrue($logger->isHandling(Level::Info));
+        $this->assertNotNull($handler->seen);
+        $this->assertSame($now->format('U.u'), $handler->seen->datetime->format('U.u'));
+    }
+
+    private function createClock(\DateTimeImmutable $now): \Psr\Clock\ClockInterface
+    {
+        return new class ($now) implements \Psr\Clock\ClockInterface {
+            public function __construct(private \DateTimeImmutable $now)
+            {
+            }
+
+            public function now(): \DateTimeImmutable
+            {
+                return $this->now;
+            }
+        };
+    }
+
     public function tearDown(): void
     {
         date_default_timezone_set('UTC');

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -693,6 +693,23 @@ class LoggerTest extends MonologTestCase
     }
 
     /**
+     * A clock that already speaks Monolog's own type knows better than the logger
+     * what it wants logged, timezone included, so it is taken as is.
+     *
+     * @covers Logger::createDateTime
+     */
+    public function testClockReturningTheMonologTypeIsUsedAsIs()
+    {
+        $now = new JsonSerializableDateTimeImmutable(true, new \DateTimeZone('Asia/Tokyo'));
+        $logger = new Logger('foo', [$handler = new TestHandler()], [], new \DateTimeZone('UTC'), $this->createClock($now));
+
+        $logger->info('test');
+
+        list($record) = $handler->getRecords();
+        $this->assertSame($now, $record->datetime);
+    }
+
+    /**
      * @covers Logger::createDateTime
      */
     public function testClockDoesNotOverrideAnExplicitDateTime()


### PR DESCRIPTION
Fixes #1902

The PSR-3 methods have no `$datetime` parameter, so today the only way to decide what "now" means is to call `addRecord()` directly. This adds an optional PSR-20 clock to the logger, plus `setClock()` / `getClock()` mirroring the `setTimezone()` / `getTimezone()` pair that is already there:

```php
$logger = new Logger('app', [$handler], [], null, new MockClock('2024-03-05 11:22:33'));
```

The two points @stof raised on the previous attempt (#1938) drove the shape of this one. The clock parameter is added at the end of the constructor with a `null` default, so no existing signature changes and subclasses that redefine the constructor stay valid. And no class is added, in particular none named `Clock`: Monolog consumes a clock, it does not provide one.

**Reporting the instant onto the record was the part that needed care.** `LogRecord::$datetime` is a `JsonSerializableDateTimeImmutable`, whose private property is only initialised by the constructor, so `createFromFormat()` leaves it uninitialised (`Error: Typed property must not be accessed before initialization`). The instant is therefore applied to an instance that is already built, and two shortcuts had to be dropped after measuring them:

- `'@'.$now->format('U.u')` is wrong before 1970. `1950-01-02 03:04:05.123456` comes back as `03:04:04.876544`, the fraction being added to a negative timestamp.
- Going through a local wall clock time is ambiguous inside the repeated hour of a DST fall back.

So the code calls `setTimestamp()` to reach the right second, then adds the microseconds as a *relative* amount of time. Neither step ever goes through a local wall clock time, and both keep the named timezone configured on the logger (`Europe/Paris`, not `+01:00`). Covered by a data provider over: a modern instant, before the epoch, the epoch itself, microseconds at 0, 1 and 999999, the ambiguous hour of a Paris DST fall back, and a clock ticking in another timezone.

`add()` rather than `modify()`, because PHPStan also runs on PHP 8.1 where `modify()` returns `static|false`, which would not survive level 8.

**One call for you:** `psr/clock` is in `require-dev` and `suggest`, not in `require`. The type only resolves when a non-null value is passed, and having a clock instance to pass implies the package is already installed, so this costs nothing to the existing installs. Promoting it to `require` is a one line change if you would rather declare it properly, and `$clock` is `protected` for consistency with `$timezone`, happy to make it private if you prefer.

`isHandling()` builds a throwaway record too and now goes through the same helper, so a handler that looks at the datetime sees the same time in both paths.

Tests: the suite goes from 1276 to 1289, no failure, same skips and deprecations as on `main`. PHPStan clean. The `Timezone ID 'CET' is invalid` notice on PHP 8.5 is pre-existing in `testTimezoneIsRespectedInOtherTimezone`. PHP 8.1 is the one version of the matrix I could not replay locally.

Documented under "Configuring a logger" in `doc/01-usage.md`. `CHANGELOG.md` left alone since you write it at release time.
