### PR TITLE
Fix TelegramBotHandler breaking HTML tags on split (#1990)

### DIFF
--- a/src/Monolog/Handler/TelegramBotHandler.php
+++ b/src/Monolog/Handler/TelegramBotHandler.php
@@ -329,9 +329,139 @@ class TelegramBotHandler extends AbstractProcessingHandler
     {
         $truncatedMarker = ' (…truncated)';
         if (!$this->splitLongMessages && \strlen($message) > self::MAX_MESSAGE_LENGTH) {
-            return [Utils::substr($message, 0, self::MAX_MESSAGE_LENGTH - \strlen($truncatedMarker)) . $truncatedMarker];
+            $maxLength = self::MAX_MESSAGE_LENGTH - \strlen($truncatedMarker);
+            $truncated = Utils::substr($message, 0, $maxLength);
+
+            if ($this->parseMode === 'HTML') {
+                $truncated = $this->trimPartialHtmlTag($truncated);
+                $closing = $this->closingHtmlTagsFor($this->updateOpenHtmlTags($truncated, []));
+
+                while ($truncated !== '' && \strlen($truncated . $closing) > $maxLength) {
+                    $truncated = $this->trimPartialHtmlTag(Utils::substr($truncated, 0, -1));
+                    $closing = $this->closingHtmlTagsFor($this->updateOpenHtmlTags($truncated, []));
+                }
+
+                $truncated .= $closing;
+            }
+
+            return [$truncated . $truncatedMarker];
+        }
+
+        if ($this->parseMode === 'HTML' && \strlen($message) > self::MAX_MESSAGE_LENGTH) {
+            return $this->splitHtmlMessage($message, self::MAX_MESSAGE_LENGTH);
         }
 
         return str_split($message, self::MAX_MESSAGE_LENGTH);
+    }
+
+    /**
+     * Splits an HTML $message into chunks of at most $maxLength characters, closing any
+     * tag left open at the end of a chunk and reopening it at the start of the next one,
+     * so that neither a tag nor a start/end tag pair is ever cut in half.
+     *
+     * @return string[]
+     */
+    private function splitHtmlMessage(string $message, int $maxLength): array
+    {
+        $chunks = [];
+        $openTags = [];
+        $remaining = $message;
+
+        while ($remaining !== '') {
+            $prefix = $this->openingHtmlTagsFor($openTags);
+            $slice = Utils::substr($remaining, 0, max(1, $maxLength - \strlen($prefix)));
+            $isLast = \strlen($slice) >= \strlen($remaining);
+
+            if (!$isLast) {
+                $slice = $this->trimPartialHtmlTag($slice);
+            }
+
+            $sliceOpenTags = $this->updateOpenHtmlTags($slice, $openTags);
+            $suffix = $isLast ? '' : $this->closingHtmlTagsFor($sliceOpenTags);
+
+            while (!$isLast && $slice !== '' && \strlen($prefix . $slice . $suffix) > $maxLength) {
+                $slice = $this->trimPartialHtmlTag(Utils::substr($slice, 0, -1));
+                $sliceOpenTags = $this->updateOpenHtmlTags($slice, $openTags);
+                $suffix = $this->closingHtmlTagsFor($sliceOpenTags);
+            }
+
+            $chunks[] = $prefix . $slice . $suffix;
+            $remaining = Utils::substr($remaining, \strlen($slice));
+            $openTags = $isLast ? [] : $sliceOpenTags;
+        }
+
+        return $chunks;
+    }
+
+    /**
+     * Backs off before a `<` that has no matching `>` yet, so $html never ends mid-tag.
+     */
+    private function trimPartialHtmlTag(string $html): string
+    {
+        $lastLt = strrpos($html, '<');
+        $lastGt = strrpos($html, '>');
+
+        if ($lastLt !== false && ($lastGt === false || $lastLt > $lastGt)) {
+            return Utils::substr($html, 0, $lastLt);
+        }
+
+        return $html;
+    }
+
+    /**
+     * Scans $html for tags, applying them onto $openTags, so the result is the set of
+     * tags still open after $html (tags opened before $html that $html did not close,
+     * plus any $html opened itself and did not close again).
+     *
+     * @param  array<array{name: string, raw: string}> $openTags
+     * @return array<array{name: string, raw: string}>
+     */
+    private function updateOpenHtmlTags(string $html, array $openTags): array
+    {
+        if (0 === preg_match_all('/<(\/?)([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>/', $html, $matches, PREG_SET_ORDER)) {
+            return $openTags;
+        }
+
+        foreach ($matches as $match) {
+            $name = strtolower($match[2]);
+            if ($match[1] === '/') {
+                for ($i = \count($openTags) - 1; $i >= 0; $i--) {
+                    if ($openTags[$i]['name'] === $name) {
+                        array_splice($openTags, $i, 1);
+                        break;
+                    }
+                }
+            } else {
+                $openTags[] = ['name' => $name, 'raw' => $match[0]];
+            }
+        }
+
+        return $openTags;
+    }
+
+    /**
+     * @param  array<array{name: string, raw: string}> $openTags
+     */
+    private function closingHtmlTagsFor(array $openTags): string
+    {
+        $closing = '';
+        foreach (array_reverse($openTags) as $tag) {
+            $closing .= '</' . $tag['name'] . '>';
+        }
+
+        return $closing;
+    }
+
+    /**
+     * @param  array<array{name: string, raw: string}> $openTags
+     */
+    private function openingHtmlTagsFor(array $openTags): string
+    {
+        $opening = '';
+        foreach ($openTags as $tag) {
+            $opening .= $tag['raw'];
+        }
+
+        return $opening;
     }
 }

--- a/tests/Monolog/Handler/TelegramBotHandlerTest.php
+++ b/tests/Monolog/Handler/TelegramBotHandlerTest.php
@@ -105,4 +105,49 @@ class TelegramBotHandlerTest extends \Monolog\Test\MonologTestCase
 
         $this->expectNotToPerformAssertions();
     }
+
+    public function testTruncatingHtmlMessageClosesTagLeftOpenByTruncation(): void
+    {
+        $handler = new TelegramBotHandler('testKey', 'testChannel', Level::Debug, true, 'HTML');
+        $reflection = new \ReflectionClass($handler);
+        $invoke = $reflection->getMethod('handleMessageLength');
+        $maxMessageLength = $reflection->getConstant('MAX_MESSAGE_LENGTH');
+
+        $message = '<code>' . str_repeat('a', $maxMessageLength) . '</code>';
+
+        /** @var string[] $result */
+        $result = $invoke->invoke($handler, $message);
+
+        $this->assertCount(1, $result);
+        $this->assertLessThanOrEqual($maxMessageLength, \strlen($result[0]));
+        $this->assertStringEndsWith('</code> (…truncated)', $result[0]);
+        $this->assertSame(1, substr_count($result[0], '<code>'));
+        $this->assertSame(1, substr_count($result[0], '</code>'));
+    }
+
+    public function testSplittingHtmlMessageReopensTagInEveryChunk(): void
+    {
+        $handler = new TelegramBotHandler('testKey', 'testChannel', Level::Debug, true, 'HTML', false, true, true);
+        $reflection = new \ReflectionClass($handler);
+        $invoke = $reflection->getMethod('handleMessageLength');
+        $maxMessageLength = $reflection->getConstant('MAX_MESSAGE_LENGTH');
+
+        $message = '<code>' . str_repeat('a', $maxMessageLength * 2) . '</code>';
+
+        /** @var string[] $result */
+        $result = $invoke->invoke($handler, $message);
+
+        $this->assertGreaterThan(1, \count($result));
+
+        foreach ($result as $key => $chunk) {
+            $this->assertLessThanOrEqual($maxMessageLength, \strlen($chunk));
+            $this->assertSame(1, substr_count($chunk, '<code>'), "chunk $key should open <code> exactly once");
+            $this->assertSame(1, substr_count($chunk, '</code>'), "chunk $key should close </code> exactly once");
+        }
+
+        $this->assertSame(
+            str_replace(['<code>', '</code>'], '', $message),
+            implode('', array_map(static fn (string $chunk): string => str_replace(['<code>', '</code>'], '', $chunk), $result))
+        );
+    }
 }


### PR DESCRIPTION
Setting parseMode to HTML and hitting the length limit corrupts the message: truncation just cuts the string at a byte offset, so a `<code>` or `<b>` tag opened earlier in the text loses its closing tag, and Telegram's API rejects the whole message with a 400 ("can't parse entities"). Splitting has the same problem since str_split() cuts at fixed byte boundaries regardless of any tag straddling the boundary.

This only changes behavior when parseMode is HTML. Truncation now backs off before any tag that got cut in half and appends closing tags for whatever is still open at the cutoff, before adding the truncated marker. Splitting tracks open tags across chunks, closes them at the end of a chunk and reopens the same tags (with their attributes, so `<a href="...">` survives too) at the start of the next one, shrinking the chunk further if needed to stay under the length limit. Plain text and the other parse modes still go through the original str_split()/substr() path, untouched.

Added two tests in TelegramBotHandlerTest with a long `<code>` block: one confirms truncation ends with a closed `</code>` tag and stays under the length limit, the other confirms splitting reopens `<code>` in every chunk and reassembles back to the original content. Ran both against the old code first to confirm they fail (unclosed/duplicated tags), then against the fix. Also ran the full TelegramBotHandlerTest suite (12 tests, 34 assertions) and phpstan on the changed file, both clean.

Closes #1990
