### PR TITLE
Fix RedactingFormatter missing secrets nested inside array-valued sensitive keys

### DIFF
--- a/src/Monolog/Formatter/RedactingFormatter.php
+++ b/src/Monolog/Formatter/RedactingFormatter.php
@@ -203,8 +203,9 @@ final class RedactingFormatter implements WrappingFormatterInterface
         if (\is_array($data)) {
             foreach ($data as $key => $value) {
                 if (\is_string($key) && \in_array(strtolower($key), $this->sensitiveKeys, true)) {
-                    // no need to recurse, the whole value is masked in the record anyway
-                    $this->addSecret($value, $secrets);
+                    // the value is masked in the record, but a nested array's leaves can still
+                    // leak elsewhere (e.g. json-encoded by PsrLogMessageProcessor)
+                    $this->collectSensitiveValue($value, $secrets, $depth + 1);
 
                     continue;
                 }
@@ -237,6 +238,28 @@ final class RedactingFormatter implements WrappingFormatterInterface
         foreach (get_object_vars($data) as $value) {
             $this->collect($value, $secrets, $seen, $depth + 1);
         }
+    }
+
+    /**
+     * Collects every string leaf nested inside a value under a sensitive key.
+     *
+     * @param list<string> $secrets
+     */
+    private function collectSensitiveValue(mixed $value, array &$secrets, int $depth): void
+    {
+        if ($depth > self::MAX_DEPTH) {
+            return;
+        }
+
+        if (\is_array($value)) {
+            foreach ($value as $item) {
+                $this->collectSensitiveValue($item, $secrets, $depth + 1);
+            }
+
+            return;
+        }
+
+        $this->addSecret($value, $secrets);
     }
 
     /**

--- a/tests/Monolog/Formatter/RedactingFormatterTest.php
+++ b/tests/Monolog/Formatter/RedactingFormatterTest.php
@@ -243,6 +243,22 @@ class RedactingFormatterTest extends MonologTestCase
         $this->assertStringContainsString('calling api with [REDACTED]', $output);
     }
 
+    public function testRedactsSecretNestedInAnArrayValueAlreadyInterpolatedIntoTheMessage()
+    {
+        // PsrLogMessageProcessor json-encodes array context into the message, so a
+        // secret nested under a sensitive key leaks before this formatter runs.
+        $formatter = new RedactingFormatter(new LineFormatter('%message% %context%', 'Y-m-d'));
+        $processor = new PsrLogMessageProcessor();
+
+        $output = $formatter->format($processor($this->getRecord(
+            message: 'password reset payload: {password}',
+            context: ['password' => ['new' => 'tok-supersecret-value']],
+        )));
+
+        $this->assertStringNotContainsString('tok-supersecret-value', $output);
+        $this->assertStringContainsString('[REDACTED]', $output);
+    }
+
     public function testRedactsSecretEmbeddedInAnExceptionMessage()
     {
         $formatter = new RedactingFormatter(new JsonFormatter());


### PR DESCRIPTION

## Problem

`RedactingFormatter` masks a sensitive context/extra key by replacing its whole value
with the mask in the record, and separately sweeps the wrapped formatter's rendered
output for the original secret values, specifically to catch copies that leak through
other channels such as `PsrLogMessageProcessor` interpolating a value into the message
before the formatter ever runs (see the class docblock and the existing
`testRedactsSecretAlreadyInterpolatedIntoTheMessage` test).

That sweep only works if the secret value was collected first. `RedactingFormatter::collect()`
only calls `addSecret()` on the value of a sensitive key directly:

```php
if (\is_string($key) && \in_array(strtolower($key), $this->sensitiveKeys, true)) {
    // no need to recurse, the whole value is masked in the record anyway
    $this->addSecret($value, $secrets);
    continue;
}
```

`addSecret()` only accepts strings and `Stringable` objects. When the value of a
sensitive key is an array, `addSecret()` silently does nothing with it, so none of its
leaf strings are ever added to the `$secrets` list used later during the sweep.

`PsrLogMessageProcessor::__invoke()` JSON-encodes array context values when
interpolating them into `{placeholder}` tokens in the message:

```php
} elseif (\is_array($val)) {
    $replacements[$placeholder] = 'array'.Utils::jsonEncode($val, null, true);
}
```

So a call such as:

```php
$log->info('password reset payload: {password}', ['password' => ['new' => 'CorrectHorseBatteryStaple42']]);
```

ends up with the message `password reset payload: array{"new":"CorrectHorseBatteryStaple42"}`
before `RedactingFormatter` ever sees the record. The context key gets masked correctly
(`"password":"[REDACTED]"`), but the secret embedded in the message is never swept,
because it was never collected: the final formatted output still contains
`CorrectHorseBatteryStaple42` in plain text.

Root cause: `src/Monolog/Formatter/RedactingFormatter.php`, `collect()` at line 205-210
(pre-fix), which calls `addSecret()` directly on a sensitive key's value instead of
recursing into it when it is an array.

## Fix

Added a small helper, `collectSensitiveValue()`, that walks a value already known to be
sensitive (because it sits under a matched key) and collects every string leaf it
contains, however deeply nested, respecting the same `MAX_DEPTH` guard used elsewhere in
the class for self-referencing structures. `collect()` now calls this helper instead of
`addSecret()` directly for a sensitive key's value.

Files changed:
- `src/Monolog/Formatter/RedactingFormatter.php`
- `tests/Monolog/Formatter/RedactingFormatterTest.php` (new regression test)
