### PR TITLE
Allow WithMonologChannel to target a constructor/method parameter

### DIFF
--- a/src/Monolog/Attribute/WithMonologChannel.php
+++ b/src/Monolog/Attribute/WithMonologChannel.php
@@ -12,14 +12,15 @@
 namespace Monolog\Attribute;
 
 /**
- * A reusable attribute to help configure a class as expecting a given logger channel.
+ * A reusable attribute to help configure a class, or one of its constructor/method arguments,
+ * as expecting a given logger channel.
  *
  * Using it offers no guarantee: it needs to be leveraged by a Monolog third-party consumer.
  *
  * Using it with the Monolog library only has no effect at all: wiring the logger instance into
  * other classes is not managed by Monolog.
  */
-#[\Attribute(\Attribute::TARGET_CLASS)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PARAMETER)]
 final class WithMonologChannel
 {
     public function __construct(

--- a/tests/Monolog/Attribute/WithMonologChannelTest.php
+++ b/tests/Monolog/Attribute/WithMonologChannelTest.php
@@ -18,4 +18,22 @@ class WithMonologChannelTest extends \Monolog\Test\MonologTestCase
         $attribute = new WithMonologChannel('fixture');
         $this->assertSame('fixture', $attribute->channel);
     }
+
+    public function testOnConstructorParameter(): void
+    {
+        $parameter = new \ReflectionParameter([WithMonologChannelOnParameterFixture::class, '__construct'], 'logger');
+        $attributes = $parameter->getAttributes(WithMonologChannel::class);
+
+        $this->assertCount(1, $attributes);
+        $this->assertSame('fixture', $attributes[0]->newInstance()->channel);
+    }
+}
+
+final class WithMonologChannelOnParameterFixture
+{
+    public function __construct(
+        #[WithMonologChannel('fixture')]
+        public readonly \stdClass $logger,
+    ) {
+    }
 }


### PR DESCRIPTION
## Summary

Widens `WithMonologChannel`'s attribute target from `TARGET_CLASS` to
`TARGET_CLASS | TARGET_PARAMETER`, so it can be placed on a single
constructor (or method) argument instead of only on the whole class.

This is purely additive: existing class-level usages keep working
unchanged.

## Motivation

Follow-up to symfony/monolog-bundle#475: users want to bind different
logger channels to different constructor arguments of the same
service, e.g.:

```php
public function __construct(
    #[WithMonologChannel('homepage')] private readonly LoggerInterface $logger,
    #[WithMonologChannel('billing')]  private readonly LoggerInterface $billingLogger,
) {}
```

Today this is impossible because `#[WithMonologChannel]` can only
target a class, and PHP rejects it on a parameter with a fatal error.
@Seldaek already gave a preliminary +1 to this in the issue, noting it
would need a tweak here in Monolog first.

A companion PR implementing the actual per-argument binding in
monolog-bundle (gated behind this attribute change) is ready and will
be linked here once opened.

## Test plan

- [x] Added a test asserting the attribute can be read via Reflection
      off a constructor parameter
- [x] `vendor/bin/phpunit tests/Monolog/Attribute/WithMonologChannelTest.php`